### PR TITLE
[feat/CK-111] webpack image-webpack-loader, OptimizeCSSAssetsPlugin 관련 build error를 해결한다.

### DIFF
--- a/client/webpack.common.js
+++ b/client/webpack.common.js
@@ -48,30 +48,7 @@ module.exports = {
         generator: {
           filename: 'images/[hash][ext][query]',
         },
-        use: [
-          {
-            loader: 'image-webpack-loader',
-            options: {
-              mozjpeg: {
-                progressive: true,
-                quality: 65,
-              },
-              optipng: {
-                enabled: false,
-              },
-              pngquant: {
-                quality: [0.65, 0.9],
-                speed: 4,
-              },
-              gifsicle: {
-                interlaced: false,
-              },
-              webp: {
-                quality: 75,
-              },
-            },
-          },
-        ],
+        use: [],
       },
       {
         test: /\.json$/,

--- a/client/webpack.prod.js
+++ b/client/webpack.prod.js
@@ -20,7 +20,6 @@ module.exports = merge(common, {
       new TerserPlugin({
         parallel: true,
       }),
-      new OptimizeCSSAssetsPlugin({}),
     ],
   },
 


### PR DESCRIPTION
## 📌 작업 이슈 번호

[CK-111](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-111)

## ✨ 작업 내용

- develop-client 에서 build 시 에러가 나는 문제를 해결했습니다.
  - image-webpack-loader, OptimizeCSSAssetsPlugin 사용을 멈추게끔 작업했습니다.
  - 정상적으로 build 되는 상황 확인 완료. 

## 💬 리뷰어에게 남길 멘트

잘부탁드려요~~~ 🙇‍♂️

## 🚀 요구사항 분석

- webpack image-webpack-loader, OptimizeCSSAssetsPlugin 관련 build error를 해결

