### PR TITLE
[feat/CK-53] 반응형 Layout의 변경된 요구사항을 반영하고 PageLayout을 구현한다

### DIFF
--- a/client/src/components/_common/pageLayout/PageLayout.styles.ts
+++ b/client/src/components/_common/pageLayout/PageLayout.styles.ts
@@ -1,0 +1,17 @@
+import { styled } from 'styled-components';
+import media from '@styles/media';
+
+export const Layout = styled.div`
+  width: 100%;
+`;
+
+export const NavBar = styled.nav`
+  width: 15rem;
+  height: 100vh;
+  background: ${({ theme }) => theme.colors.gray100};
+  border-radius: 3rem;
+
+  ${media.mobile`
+    display: none;
+  `}
+`;

--- a/client/src/components/_common/pageLayout/PageLayout.tsx
+++ b/client/src/components/_common/pageLayout/PageLayout.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from 'react';
+import * as S from './PageLayout.styles';
+
+const Layout = ({ children }: PropsWithChildren) => {
+  return (
+    <S.Layout>
+      <S.NavBar />
+      {children}
+    </S.Layout>
+  );
+};
+
+export default Layout;

--- a/client/src/components/_common/responsiveContainer/ResponsiveContainer.styles.tsx
+++ b/client/src/components/_common/responsiveContainer/ResponsiveContainer.styles.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import BREAK_POINTS from '@constants/_common/breakPoints';
-import pxToVw from '@utils/_common/pxToVw';
 
 export const Container = styled.div`
   width: 100%;
@@ -8,15 +7,11 @@ export const Container = styled.div`
   margin-left: auto;
   background: red;
 
-  @media (min-width: ${BREAK_POINTS.MOBILE}px) {
-    max-width: ${pxToVw(BREAK_POINTS.MOBILE)};
-  }
-
   @media (min-width: ${BREAK_POINTS.TABLET}px) {
-    max-width: ${pxToVw(BREAK_POINTS.TABLET)};
+    max-width: 100vw;
   }
 
   @media (min-width: ${BREAK_POINTS.DESKTOP}px) {
-    max-width: ${pxToVw(BREAK_POINTS.DESKTOP)};
+    max-width: 1137px;
   }
 `;

--- a/client/src/utils/_common/pxToVw.ts
+++ b/client/src/utils/_common/pxToVw.ts
@@ -1,6 +1,0 @@
-import BREAK_POINTS from '@constants/_common/breakPoints';
-
-const pxToVw = (size: number, width = BREAK_POINTS.DESKTOP) =>
-  `${(size / width) * 100}vw`;
-
-export default pxToVw;


### PR DESCRIPTION
## 📌 작업 이슈 번호
53
https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-53


## ✨ 작업 내용
Web 환경에서 width이 1137px이 되도록,
모바일과 테블릿 환경에서 100vw가 되도록 변경
PageLayout 템플릿 추가


## 💬 리뷰어에게 남길 멘트
반응형 레이아웃의 요구 사항이 변하면서 `pxToVw`함수의 필요성을 느끼지 못했습니다
이러한 이유로 제거하였는데 혹시 다른 고견이 있으시다면 말씀해주시면 감사드리겠습니다!!

또 PageLayout을 추가하였습니다
Header(NavBar), Footer 등을 추가하기 위해서 입니다
반응형 Layout과는 성격이 다르다고 생각해서 따로 분리했습니다! 이것도 의견 부탁드려요!
추후, props를 넘겨서 page 마다 다르게 대응할 수 있도록 유연하게 수정할 예정입니다!

### Web인 경우 (1137px)
<img width="1510" alt="image" src="https://github.com/woowacourse-teams/2023-co-kirikiri/assets/88191233/543b3917-6765-4102-a0eb-08235faf0e7d">

### Mobile과 Tablet인 경우 (100vw)
<img width="640" alt="image" src="https://github.com/woowacourse-teams/2023-co-kirikiri/assets/88191233/8b38760f-f31e-4238-8e60-be6102d65924">
