### PR TITLE
[feat/CK-86] 로드맵의 태그를 생성한다

### DIFF
--- a/client/src/components/roadmapCreatePage/roadmapCreateForm/RoadmapCreateForm.tsx
+++ b/client/src/components/roadmapCreatePage/roadmapCreateForm/RoadmapCreateForm.tsx
@@ -6,6 +6,7 @@ import Difficulty, { DummyDifficultyType } from '../difficulty/Difficulty';
 import MainText from '../mainText/MainText';
 import Period from '../period/Period';
 import Roadmap from '../roadmap/Roadmap';
+import Tag from '../tag/Tag';
 import Title from '../title/Title';
 
 // ref공유를 위한 context - 다음 브랜치에서 파일 옮길 예정
@@ -66,6 +67,7 @@ const RoadmapCreateForm = () => {
         <Title />
         <Description />
         <Difficulty getSelectedDifficulty={getSelectedDifficulty} />
+        <Tag />
         <MainText />
         <Period />
         <Roadmap />

--- a/client/src/components/roadmapCreatePage/tag/Tag.tsx
+++ b/client/src/components/roadmapCreatePage/tag/Tag.tsx
@@ -5,7 +5,7 @@ import TagItem from './TagItem';
 import { useCreateTag } from '@/hooks/roadmap/useCreateTag';
 
 const Tag = () => {
-  const { tags, ref, getTagText, checkTagCountUnderFive } = useCreateTag();
+  const { tags, ref, getAddedTagText, checkIsTagCountMax } = useCreateTag();
 
   return (
     <S.Container>
@@ -13,10 +13,10 @@ const Tag = () => {
       <InputDescription text='컨텐츠와 어울리는 태그를 작성해주세요' />
       <S.TagWrapper>
         {tags.map((item) => (
-          <TagItem key={item} value={item} readOnly />
+          <S.AddedTagItem key={item}>{item}</S.AddedTagItem>
         ))}
         <TagItem ref={ref} />
-        {checkTagCountUnderFive() && <S.AddButton onClick={getTagText}>+</S.AddButton>}
+        {checkIsTagCountMax() && <S.AddButton onClick={getAddedTagText}>+</S.AddButton>}
       </S.TagWrapper>
     </S.Container>
   );

--- a/client/src/components/roadmapCreatePage/tag/Tag.tsx
+++ b/client/src/components/roadmapCreatePage/tag/Tag.tsx
@@ -1,0 +1,25 @@
+import * as S from './tag.styles';
+import InputDescription from '../input/inputDescription/InputDescription';
+import InputLabel from '../input/inputLabel/InputLebel';
+import TagItem from './TagItem';
+import { useCreateTag } from '@/hooks/roadmap/useCreateTag';
+
+const Tag = () => {
+  const { tags, ref, getTagText, checkTagCountUnderFive } = useCreateTag();
+
+  return (
+    <S.Container>
+      <InputLabel text='태그' />
+      <InputDescription text='컨텐츠와 어울리는 태그를 작성해주세요' />
+      <S.TagWrapper>
+        {tags.map((item) => (
+          <TagItem key={item} value={item} readOnly />
+        ))}
+        <TagItem ref={ref} />
+        {checkTagCountUnderFive() && <S.AddButton onClick={getTagText}>+</S.AddButton>}
+      </S.TagWrapper>
+    </S.Container>
+  );
+};
+
+export default Tag;

--- a/client/src/components/roadmapCreatePage/tag/TagItem.tsx
+++ b/client/src/components/roadmapCreatePage/tag/TagItem.tsx
@@ -1,10 +1,11 @@
+import { TAG_MAX_LENGTH } from '@/constants/roadmap/regex';
+import { TAG_ITEM_MAX_LENGTH } from '@/constants/roadmap/tag';
 import { useValidateInput } from '@/hooks/_common/useValidateInput';
 import { forwardRef, InputHTMLAttributes } from 'react';
 import * as S from './tag.styles';
 
 type TagItemProps = InputHTMLAttributes<HTMLInputElement>;
 
-const TAG_MAX_LENGTH = { rule: /^.{1,10}$/, message: '1글자부터 5글자까지 작성해주세요' };
 const TagItem = forwardRef<HTMLInputElement, TagItemProps>((props, ref) => {
   const { handleInputChange, value } = useValidateInput(TAG_MAX_LENGTH);
 
@@ -12,7 +13,7 @@ const TagItem = forwardRef<HTMLInputElement, TagItemProps>((props, ref) => {
     <S.TagItem width={props.readOnly ? String(props.value).length : value.length}>
       <S.TagInputField
         onChange={handleInputChange}
-        maxLength={10}
+        maxLength={TAG_ITEM_MAX_LENGTH}
         value={props.value}
         ref={ref}
         readOnly={props.readOnly}

--- a/client/src/components/roadmapCreatePage/tag/TagItem.tsx
+++ b/client/src/components/roadmapCreatePage/tag/TagItem.tsx
@@ -1,0 +1,24 @@
+import { useValidateInput } from '@/hooks/_common/useValidateInput';
+import { forwardRef, InputHTMLAttributes } from 'react';
+import * as S from './tag.styles';
+
+type TagItemProps = InputHTMLAttributes<HTMLInputElement>;
+
+const TAG_MAX_LENGTH = { rule: /^.{1,10}$/, message: '1글자부터 5글자까지 작성해주세요' };
+const TagItem = forwardRef<HTMLInputElement, TagItemProps>((props, ref) => {
+  const { handleInputChange, value } = useValidateInput(TAG_MAX_LENGTH);
+
+  return (
+    <S.TagItem width={props.readOnly ? String(props.value).length : value.length}>
+      <S.TagInputField
+        onChange={handleInputChange}
+        maxLength={10}
+        value={props.value}
+        ref={ref}
+        readOnly={props.readOnly}
+      />
+    </S.TagItem>
+  );
+});
+
+export default TagItem;

--- a/client/src/components/roadmapCreatePage/tag/tag.styles.ts
+++ b/client/src/components/roadmapCreatePage/tag/tag.styles.ts
@@ -5,11 +5,24 @@ export const Container = styled.section`
 `;
 
 export const TagWrapper = styled.div`
-  ${({ theme }) => theme.fonts.nav_title};
+  ${({ theme }) => theme.fonts.description5};
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  color: ${({ theme }) => theme.colors.black};
+`;
+
+export const AddedTagItem = styled.article`
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  color: ${({ theme }) => theme.colors.main_dark};
+  justify-content: center;
+
+  height: 4.7rem;
+  margin-right: 2rem;
+  padding: 0 1rem;
+
+  border: 0.2rem solid ${({ theme }) => theme.colors.main_dark};
+  border-radius: 100px;
 `;
 
 export const TagItem = styled.article<{ width: number }>`
@@ -26,12 +39,13 @@ export const TagItem = styled.article<{ width: number }>`
 `;
 
 export const TagInputField = styled.input`
+  ${({ theme }) => theme.fonts.description5};
   width: 80%;
   text-align: center;
 `;
 
 export const AddButton = styled.button`
-  /* ${({ theme }) => theme.fonts.nav_title} */
+  ${({ theme }) => theme.fonts.nav_title}
   width: 5rem;
   height: 5rem;
 `;

--- a/client/src/components/roadmapCreatePage/tag/tag.styles.ts
+++ b/client/src/components/roadmapCreatePage/tag/tag.styles.ts
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+
+export const Container = styled.section`
+  margin-top: 5.5rem;
+`;
+
+export const TagWrapper = styled.div`
+  ${({ theme }) => theme.fonts.nav_title};
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  color: ${({ theme }) => theme.colors.main_dark};
+`;
+
+export const TagItem = styled.article<{ width: number }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: ${({ width }) => (width > 4 ? width * 2 : 10)}rem;
+  height: 4.7rem;
+  margin-right: 2rem;
+
+  border: 0.2rem solid ${({ theme }) => theme.colors.main_dark};
+  border-radius: 100px;
+`;
+
+export const TagInputField = styled.input`
+  width: 80%;
+  text-align: center;
+`;
+
+export const AddButton = styled.button`
+  /* ${({ theme }) => theme.fonts.nav_title} */
+  width: 5rem;
+  height: 5rem;
+`;

--- a/client/src/constants/roadmap/regex.ts
+++ b/client/src/constants/roadmap/regex.ts
@@ -19,3 +19,8 @@ export const ROADMAP_MAX_LENGTH = {
   rule: /^.{1,40}$/,
   message: '로드맵의 제목은 필수로 입력해주세요',
 };
+
+export const TAG_MAX_LENGTH = {
+  rule: /^.{1,10}$/,
+  message: '1글자부터 5글자까지 작성해주세요',
+};

--- a/client/src/constants/roadmap/tag.ts
+++ b/client/src/constants/roadmap/tag.ts
@@ -1,0 +1,3 @@
+export const TAG_LIMIT = 4;
+
+export const TAG_ITEM_MAX_LENGTH = 10;

--- a/client/src/hooks/_common/useValidateInput.ts
+++ b/client/src/hooks/_common/useValidateInput.ts
@@ -6,7 +6,7 @@ export const useValidateInput = (pattern: PatternType) => {
   const [value, setValue] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
 
-  const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+  const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     setValue(e.target.value);
   };
 

--- a/client/src/hooks/roadmap/useCreateTag.ts
+++ b/client/src/hooks/roadmap/useCreateTag.ts
@@ -1,10 +1,11 @@
+import { TAG_LIMIT } from '@/constants/roadmap/tag';
 import { useRef, useState } from 'react';
 
 export const useCreateTag = () => {
   const [tags, setTags] = useState<string[]>([]);
   const ref = useRef<HTMLInputElement | null>(null);
 
-  const getTagText = () => {
+  const getAddedTagText = () => {
     if (ref.current === null) return;
     if (ref.current.value === '') return;
 
@@ -12,9 +13,9 @@ export const useCreateTag = () => {
     ref.current.value = '';
   };
 
-  const checkTagCountUnderFive = () => {
-    return tags.length < 4;
+  const checkIsTagCountMax = () => {
+    return tags.length < TAG_LIMIT;
   };
 
-  return { tags, ref, getTagText, checkTagCountUnderFive };
+  return { tags, ref, getAddedTagText, checkIsTagCountMax };
 };

--- a/client/src/hooks/roadmap/useCreateTag.ts
+++ b/client/src/hooks/roadmap/useCreateTag.ts
@@ -1,0 +1,20 @@
+import { useRef, useState } from 'react';
+
+export const useCreateTag = () => {
+  const [tags, setTags] = useState<string[]>([]);
+  const ref = useRef<HTMLInputElement | null>(null);
+
+  const getTagText = () => {
+    if (ref.current === null) return;
+    if (ref.current.value === '') return;
+
+    setTags((prev) => [...prev, ref.current?.value as string]);
+    ref.current.value = '';
+  };
+
+  const checkTagCountUnderFive = () => {
+    return tags.length < 4;
+  };
+
+  return { tags, ref, getTagText, checkTagCountUnderFive };
+};

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -5,17 +5,17 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import App from './App';
 
 const startApp = async () => {
-  if (process.env.NODE_ENV === 'development') {
-    const { worker } = await import('./mocks/browser');
-    await worker.start({
-      serviceWorker: {
-        url: '/mockServiceWorker.js',
-        options: {
-          scope: '/api',
-        },
-      },
-    });
-  }
+  // if (process.env.NODE_ENV === 'development') {
+  //   const { worker } = await import('./mocks/browser');
+  //   await worker.start({
+  //     serviceWorker: {
+  //       url: '/mockServiceWorker.js',
+  //       options: {
+  //         scope: '/api',
+  //       },
+  //     },
+  //   });
+  // }
 
   const queryClient = new QueryClient({
     defaultOptions: {


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-86](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1/backlog?selectedIssue=CK-86)


## ✨ 작업 내용
- 태그를 생성하는 부분을 구현했습니다.
- 이부분은 textarea가 아니라 input태그를 이용해야해서 이전에 만들어뒀던 input컴포넌트를 재화용하지 못했어요.. 이전에 만들어뒀던 공용컴포넌트 & input로직을 전체적으로 수정해야할 것 같아요😭
- 태그는 10자 이하로 입력할 수 있고, 전체 개수는 5개까지 생성할 수 있습니다.

https://github.com/woowacourse-teams/2023-co-kirikiri/assets/87578512/35656f10-a5b0-4864-acd3-1392f1f116d1




## 💬 리뷰어에게 남길 멘트
- 화면 전체적으로 리랜더링이 될 때 높이가 달라져서 화면이 이리저리 흔들리는 현상이 생기는데.. 아직 이유를 못찾았습니다ㅠ
- 작업 속도가 느려서 죄송해욤.. 빠르게 하겠슴당 화이팅!


## 🚀 요구사항 분석


