### PR TITLE
[feat/CK-124] 투두리스트, 인증피드 모달을 구현하고 생성 기능을 매핑한다.

### DIFF
--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -74,6 +74,7 @@ module.exports = {
     'import/order': 'off',
     'react/jsx-no-constructed-context-values': 'off',
     'react/jsx-props-no-spreading': 'off',
-    'no-nested-ternary': 'off'
+    'no-nested-ternary': 'off',
+    "react/jsx-no-useless-fragment": "off"
   }
 };

--- a/client/src/apis/axios/client.ts
+++ b/client/src/apis/axios/client.ts
@@ -23,7 +23,7 @@ client.interceptors.request.use((config) => {
 });
 
 client.interceptors.response.use(
-  (response) => response.data,
+  (response) => response,
   async (error) => {
     const originalRequest = error.config;
 

--- a/client/src/apis/goalRoom.ts
+++ b/client/src/apis/goalRoom.ts
@@ -8,7 +8,7 @@ import {
 
 export const getGoalRoomDashboard = async (goalRoomId: string) => {
   const { data } = await client.get<GoalRoomBrowseResponse>(
-    `/api/members/goal-rooms/${goalRoomId}`
+    `/members/goal-rooms/${goalRoomId}`
   );
 
   return data;
@@ -22,12 +22,12 @@ export const postCreateGoalRoom = async (body: CreateGoalRoomRequest) => {
 
 export const getGoalRoomTodos = async (goalRoomId: string) => {
   const { data } = await client.get<GoalRoomTodoResponse>(
-    `/api/goal-rooms/${goalRoomId}/todos`
+    `/goal-rooms/${goalRoomId}/todos`
   );
 
   return data;
 };
 
 export const postCreateNewTodo = (goalRoomId: string, body: newTodoPayload) => {
-  return client.post(`/api/goal-rooms/${goalRoomId}/todos`, body);
+  return client.post(`/goal-rooms/${goalRoomId}/todos`, body);
 };

--- a/client/src/apis/goalRoom.ts
+++ b/client/src/apis/goalRoom.ts
@@ -3,6 +3,7 @@ import {
   GoalRoomBrowseResponse,
   newTodoPayload,
   CreateGoalRoomRequest,
+  GoalRoomTodoResponse,
 } from '@myTypes/goalRoom/remote';
 
 export const getGoalRoomDashboard = async (goalRoomId: string) => {
@@ -19,6 +20,14 @@ export const postCreateGoalRoom = async (body: CreateGoalRoomRequest) => {
   return data;
 };
 
+export const getGoalRoomTodos = async (goalRoomId: string) => {
+  const { data } = await client.get<GoalRoomTodoResponse>(
+    `/api/goal-rooms/${goalRoomId}/todos`
+  );
+
+  return data;
+};
+
 export const postCreateNewTodo = (goalRoomId: string, body: newTodoPayload) => {
-  return client.post(`/goal-rooms/${goalRoomId}/todos`, body);
+  return client.post(`/api/goal-rooms/${goalRoomId}/todos`, body);
 };

--- a/client/src/apis/goalRoom.ts
+++ b/client/src/apis/goalRoom.ts
@@ -8,7 +8,7 @@ import {
 
 export const getGoalRoomDashboard = async (goalRoomId: string) => {
   const { data } = await client.get<GoalRoomBrowseResponse>(
-    `/members/goal-rooms/${goalRoomId}`
+    `/goal-rooms/${goalRoomId}/me`
   );
 
   return data;

--- a/client/src/apis/goalRoom.ts
+++ b/client/src/apis/goalRoom.ts
@@ -1,5 +1,9 @@
 import client from '@apis/axios/client';
-import { GoalRoomBrowseResponse, CreateGoalRoomRequest } from '@myTypes/goalRoom/remote';
+import {
+  GoalRoomBrowseResponse,
+  newTodoPayload,
+  CreateGoalRoomRequest,
+} from '@myTypes/goalRoom/remote';
 
 export const getGoalRoomDashboard = async (goalRoomId: string) => {
   const { data } = await client.get<GoalRoomBrowseResponse>(
@@ -13,4 +17,8 @@ export const postCreateGoalRoom = async (body: CreateGoalRoomRequest) => {
   const { data } = await client.post<CreateGoalRoomRequest>(`/goal-rooms`, body);
 
   return data;
+};
+
+export const postCreateNewTodo = (goalRoomId: string, body: newTodoPayload) => {
+  return client.post(`/goal-rooms/${goalRoomId}/todos`, body);
 };

--- a/client/src/apis/goalRoom.ts
+++ b/client/src/apis/goalRoom.ts
@@ -31,3 +31,14 @@ export const getGoalRoomTodos = async (goalRoomId: string) => {
 export const postCreateNewTodo = (goalRoomId: string, body: newTodoPayload) => {
   return client.post(`/goal-rooms/${goalRoomId}/todos`, body);
 };
+
+export const postCreateNewCertificationFeed = (
+  goalRoomId: string,
+  formData: FormData
+) => {
+  return client.post(`/goal-rooms/${goalRoomId}/checkFeeds`, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+};

--- a/client/src/components/_common/dialog/dialog.tsx
+++ b/client/src/components/_common/dialog/dialog.tsx
@@ -56,5 +56,5 @@ export const DialogBackdrop = (props: PropsWithChildren<DialogBackdropProps>) =>
 
 export const DialogContent = ({ children }: PropsWithChildren) => {
   const { isOpen } = useContextScope(DialogContext);
-  return isOpen ? <div>{children}</div> : null;
+  return isOpen ? <>{children}</> : null;
 };

--- a/client/src/components/_common/navBar/NavBar.styles.ts
+++ b/client/src/components/_common/navBar/NavBar.styles.ts
@@ -107,9 +107,7 @@ export const Nav = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-
   height: calc(100% - 10rem);
-  padding: 3rem 1rem;
 
   ${media.mobile`
     height:100%;

--- a/client/src/components/_common/spinner/Spinner.styles.ts
+++ b/client/src/components/_common/spinner/Spinner.styles.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+import { spin } from '@styles/animations';
+
+export const Spinner = styled.div`
+  width: 120px;
+  height: 120px;
+  margin: 60px auto;
+
+  border: 16px solid ${({ theme }) => theme.colors.gray300};
+  border-top: 16px solid ${({ theme }) => theme.colors.main_dark};
+  border-radius: 50%;
+
+  animation: ${spin} 2s linear infinite;
+`;

--- a/client/src/components/_common/spinner/Spinner.tsx
+++ b/client/src/components/_common/spinner/Spinner.tsx
@@ -1,0 +1,7 @@
+import * as S from './Spinner.styles';
+
+const Spinner = () => {
+  return <S.Spinner />;
+};
+
+export default Spinner;

--- a/client/src/components/_providers/GoalRoomDashboardProvider.tsx
+++ b/client/src/components/_providers/GoalRoomDashboardProvider.tsx
@@ -6,10 +6,8 @@ import { goalRoomDashboardContext } from '@/context/goalRoomDashboardContext';
 const GoalRoomDashboardProvider = ({ children }: PropsWithChildren) => {
   const { goalroomId } = useValidParams<GoalRoomDashboardContentParams>();
 
-  const value = { goalroomId };
-
   return (
-    <goalRoomDashboardContext.Provider value={value}>
+    <goalRoomDashboardContext.Provider value={{ goalroomId }}>
       {children}
     </goalRoomDashboardContext.Provider>
   );

--- a/client/src/components/_providers/GoalRoomDashboardProvider.tsx
+++ b/client/src/components/_providers/GoalRoomDashboardProvider.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from 'react';
+import useValidParams from '@hooks/_common/useValidParams';
+import { GoalRoomDashboardContentParams } from '@components/goalRoomDahsboardPage/goalRoomDashboardContent/GoalRoomDashboardContent';
+import { goalRoomDashboardContext } from '@/context/goalRoomDashboardContext';
+
+const GoalRoomDashboardProvider = ({ children }: PropsWithChildren) => {
+  const { goalroomId } = useValidParams<GoalRoomDashboardContentParams>();
+
+  const value = { goalroomId };
+
+  return (
+    <goalRoomDashboardContext.Provider value={value}>
+      {children}
+    </goalRoomDashboardContext.Provider>
+  );
+};
+
+export default GoalRoomDashboardProvider;

--- a/client/src/components/goalRoomCreatePage/createGoalRoomForm/CreateGoalRoomForm.tsx
+++ b/client/src/components/goalRoomCreatePage/createGoalRoomForm/CreateGoalRoomForm.tsx
@@ -20,7 +20,6 @@ const CreateGoalRoomForm = ({ roadmapContentId, nodes }: CreateGoalRoomFormProps
     name: '',
     limitedMemberCount: 10,
     goalRoomTodo: {
-      id: null,
       content: '',
       startDate: '',
       endDate: '',

--- a/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/GoalRoomCertificationFeed.styles.ts
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/GoalRoomCertificationFeed.styles.ts
@@ -1,5 +1,6 @@
 import { DashBoardSection } from '@components/goalRoomDahsboardPage/goalRoomDashboardContent/GoalRoomDashboardContent.styles';
 import styled from 'styled-components';
+import { BackDrop } from '@components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.styles';
 
 export const CertificationFeedWrapper = styled(DashBoardSection)``;
 
@@ -27,3 +28,5 @@ export const StyledImage = styled.img`
     box-shadow: ${({ theme }) => theme.shadows.threeDHovered};
   }
 `;
+
+export const ModalBackdrop = styled(BackDrop)``;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/GoalRoomCertificationFeed.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/GoalRoomCertificationFeed.tsx
@@ -2,6 +2,13 @@ import * as S from './GoalRoomCertificationFeed.styles';
 import SVGIcon from '@components/icons/SVGIcon';
 import { GoalRoomBrowseResponse } from '@myTypes/goalRoom/remote';
 import { StyledImage } from './GoalRoomCertificationFeed.styles';
+import {
+  DialogBackdrop,
+  DialogBox,
+  DialogContent,
+  DialogTrigger,
+} from '@components/_common/dialog/dialog';
+import CertificationFeedModal from '@components/goalRoomDahsboardPage/goalRoomCertificationFeed/certificationFeedModal/CertificationFeedModal';
 
 type GoalRoomCertificationFeedProps = {
   goalRoomData: GoalRoomBrowseResponse;
@@ -13,24 +20,37 @@ const GoalRoomCertificationFeed = ({ goalRoomData }: GoalRoomCertificationFeedPr
   const { checkFeeds } = goalRoomData;
 
   return (
-    <S.CertificationFeedWrapper>
-      <div>
-        <h2>인증 피드</h2>
-        <button aria-labelledby='이미지 피드 전체보기'>
-          <span>전체보기</span>
-          <SVGIcon name='RightArrowIcon' aria-hidden='true' />
-        </button>
-      </div>
-      <S.ImageGrid>
-        {checkFeeds.map((feed) => {
-          return (
-            <button key={feed.id} aria-label='이미지 크게보기'>
-              <StyledImage src={feed.imageUrl} alt={`Image ${feed.id}`} />
+    <DialogBox>
+      <S.CertificationFeedWrapper>
+        <div>
+          <h2>인증 피드</h2>
+
+          <DialogTrigger asChild>
+            <button aria-labelledby='이미지 피드 전체보기'>
+              <span>전체보기</span>
+              <SVGIcon name='RightArrowIcon' aria-hidden='true' />
             </button>
-          );
-        })}
-      </S.ImageGrid>
-    </S.CertificationFeedWrapper>
+          </DialogTrigger>
+        </div>
+        <S.ImageGrid>
+          {checkFeeds.map((feed) => {
+            return (
+              <button key={feed.id} aria-label='이미지 크게보기'>
+                <StyledImage src={feed.imageUrl} alt={`Image ${feed.id}`} />
+              </button>
+            );
+          })}
+        </S.ImageGrid>
+      </S.CertificationFeedWrapper>
+
+      <DialogBackdrop asChild>
+        <S.ModalBackdrop />
+      </DialogBackdrop>
+
+      <DialogContent>
+        <CertificationFeedModal />
+      </DialogContent>
+    </DialogBox>
   );
 };
 

--- a/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/certificationFeedModal/CertificationFeedModal.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/certificationFeedModal/CertificationFeedModal.tsx
@@ -1,0 +1,95 @@
+import * as S from './CertificationModal.styles';
+import { ChangeEvent, useState } from 'react';
+import InputField from '@components/roadmapCreatePage/input/inputField/InputField';
+import { useValidateInput } from '@hooks/_common/useValidateInput';
+import { CERTIFICATION_FEED } from '@constants/goalRoom/regex';
+import TextCount from '@components/roadmapCreatePage/input/textCount/TextCount';
+import { useCreateCertificationFeed } from '@hooks/queries/goalRoom';
+import { useGoalRoomDashboardContext } from '@/context/goalRoomDashboardContext';
+
+const CertificationFeedModal = () => {
+  const { goalroomId } = useGoalRoomDashboardContext();
+
+  const [imagePreview, setImagePreview] = useState<string | null>('');
+  const [imageFile, setImageFile] = useState<File | null>(null); // add this state for file
+  const { handleInputChange, validateInput, errorMessage, resetErrorMessage, value } =
+    useValidateInput(CERTIFICATION_FEED);
+
+  const { createCertificationFeed } = useCreateCertificationFeed(goalroomId);
+
+  const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files ? event.target.files[0] : null;
+
+    if (file) {
+      setImageFile(file);
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setImagePreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleRemoveImage = () => {
+    setImagePreview(null);
+    setImageFile(null);
+  };
+
+  const handleFormSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!imageFile || !value) return;
+
+    const formData = new FormData();
+
+    formData.append('image', imageFile);
+    formData.append('description', value);
+
+    createCertificationFeed(formData);
+  };
+
+  return (
+    <S.CertificationModalWrapper>
+      <S.CertificationHeader>인증피드</S.CertificationHeader>
+      <S.CertificationText>새로운 인증피드 등록</S.CertificationText>
+      {imagePreview && (
+        <S.PreviewWrapper>
+          <S.PreviewImage src={imagePreview} alt='업로드한 인증 피드 이미지' />
+          <S.PreviewDeleteButton onClick={handleRemoveImage}>X</S.PreviewDeleteButton>
+        </S.PreviewWrapper>
+      )}
+
+      <form action='' onSubmit={handleFormSubmit}>
+        {!imagePreview && (
+          <S.FileUploadCard htmlFor='fileInput'>
+            <S.PlusButton>인증피드 사진 업로드</S.PlusButton>
+            <input
+              id='fileInput'
+              type='file'
+              onChange={handleImageChange}
+              style={{ display: 'none' }}
+            />
+          </S.FileUploadCard>
+        )}
+        <S.InputFieldWrapper>
+          <InputField
+            placeholder='컨텐츠를 소개하는 문장을 작성해주세요'
+            handleInputChange={handleInputChange}
+            maxLength={250}
+            validateInput={validateInput}
+            resetErrorMessage={resetErrorMessage}
+            name='introduction'
+            data-valid={validateInput}
+          />
+        </S.InputFieldWrapper>
+        <TextCount maxCount={250} currentCount={value.length} />
+        <S.ErrorMessage>{errorMessage}</S.ErrorMessage>
+        <S.CertificationSubmitButton type='submit'>
+          인증피드 등록
+        </S.CertificationSubmitButton>
+      </form>
+    </S.CertificationModalWrapper>
+  );
+};
+
+export default CertificationFeedModal;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/certificationFeedModal/CertificationModal.styles.ts
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/certificationFeedModal/CertificationModal.styles.ts
@@ -1,0 +1,92 @@
+import {
+  ModalHeader,
+  ModalWrapper,
+  NewTodoText,
+} from '@components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.styles';
+import styled from 'styled-components';
+
+export const CertificationModalWrapper = styled(ModalWrapper)``;
+
+export const CertificationHeader = styled(ModalHeader)``;
+
+export const CertificationText = styled(NewTodoText)``;
+
+export const PreviewImage = styled.img`
+  width: 20rem;
+  height: 25rem;
+
+  object-fit: cover;
+  border-radius: 10px;
+  box-shadow: ${({ theme }) => theme.shadows.threeD};
+`;
+
+export const FileUploadCard = styled.label`
+  cursor: pointer;
+
+  position: relative;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 20rem;
+  height: 25rem;
+
+  border: dashed 0.2rem ${({ theme }) => theme.colors.gray200};
+  border-radius: 10px;
+`;
+
+export const PlusButton = styled.span`
+  ${({ theme }) => theme.fonts.h2};
+  color: ${({ theme }) => theme.colors.gray200};
+`;
+
+export const PreviewWrapper = styled.div`
+  position: relative;
+  width: 20rem;
+  height: 25rem;
+  margin-top: 2rem;
+`;
+
+export const PreviewDeleteButton = styled.button`
+  position: absolute;
+  top: 2rem;
+  right: 1rem;
+
+  width: 2rem;
+  height: 2rem;
+
+  background: ${({ theme }) => theme.colors.red};
+  border-radius: 50%;
+  box-shadow: ${({ theme }) => theme.shadows.threeD};
+
+  &:hover {
+    box-shadow: ${({ theme }) => theme.shadows.threeDHovered};
+
+    &:hover {
+      transform: scale(1.04);
+    }
+  }
+`;
+
+export const ErrorMessage = styled.div`
+  height: 2rem;
+  margin-top: 1rem;
+  color: ${({ theme }) => theme.colors.red};
+`;
+
+export const InputFieldWrapper = styled.div`
+  width: 20rem;
+  margin-top: 1rem;
+  padding: 1rem;
+
+  border: 1px solid ${({ theme }) => theme.colors.gray200};
+  border-radius: 10px;
+`;
+
+export const CertificationSubmitButton = styled.button`
+  width: 20rem;
+  padding: 1rem;
+  background: ${({ theme }) => theme.colors.main_middle};
+  border-radius: 10px;
+`;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.styles.ts
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.styles.ts
@@ -29,3 +29,13 @@ export const CountBox = styled.span`
   border-radius: 50%;
   box-shadow: ${({ theme }) => theme.shadows.main};
 `;
+
+export const BackDrop = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+
+  background-color: ${({ theme }) => theme.colors.backdrop};
+`;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
@@ -10,12 +10,15 @@ import {
 } from '@components/_common/dialog/dialog';
 import TodoModal from '@components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal';
 
+type GoalRoomDashboardTodoProps = {
+  goalRoomData: GoalRoomBrowseResponse;
+  goalRoomId: string;
+};
 
 const GoalRoomDashboardTodo = ({
   goalRoomData,
-}: {
-  goalRoomData: GoalRoomBrowseResponse;
-}) => {
+  goalRoomId,
+}: GoalRoomDashboardTodoProps) => {
   const { goalRoomTodos } = goalRoomData;
 
   return (
@@ -45,11 +48,11 @@ const GoalRoomDashboardTodo = ({
       </S.TodoWrapper>
 
       <DialogBackdrop asChild>
-        <BackDrop />
+        <S.BackDrop />
       </DialogBackdrop>
 
       <DialogContent>
-        <TodoModal />
+        <TodoModal goalRoomId={goalRoomId} />
       </DialogContent>
     </DialogBox>
   );

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
@@ -2,6 +2,24 @@ import * as S from './GoalRoomDashboardTodo.styles';
 import SVGIcon from '@components/icons/SVGIcon';
 import { GoalRoomBrowseResponse } from '@myTypes/goalRoom/remote';
 import SingleTodo from '@components/goalRoomDahsboardPage/goalRoomDahsboardTodo/singleTodo/SingleTodo';
+import {
+  DialogBackdrop,
+  DialogBox,
+  DialogContent,
+  DialogTrigger,
+} from '@components/_common/dialog/dialog';
+import styled from 'styled-components';
+import TodoModal from '@components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal';
+
+const BackDrop = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+
+  background-color: rgba(220, 220, 220, 0.44);
+`;
 
 const GoalRoomDashboardTodo = ({
   goalRoomData,
@@ -11,27 +29,39 @@ const GoalRoomDashboardTodo = ({
   const { goalRoomTodos } = goalRoomData;
 
   return (
-    <S.TodoWrapper>
-      <div>
-        <S.TitleWrapper>
-          <h2>투두 리스트</h2>
-          <S.CountBox>8</S.CountBox>
-        </S.TitleWrapper>
+    <DialogBox>
+      <S.TodoWrapper>
+        <div>
+          <S.TitleWrapper>
+            <h2>투두 리스트</h2>
+            <S.CountBox>8</S.CountBox>
+          </S.TitleWrapper>
 
-        <button>
-          <span>전체보기</span>
-          <SVGIcon name='RightArrowIcon' />
-        </button>
-      </div>
+          <DialogTrigger asChild>
+            <button>
+              <span>전체보기</span>
+              <SVGIcon name='RightArrowIcon' aria-hidden='true' />
+            </button>
+          </DialogTrigger>
+        </div>
 
-      <div>
-        <S.TodoContent>
-          {goalRoomTodos.map((todo) => {
-            return <SingleTodo key={todo.id} todoContent={todo} />;
-          })}
-        </S.TodoContent>
-      </div>
-    </S.TodoWrapper>
+        <div>
+          <S.TodoContent>
+            {goalRoomTodos.map((todo) => {
+              return <SingleTodo key={todo.id} todoContent={todo} />;
+            })}
+          </S.TodoContent>
+        </div>
+      </S.TodoWrapper>
+
+      <DialogContent>
+        <TodoModal />
+      </DialogContent>
+
+      <DialogBackdrop asChild>
+        <BackDrop />
+      </DialogBackdrop>
+    </DialogBox>
   );
 };
 

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
@@ -8,18 +8,8 @@ import {
   DialogContent,
   DialogTrigger,
 } from '@components/_common/dialog/dialog';
-import styled from 'styled-components';
 import TodoModal from '@components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal';
 
-const BackDrop = styled.div`
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-
-  background-color: rgba(220, 220, 220, 0.44);
-`;
 
 const GoalRoomDashboardTodo = ({
   goalRoomData,

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
@@ -54,13 +54,13 @@ const GoalRoomDashboardTodo = ({
         </div>
       </S.TodoWrapper>
 
-      <DialogContent>
-        <TodoModal />
-      </DialogContent>
-
       <DialogBackdrop asChild>
         <BackDrop />
       </DialogBackdrop>
+
+      <DialogContent>
+        <TodoModal />
+      </DialogContent>
     </DialogBox>
   );
 };

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
@@ -12,13 +12,9 @@ import TodoModal from '@components/goalRoomDahsboardPage/goalRoomDahsboardTodo/t
 
 type GoalRoomDashboardTodoProps = {
   goalRoomData: GoalRoomBrowseResponse;
-  goalRoomId: string;
 };
 
-const GoalRoomDashboardTodo = ({
-  goalRoomData,
-  goalRoomId,
-}: GoalRoomDashboardTodoProps) => {
+const GoalRoomDashboardTodo = ({ goalRoomData }: GoalRoomDashboardTodoProps) => {
   const { goalRoomTodos } = goalRoomData;
 
   return (
@@ -52,7 +48,7 @@ const GoalRoomDashboardTodo = ({
       </DialogBackdrop>
 
       <DialogContent>
-        <TodoModal goalRoomId={goalRoomId} />
+        <TodoModal />
       </DialogContent>
     </DialogBox>
   );

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/NewTodoForm.styles.ts
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/NewTodoForm.styles.ts
@@ -4,7 +4,8 @@ export const AddingTodoForm = styled.form`
   display: flex;
   align-items: center;
 
-  padding: 1rem;
+  margin-bottom: 1rem;
+  padding: 1.5rem;
 
   border: 1px solid ${({ theme }) => theme.colors.gray200};
   border-radius: 10px;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/NewTodoForm.styles.ts
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/NewTodoForm.styles.ts
@@ -1,0 +1,81 @@
+import styled from 'styled-components';
+
+export const AddingTodoForm = styled.form`
+  display: flex;
+  align-items: center;
+
+  padding: 1rem;
+
+  border: 1px solid ${({ theme }) => theme.colors.gray200};
+  border-radius: 10px;
+  box-shadow: ${({ theme }) => theme.shadows.main};
+`;
+
+export const InputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 1rem;
+`;
+
+export const ContentInputContainer = styled(InputContainer)`
+  flex: 4;
+`;
+
+export const DateInputContainer = styled(InputContainer)`
+  flex: 1;
+`;
+
+export const TodoDateInput = styled.input`
+  display: block;
+  flex: 1;
+
+  width: 100%;
+  margin-top: 1rem;
+  padding: 0.5rem;
+
+  font-size: 1rem;
+
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray200};
+  border-radius: 5px;
+`;
+
+export const ModalContentInput = styled(TodoDateInput)`
+  flex: 3;
+`;
+
+export const DateInputLabel = styled.label`
+  ${({ theme }) => theme.fonts.caption1};
+  margin-bottom: 0.3rem;
+  color: ${({ theme }) => theme.colors.gray300};
+  text-align: center;
+`;
+
+export const SubmitButton = styled.button`
+  cursor: pointer;
+
+  flex: 0.4;
+
+  margin: 1rem 0 0 2rem;
+  padding: 0.5rem;
+
+  color: ${({ theme }) => theme.colors.white};
+  text-align: center;
+
+  background-color: ${({ theme }) => theme.colors.main_middle};
+  border: none;
+  border-radius: 5px;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.main_dark};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    background-color: #bbbbbb;
+  }
+`;
+
+export const Error = styled.span`
+  ${({ theme }) => theme.fonts.caption1};
+  color: ${({ theme }) => theme.colors.red};
+`;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/NewTodoForm.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/NewTodoForm.tsx
@@ -3,16 +3,15 @@ import { FormEvent } from 'react';
 import useNewTodoFormValidation from '@hooks/goalRoom/useNewTodoFormValidation';
 import { useCreateTodo } from '@hooks/queries/goalRoom';
 import removeDashesFromStr from '@utils/_common/removeDashesFromStr';
+import { useGoalRoomDashboardContext } from '@/context/goalRoomDashboardContext';
 
-type TodoFormProps = {
-  goalRoomId: string;
-};
+const TodoForm = () => {
+  const { goalroomId } = useGoalRoomDashboardContext();
 
-const TodoForm = ({ goalRoomId }: TodoFormProps) => {
   const { formState, validateForm, contentInput, startDateInput, endDateInput } =
     useNewTodoFormValidation();
 
-  const { createTodo } = useCreateTodo(goalRoomId);
+  const { createTodo } = useCreateTodo(goalroomId);
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/NewTodoForm.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/NewTodoForm.tsx
@@ -1,16 +1,28 @@
 import * as S from './NewTodoForm.styles';
 import { FormEvent } from 'react';
 import useNewTodoFormValidation from '@hooks/goalRoom/useNewTodoFormValidation';
+import { useCreateTodo } from '@hooks/queries/goalRoom';
+import removeDashesFromStr from '@utils/_common/removeDashesFromStr';
 
-const TodoForm = () => {
+type TodoFormProps = {
+  goalRoomId: string;
+};
+
+const TodoForm = ({ goalRoomId }: TodoFormProps) => {
   const { formState, validateForm, contentInput, startDateInput, endDateInput } =
     useNewTodoFormValidation();
+
+  const { createTodo } = useCreateTodo(goalRoomId);
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
 
     if (validateForm()) {
-      console.log(formState, 'formState');
+      createTodo({
+        ...formState,
+        startDate: removeDashesFromStr(formState.startDate),
+        endDate: removeDashesFromStr(formState.endDate),
+      });
     }
   };
 

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/NewTodoForm.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/NewTodoForm.tsx
@@ -1,0 +1,66 @@
+import * as S from './NewTodoForm.styles';
+import { FormEvent } from 'react';
+import useNewTodoFormValidation from '@hooks/goalRoom/useNewTodoFormValidation';
+
+const TodoForm = () => {
+  const { formState, validateForm, contentInput, startDateInput, endDateInput } =
+    useNewTodoFormValidation();
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+
+    if (validateForm()) {
+      console.log(formState, 'formState');
+    }
+  };
+
+  return (
+    <S.AddingTodoForm onSubmit={handleSubmit} aria-label='투두리스트 작성 폼'>
+      <S.ContentInputContainer>
+        <S.DateInputLabel htmlFor='투두리스트 내용'>내용:</S.DateInputLabel>
+        <S.ModalContentInput
+          id='투두리스트 내용'
+          type='text'
+          placeholder='투두리스트 내용을 입력해주세요'
+          value={contentInput.value}
+          onChange={contentInput.controlInputChange}
+          aria-required='true'
+        />
+        {contentInput.errorMessage && (
+          <S.Error role='alert'>{contentInput.errorMessage}</S.Error>
+        )}
+      </S.ContentInputContainer>
+      <S.DateInputContainer>
+        <S.DateInputLabel htmlFor='startDate'>시작일:</S.DateInputLabel>
+        <S.TodoDateInput
+          id='startDate'
+          name='startDate'
+          type='date'
+          value={startDateInput.value}
+          onChange={startDateInput.controlInputChange}
+          aria-required='true'
+        />
+        {startDateInput.errorMessage && (
+          <S.Error role='alert'>{startDateInput.errorMessage}</S.Error>
+        )}
+      </S.DateInputContainer>
+      <S.DateInputContainer>
+        <S.DateInputLabel htmlFor='endDate'>종료일:</S.DateInputLabel>
+        <S.TodoDateInput
+          id='endDate'
+          name='endDate'
+          type='date'
+          value={endDateInput.value}
+          onChange={endDateInput.controlInputChange}
+          aria-required='true'
+        />
+        {endDateInput.errorMessage && (
+          <S.Error role='alert'>{endDateInput.errorMessage}</S.Error>
+        )}
+      </S.DateInputContainer>
+      <S.SubmitButton type='submit'>등록</S.SubmitButton>
+    </S.AddingTodoForm>
+  );
+};
+
+export default TodoForm;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.styles.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.styles.tsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+export const ModalWrapper = styled.div`
+  position: fixed;
+  z-index: 100;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  width: 70%;
+  padding: 2rem;
+
+  background-color: ${({ theme }) => theme.colors.gray_light};
+  border-radius: 10px;
+  box-shadow: ${({ theme }) => theme.shadows.modal};
+`;
+
+export const ModalHeader = styled.h1`
+  ${({ theme }) => theme.fonts.h1};
+  text-align: center;
+  margin-bottom: 2rem;
+`;
+
+export const NewTodoText = styled.h3`
+  ${({ theme }) => theme.fonts.description2};
+  margin-bottom: 1rem;
+`;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.styles.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.styles.tsx
@@ -7,7 +7,7 @@ export const ModalWrapper = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
 
-  width: 70%;
+  width: 45%;
   padding: 2rem;
 
   background-color: ${({ theme }) => theme.colors.gray_light};

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.tsx
@@ -1,0 +1,17 @@
+import * as S from './TodoModal.styles';
+import { createPortal } from 'react-dom';
+import NewTodoForm from './NewTodoForm';
+
+const TodoModal = () => {
+  const TodoModalContent = (
+    <S.ModalWrapper>
+      <S.ModalHeader>투두리스트</S.ModalHeader>
+      <S.NewTodoText>새로운 투두리스트 등록</S.NewTodoText>
+      <NewTodoForm />
+    </S.ModalWrapper>
+  );
+
+  return createPortal(TodoModalContent, document.body);
+};
+
+export default TodoModal;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.tsx
@@ -3,18 +3,17 @@ import { createPortal } from 'react-dom';
 import NewTodoForm from './NewTodoForm';
 import { useFetchGoalRoomTodos } from '@hooks/queries/goalRoom';
 import SingleTodo from '@components/goalRoomDahsboardPage/goalRoomDahsboardTodo/singleTodo/SingleTodo';
+import { useGoalRoomDashboardContext } from '@/context/goalRoomDashboardContext';
 
-type TodoModalProps = {
-  goalRoomId: string;
-};
-const TodoModal = ({ goalRoomId }: TodoModalProps) => {
-  const { goalRoomTodos } = useFetchGoalRoomTodos(goalRoomId);
+const TodoModal = () => {
+  const { goalroomId } = useGoalRoomDashboardContext();
+  const { goalRoomTodos } = useFetchGoalRoomTodos(goalroomId);
 
   const TodoModalContent = (
     <S.ModalWrapper>
       <S.ModalHeader>투두리스트</S.ModalHeader>
       <S.NewTodoText>새로운 투두리스트 등록</S.NewTodoText>
-      <NewTodoForm goalRoomId={goalRoomId} />
+      <NewTodoForm />
       {goalRoomTodos.map((todo) => {
         return <SingleTodo todoContent={todo} key={todo.id} />;
       })}

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.tsx
@@ -2,12 +2,15 @@ import * as S from './TodoModal.styles';
 import { createPortal } from 'react-dom';
 import NewTodoForm from './NewTodoForm';
 
-const TodoModal = () => {
+type TodoModalProps = {
+  goalRoomId: string;
+};
+const TodoModal = ({ goalRoomId }: TodoModalProps) => {
   const TodoModalContent = (
     <S.ModalWrapper>
       <S.ModalHeader>투두리스트</S.ModalHeader>
       <S.NewTodoText>새로운 투두리스트 등록</S.NewTodoText>
-      <NewTodoForm />
+      <NewTodoForm goalRoomId={goalRoomId} />
     </S.ModalWrapper>
   );
 

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.tsx
@@ -1,16 +1,23 @@
 import * as S from './TodoModal.styles';
 import { createPortal } from 'react-dom';
 import NewTodoForm from './NewTodoForm';
+import { useFetchGoalRoomTodos } from '@hooks/queries/goalRoom';
+import SingleTodo from '@components/goalRoomDahsboardPage/goalRoomDahsboardTodo/singleTodo/SingleTodo';
 
 type TodoModalProps = {
   goalRoomId: string;
 };
 const TodoModal = ({ goalRoomId }: TodoModalProps) => {
+  const { goalRoomTodos } = useFetchGoalRoomTodos(goalRoomId);
+
   const TodoModalContent = (
     <S.ModalWrapper>
       <S.ModalHeader>투두리스트</S.ModalHeader>
       <S.NewTodoText>새로운 투두리스트 등록</S.NewTodoText>
       <NewTodoForm goalRoomId={goalRoomId} />
+      {goalRoomTodos.map((todo) => {
+        return <SingleTodo todoContent={todo} key={todo.id} />;
+      })}
     </S.ModalWrapper>
   );
 

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDashboardContent/GoalRoomDashboardContent.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDashboardContent/GoalRoomDashboardContent.tsx
@@ -9,6 +9,8 @@ import { useFetchGoalRoom } from '@hooks/queries/goalRoom';
 
 import * as S from './GoalRoomDashboardContent.styles';
 import useValidParams from '@hooks/_common/useValidParams';
+import { Suspense } from 'react';
+import Spinner from '@components/_common/spinner/Spinner';
 
 export type GoalRoomDashboardContentParams = {
   goalroomId: string;
@@ -20,16 +22,18 @@ const GoalRoomDashboardContent = () => {
   const { goalRoom } = useFetchGoalRoom(goalroomId);
 
   return (
-    <div>
-      <GoalRoomDashboardHeader goalRoomData={goalRoom} />
-      <S.GoalRoomGridContainer>
-        <GoalRoomDashboardChat />
-        <GoalRoomDashboardTodo goalRoomData={goalRoom} goalRoomId={goalroomId} />
-        <GoalRoomDashboardRoadmap />
-        <GoalRoomDashboardCalender />
-        <GoalRoomCertificationFeed goalRoomData={goalRoom} />
-      </S.GoalRoomGridContainer>
-    </div>
+    <Suspense fallback={<Spinner />}>
+      <div>
+        <GoalRoomDashboardHeader goalRoomData={goalRoom} />
+        <S.GoalRoomGridContainer>
+          <GoalRoomDashboardChat />
+          <GoalRoomDashboardTodo goalRoomData={goalRoom} goalRoomId={goalroomId} />
+          <GoalRoomDashboardRoadmap />
+          <GoalRoomDashboardCalender />
+          <GoalRoomCertificationFeed goalRoomData={goalRoom} />
+        </S.GoalRoomGridContainer>
+      </div>
+    </Suspense>
   );
 };
 

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDashboardContent/GoalRoomDashboardContent.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDashboardContent/GoalRoomDashboardContent.tsx
@@ -8,16 +8,16 @@ import GoalRoomCertificationFeed from '@components/goalRoomDahsboardPage/goalRoo
 import { useFetchGoalRoom } from '@hooks/queries/goalRoom';
 
 import * as S from './GoalRoomDashboardContent.styles';
-import useValidParams from '@hooks/_common/useValidParams';
 import { Suspense } from 'react';
 import Spinner from '@components/_common/spinner/Spinner';
+import { useGoalRoomDashboardContext } from '@/context/goalRoomDashboardContext';
 
 export type GoalRoomDashboardContentParams = {
   goalroomId: string;
 };
 
 const GoalRoomDashboardContent = () => {
-  const { goalroomId } = useValidParams<GoalRoomDashboardContentParams>();
+  const { goalroomId } = useGoalRoomDashboardContext();
 
   const { goalRoom } = useFetchGoalRoom(goalroomId);
 
@@ -27,7 +27,7 @@ const GoalRoomDashboardContent = () => {
         <GoalRoomDashboardHeader goalRoomData={goalRoom} />
         <S.GoalRoomGridContainer>
           <GoalRoomDashboardChat />
-          <GoalRoomDashboardTodo goalRoomData={goalRoom} goalRoomId={goalroomId} />
+          <GoalRoomDashboardTodo goalRoomData={goalRoom} />
           <GoalRoomDashboardRoadmap />
           <GoalRoomDashboardCalender />
           <GoalRoomCertificationFeed goalRoomData={goalRoom} />

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDashboardContent/GoalRoomDashboardContent.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDashboardContent/GoalRoomDashboardContent.tsx
@@ -10,7 +10,7 @@ import { useFetchGoalRoom } from '@hooks/queries/goalRoom';
 import * as S from './GoalRoomDashboardContent.styles';
 import useValidParams from '@hooks/_common/useValidParams';
 
-type GoalRoomDashboardContentParams = {
+export type GoalRoomDashboardContentParams = {
   goalroomId: string;
 };
 
@@ -24,7 +24,7 @@ const GoalRoomDashboardContent = () => {
       <GoalRoomDashboardHeader goalRoomData={goalRoom} />
       <S.GoalRoomGridContainer>
         <GoalRoomDashboardChat />
-        <GoalRoomDashboardTodo goalRoomData={goalRoom} />
+        <GoalRoomDashboardTodo goalRoomData={goalRoom} goalRoomId={goalroomId} />
         <GoalRoomDashboardRoadmap />
         <GoalRoomDashboardCalender />
         <GoalRoomCertificationFeed goalRoomData={goalRoom} />

--- a/client/src/constants/goalRoom/regex.ts
+++ b/client/src/constants/goalRoom/regex.ts
@@ -12,3 +12,8 @@ export const TODO_END_DATE = {
   rule: /^(19|20)\d{2}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/,
   message: 'yyyy-mm-dd 형식으로 입력해주세요 (ex. 2021-01-01)',
 };
+
+export const CERTIFICATION_FEED = {
+  rule: /^.{1,250}$/,
+  message: '1글자부터 250글자까지 작성해주세요',
+};

--- a/client/src/constants/goalRoom/regex.ts
+++ b/client/src/constants/goalRoom/regex.ts
@@ -1,0 +1,14 @@
+export const TODO_CONTENT_MAX_LENGTH = {
+  rule: /^.{1,250}$/,
+  message: '1글자부터 250글자까지 작성해주세요',
+};
+
+export const TODO_START_DATE = {
+  rule: /^(19|20)\d{2}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/,
+  message: 'yyyy-mm-dd 형식으로 입력해주세요 (ex. 2021-01-01)',
+};
+
+export const TODO_END_DATE = {
+  rule: /^(19|20)\d{2}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/,
+  message: 'yyyy-mm-dd 형식으로 입력해주세요 (ex. 2021-01-01)',
+};

--- a/client/src/context/goalRoomDashboardContext.ts
+++ b/client/src/context/goalRoomDashboardContext.ts
@@ -1,0 +1,8 @@
+import { createContext, useContext } from 'react';
+import { GoalRoomDashboardContextType } from '@myTypes/_common/dashboard';
+
+export const goalRoomDashboardContext = createContext<GoalRoomDashboardContextType>({
+  goalroomId: '',
+});
+
+export const useGoalRoomDashboardContext = () => useContext(goalRoomDashboardContext);

--- a/client/src/hooks/_common/useValidateInput.ts
+++ b/client/src/hooks/_common/useValidateInput.ts
@@ -1,24 +1,26 @@
 import { ChangeEvent, useState } from 'react';
 import { PatternType } from '@myTypes/roadmap/internal';
 
-export const useValidateInput = (pattern: PatternType) => {
+export const useValidateInput = <T extends HTMLInputElement | HTMLTextAreaElement>(
+  pattern: PatternType
+) => {
   const { rule, message } = pattern;
   const [value, setValue] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
 
-  const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+  const handleInputChange = (e: ChangeEvent<T>) => {
     setValue(e.target.value);
   };
 
-  const controlInputChange = ({
-    target: { value },
-  }: ChangeEvent<HTMLTextAreaElement>) => {
+  const controlInputChange = (e: ChangeEvent<T>) => {
+    const { value } = e.target;
     if (!rule.test(value)) {
       setErrorMessage(message);
 
       return;
     }
 
+    setErrorMessage('');
     setValue(value);
   };
 
@@ -41,5 +43,6 @@ export const useValidateInput = (pattern: PatternType) => {
     validateInput,
     controlInputChange,
     resetErrorMessage,
+    setErrorMessage,
   };
 };

--- a/client/src/hooks/goalRoom/useNewTodoFormValidation.ts
+++ b/client/src/hooks/goalRoom/useNewTodoFormValidation.ts
@@ -27,29 +27,25 @@ const useNewTodoFormValidation = () => {
   }, [contentInput.value, startDateInput.value, endDateInput.value]);
 
   const validateForm = () => {
-    let isValid = true;
-
     if (!startDateInput.value) {
       startDateInput.setErrorMessage('시작일을 기입해주세요.');
-      isValid = false;
+      return false;
     }
 
     if (!endDateInput.value) {
       endDateInput.setErrorMessage('종료일을 기입해주세요.');
-      isValid = false;
+      return false;
     }
 
-    if (isValid) {
-      const startDate = new Date(startDateInput.value);
-      const endDate = new Date(endDateInput.value);
+    const startDate = new Date(startDateInput.value);
+    const endDate = new Date(endDateInput.value);
 
-      if (startDate >= endDate) {
-        endDateInput.setErrorMessage('종료일이 시작일보다 이전입니다.');
-        isValid = false;
-      }
+    if (startDate >= endDate) {
+      endDateInput.setErrorMessage('종료일이 시작일보다 이전입니다.');
+      return false;
     }
 
-    return isValid;
+    return true;
   };
 
   return { formState, validateForm, contentInput, startDateInput, endDateInput };

--- a/client/src/hooks/goalRoom/useNewTodoFormValidation.ts
+++ b/client/src/hooks/goalRoom/useNewTodoFormValidation.ts
@@ -1,0 +1,53 @@
+import { useValidateInput } from '@hooks/_common/useValidateInput';
+import {
+  TODO_CONTENT_MAX_LENGTH,
+  TODO_END_DATE,
+  TODO_START_DATE,
+} from '@constants/goalRoom/regex';
+import { useEffect, useState } from 'react';
+
+const useNewTodoFormValidation = () => {
+  const contentInput = useValidateInput(TODO_CONTENT_MAX_LENGTH);
+  const startDateInput = useValidateInput(TODO_START_DATE);
+  const endDateInput = useValidateInput(TODO_END_DATE);
+
+  const [formState, setFormState] = useState({});
+
+  useEffect(() => {
+    setFormState({
+      content: contentInput.value,
+      startDate: startDateInput.value,
+      endDate: endDateInput.value,
+    });
+  }, [contentInput.value, startDateInput.value, endDateInput.value]);
+
+  const validateForm = () => {
+    let isValid = true;
+
+    if (!startDateInput.value) {
+      startDateInput.setErrorMessage('시작일을 기입해주세요.');
+      isValid = false;
+    }
+
+    if (!endDateInput.value) {
+      endDateInput.setErrorMessage('종료일을 기입해주세요.');
+      isValid = false;
+    }
+
+    if (isValid) {
+      const startDate = new Date(startDateInput.value);
+      const endDate = new Date(endDateInput.value);
+
+      if (startDate >= endDate) {
+        endDateInput.setErrorMessage('종료일이 시작일보다 이전입니다.');
+        isValid = false;
+      }
+    }
+
+    return isValid;
+  };
+
+  return { formState, validateForm, contentInput, startDateInput, endDateInput };
+};
+
+export default useNewTodoFormValidation;

--- a/client/src/hooks/goalRoom/useNewTodoFormValidation.ts
+++ b/client/src/hooks/goalRoom/useNewTodoFormValidation.ts
@@ -5,13 +5,18 @@ import {
   TODO_START_DATE,
 } from '@constants/goalRoom/regex';
 import { useEffect, useState } from 'react';
+import { newTodoPayload } from '@myTypes/goalRoom/remote';
 
 const useNewTodoFormValidation = () => {
   const contentInput = useValidateInput(TODO_CONTENT_MAX_LENGTH);
   const startDateInput = useValidateInput(TODO_START_DATE);
   const endDateInput = useValidateInput(TODO_END_DATE);
 
-  const [formState, setFormState] = useState({});
+  const [formState, setFormState] = useState<Omit<newTodoPayload, 'goalRoomId'>>({
+    content: '',
+    startDate: '',
+    endDate: '',
+  });
 
   useEffect(() => {
     setFormState({

--- a/client/src/hooks/queries/goalRoom.ts
+++ b/client/src/hooks/queries/goalRoom.ts
@@ -1,7 +1,11 @@
-import { CreateGoalRoomRequest } from '@myTypes/goalRoom/remote';
-import { postCreateGoalRoom, getGoalRoomDashboard } from '@apis/goalRoom';
+import { CreateGoalRoomRequest, newTodoPayload } from '@myTypes/goalRoom/remote';
+import {
+  postCreateGoalRoom,
+  getGoalRoomDashboard,
+  postCreateNewTodo,
+} from '@apis/goalRoom';
 import { useSuspendedQuery } from '@hooks/queries/useSuspendedQuery';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useFetchGoalRoom = (goalRoomId: string) => {
   const { data } = useSuspendedQuery(['goalRoom', goalRoomId], () =>
@@ -24,5 +28,23 @@ export const useCreateGoalRoom = () => {
 
   return {
     createGoalRoom: mutate,
+  };
+};
+
+export const useCreateTodo = (goalRoomId: string, funcAfterSuccess: () => void) => {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation(
+    (body: newTodoPayload) => postCreateNewTodo(goalRoomId, body),
+    {
+      onSuccess() {
+        queryClient.invalidateQueries(['goalRoom', goalRoomId]);
+        funcAfterSuccess();
+      },
+    }
+  );
+
+  return {
+    createTodo: mutate,
   };
 };

--- a/client/src/hooks/queries/goalRoom.ts
+++ b/client/src/hooks/queries/goalRoom.ts
@@ -4,6 +4,7 @@ import {
   getGoalRoomDashboard,
   postCreateNewTodo,
   getGoalRoomTodos,
+  postCreateNewCertificationFeed,
 } from '@apis/goalRoom';
 import { useSuspendedQuery } from '@hooks/queries/useSuspendedQuery';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -59,5 +60,22 @@ export const useFetchGoalRoomTodos = (goalRoomId: string) => {
 
   return {
     goalRoomTodos: data,
+  };
+};
+
+export const useCreateCertificationFeed = (goalRoomId: string) => {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation(
+    (formData: FormData) => postCreateNewCertificationFeed(goalRoomId, formData),
+    {
+      onSuccess() {
+        queryClient.invalidateQueries([['goalRoom', goalRoomId]]);
+      },
+    }
+  );
+
+  return {
+    createCertificationFeed: mutate,
   };
 };

--- a/client/src/hooks/queries/goalRoom.ts
+++ b/client/src/hooks/queries/goalRoom.ts
@@ -10,12 +10,12 @@ import { useSuspendedQuery } from '@hooks/queries/useSuspendedQuery';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useFetchGoalRoom = (goalRoomId: string) => {
-  const { data } = useSuspendedQuery(['goalRoom', goalRoomId], () =>
+  const { data: goalRoomRes } = useSuspendedQuery(['goalRoom', goalRoomId], () =>
     getGoalRoomDashboard(goalRoomId)
   );
 
   return {
-    goalRoom: data,
+    goalRoom: goalRoomRes,
   };
 };
 

--- a/client/src/hooks/queries/goalRoom.ts
+++ b/client/src/hooks/queries/goalRoom.ts
@@ -31,7 +31,7 @@ export const useCreateGoalRoom = () => {
   };
 };
 
-export const useCreateTodo = (goalRoomId: string, funcAfterSuccess: () => void) => {
+export const useCreateTodo = (goalRoomId: string) => {
   const queryClient = useQueryClient();
 
   const { mutate } = useMutation(
@@ -39,7 +39,6 @@ export const useCreateTodo = (goalRoomId: string, funcAfterSuccess: () => void) 
     {
       onSuccess() {
         queryClient.invalidateQueries(['goalRoom', goalRoomId]);
-        funcAfterSuccess();
       },
     }
   );

--- a/client/src/hooks/queries/goalRoom.ts
+++ b/client/src/hooks/queries/goalRoom.ts
@@ -3,6 +3,7 @@ import {
   postCreateGoalRoom,
   getGoalRoomDashboard,
   postCreateNewTodo,
+  getGoalRoomTodos,
 } from '@apis/goalRoom';
 import { useSuspendedQuery } from '@hooks/queries/useSuspendedQuery';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -38,12 +39,25 @@ export const useCreateTodo = (goalRoomId: string) => {
     (body: newTodoPayload) => postCreateNewTodo(goalRoomId, body),
     {
       onSuccess() {
-        queryClient.invalidateQueries(['goalRoom', goalRoomId]);
+        queryClient.invalidateQueries([
+          ['goalRoom', goalRoomId],
+          ['goalRoomTodos', goalRoomId],
+        ]);
       },
     }
   );
 
   return {
     createTodo: mutate,
+  };
+};
+
+export const useFetchGoalRoomTodos = (goalRoomId: string) => {
+  const { data } = useSuspendedQuery(['goalRoomTodos', goalRoomId], () =>
+    getGoalRoomTodos(goalRoomId)
+  );
+
+  return {
+    goalRoomTodos: data,
   };
 };

--- a/client/src/mocks/fixtures/goalRoom.ts
+++ b/client/src/mocks/fixtures/goalRoom.ts
@@ -3,6 +3,7 @@ import { GoalRoomBrowseResponse } from '@myTypes/goalRoom/remote';
 type GoalRoomFixture = {
   data: GoalRoomBrowseResponse;
   getBrowsedGoalRoom: () => GoalRoomBrowseResponse;
+  getBrowsedGoalRoomTodos: () => GoalRoomBrowseResponse['goalRoomTodos'];
 };
 
 const fixture: GoalRoomFixture = {
@@ -78,6 +79,10 @@ const fixture: GoalRoomFixture = {
 
   getBrowsedGoalRoom() {
     return JSON.parse(JSON.stringify(this.data));
+  },
+
+  getBrowsedGoalRoomTodos() {
+    return this.data.goalRoomTodos;
   },
 };
 

--- a/client/src/mocks/fixtures/goalRoom.ts
+++ b/client/src/mocks/fixtures/goalRoom.ts
@@ -11,6 +11,7 @@ const fixture: GoalRoomFixture = {
     name: '골룸',
     status: 'RECRUITING',
     currentMemberCount: 10,
+    leaderId: 4,
     initMemberCount: 15,
     startDate: '2023-07-19',
     endDate: '2023-08-05',
@@ -20,12 +21,14 @@ const fixture: GoalRoomFixture = {
       hasBackNode: true,
       nodes: [
         {
+          id: 1,
           title: '로드맵 1주차',
           startDate: '2023-07-19',
           endDate: '2023-07-30',
           checkCount: 10,
         },
         {
+          id: 2,
           title: '로드맵 2주차',
           startDate: '2023-08-01',
           endDate: '2023-08-05',

--- a/client/src/mocks/fixtures/goalRoom.ts
+++ b/client/src/mocks/fixtures/goalRoom.ts
@@ -35,7 +35,19 @@ const fixture: GoalRoomFixture = {
     goalRoomTodos: [
       {
         id: 1,
-        content: '투두 내용',
+        content: '투두 내용 11',
+        startDate: '2023-07-19',
+        endDate: '2023-07-20',
+      },
+      {
+        id: 2,
+        content: '투두 내용 22',
+        startDate: '2023-07-19',
+        endDate: '2023-07-20',
+      },
+      {
+        id: 3,
+        content: '투두 내용 33',
         startDate: '2023-07-19',
         endDate: '2023-07-20',
       },

--- a/client/src/mocks/handlers/goalRoomHander.ts
+++ b/client/src/mocks/handlers/goalRoomHander.ts
@@ -15,6 +15,19 @@ const goalRoomHandler = [
       return res(ctx.status(500));
     }
   }),
+
+  rest.get(`${BASE_URL}/api/goal-rooms/:goalRoomId/todos`, (_, res, ctx) => {
+    try {
+      const goalRoomBrowseResponseData = goalRoom.getBrowsedGoalRoomTodos();
+
+      return res(ctx.status(200), ctx.json({ data: goalRoomBrowseResponseData }));
+    } catch (err) {
+      if (err instanceof Error) {
+        return res(ctx.status(401), ctx.json({ message: '..????' }));
+      }
+      return res(ctx.status(500));
+    }
+  }),
 ];
 
 export default goalRoomHandler;

--- a/client/src/mocks/handlers/goalRoomHander.ts
+++ b/client/src/mocks/handlers/goalRoomHander.ts
@@ -3,7 +3,7 @@ import { BASE_URL } from '@apis/axios/client';
 import goalRoom from '@mocks/fixtures/goalRoom';
 
 const goalRoomHandler = [
-  rest.get(`${BASE_URL}/api/members/goal-rooms/:goalRoomId`, (_, res, ctx) => {
+  rest.get(`${BASE_URL}/members/goal-rooms/:goalRoomId`, (_, res, ctx) => {
     try {
       const goalRoomBrowseResponseData = goalRoom.getBrowsedGoalRoom();
 
@@ -16,7 +16,7 @@ const goalRoomHandler = [
     }
   }),
 
-  rest.get(`${BASE_URL}/api/goal-rooms/:goalRoomId/todos`, (_, res, ctx) => {
+  rest.get(`${BASE_URL}/goal-rooms/:goalRoomId/todos`, (_, res, ctx) => {
     try {
       const goalRoomBrowseResponseData = goalRoom.getBrowsedGoalRoomTodos();
 

--- a/client/src/myTypes/_common/dashboard.ts
+++ b/client/src/myTypes/_common/dashboard.ts
@@ -1,0 +1,3 @@
+export type GoalRoomDashboardContextType = {
+  goalroomId: string;
+};

--- a/client/src/myTypes/goalRoom/internal.ts
+++ b/client/src/myTypes/goalRoom/internal.ts
@@ -11,6 +11,7 @@ export type GoalRoomRoadmap = {
 };
 
 export type GoalRoomNode = {
+  id: number;
   title: string;
   startDate: string;
   endDate: string;

--- a/client/src/myTypes/goalRoom/internal.ts
+++ b/client/src/myTypes/goalRoom/internal.ts
@@ -18,7 +18,7 @@ export type GoalRoomNode = {
 };
 
 export type GoalRoomTodo = {
-  id: number | null;
+  id: number;
   content: string;
   startDate: string;
   endDate: string;

--- a/client/src/myTypes/goalRoom/remote.ts
+++ b/client/src/myTypes/goalRoom/remote.ts
@@ -38,3 +38,5 @@ export type newTodoPayload = {
   startDate: string;
   endDate: string;
 };
+
+export type GoalRoomTodoResponse = GoalRoomTodo[];

--- a/client/src/myTypes/goalRoom/remote.ts
+++ b/client/src/myTypes/goalRoom/remote.ts
@@ -34,7 +34,6 @@ export type CreateGoalRoomRequest = {
 };
 
 export type newTodoPayload = {
-  goalRoomId: string;
   content: string;
   startDate: string;
   endDate: string;

--- a/client/src/myTypes/goalRoom/remote.ts
+++ b/client/src/myTypes/goalRoom/remote.ts
@@ -29,6 +29,13 @@ export type CreateGoalRoomRequest = {
   roadmapContentId: number;
   name: string;
   limitedMemberCount: number;
-  goalRoomTodo: GoalRoomTodo;
+  goalRoomTodo: Omit<GoalRoomTodo, 'id'>;
   goalRoomRoadmapNodeRequests: GoalRoomRoadmapNodeRequestsType[];
+};
+
+export type newTodoPayload = {
+  goalRoomId: string;
+  content: string;
+  startDate: string;
+  endDate: string;
 };

--- a/client/src/myTypes/goalRoom/remote.ts
+++ b/client/src/myTypes/goalRoom/remote.ts
@@ -9,6 +9,7 @@ export type GoalRoomBrowseResponse = {
   name: string;
   status: GoalRoomRecruitmentStatus;
   currentMemberCount: number;
+  leaderId: number;
   initMemberCount: number;
   startDate: string;
   endDate: string;

--- a/client/src/pages/goalRoomDashboardPage/GoalRoomDashboardPage.tsx
+++ b/client/src/pages/goalRoomDashboardPage/GoalRoomDashboardPage.tsx
@@ -1,7 +1,12 @@
 import GoalRoomDashboardContent from '@components/goalRoomDahsboardPage/goalRoomDashboardContent/GoalRoomDashboardContent';
+import GoalRoomDashboardProvider from '@components/_providers/GoalRoomDashboardProvider';
 
 const GoalRoomDashboardPage = () => {
-  return <GoalRoomDashboardContent />;
+  return (
+    <GoalRoomDashboardProvider>
+      <GoalRoomDashboardContent />
+    </GoalRoomDashboardProvider>
+  );
 };
 
 export default GoalRoomDashboardPage;

--- a/client/src/styles/animations.ts
+++ b/client/src/styles/animations.ts
@@ -17,3 +17,8 @@ export const shake = keyframes`
     transform: translate3d(1px, 0, 0) rotate(0.5deg);
   }
 `;
+
+export const spin = keyframes`
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+`;

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -14,6 +14,7 @@ const theme: DefaultTheme = {
     black: '#000',
     white: '#fff',
     red: '#ff0000',
+    backdrop: 'rgba(220, 220, 220, 0.44)'
   },
 
   fonts: {

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -46,6 +46,7 @@ const theme: DefaultTheme = {
     main: 'rgba(0, 0, 0, 0.25) 0px 0px 0.315rem',
     threeD: '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24)',
     threeDHovered: '0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22)',
+    modal: '0px 5px 15px rgba(0, 0, 0, 0.2)',
   },
 };
 

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -14,7 +14,7 @@ const theme: DefaultTheme = {
     black: '#000',
     white: '#fff',
     red: '#ff0000',
-    backdrop: 'rgba(220, 220, 220, 0.44)'
+    backdrop: 'rgba(220, 220, 220, 0.44)',
   },
 
   fonts: {

--- a/client/src/tests/utilTests/removeDashesFromStr.test.ts
+++ b/client/src/tests/utilTests/removeDashesFromStr.test.ts
@@ -1,0 +1,15 @@
+import removeDashesFromStr from '@utils/_common/removeDashesFromStr';
+
+describe('removeDashes function', () => {
+  it('string 으로부터 모든 대시를 삭제한다.', () => {
+    const input = '123-456-7890';
+    const output = removeDashesFromStr(input);
+    expect(output).toBe('1234567890');
+  });
+
+  it('문자열에 대시가 없다면 그대로 반환한다.', () => {
+    const input = '1234567890';
+    const output = removeDashesFromStr(input);
+    expect(output).toBe('1234567890');
+  });
+});

--- a/client/src/utils/_common/removeDashesFromStr.ts
+++ b/client/src/utils/_common/removeDashesFromStr.ts
@@ -1,0 +1,15 @@
+/*
+    문자열의 '-'를 제거하는 함수
+
+    @param str: string
+    @return string
+
+    Example:
+    removeDashesFromStr('hello-world') => 'helloworld'
+ */
+
+const removeDashesFromStr = (str: string): string => {
+  return str.replace(/-/g, '');
+};
+
+export default removeDashesFromStr;


### PR DESCRIPTION
## 📌 작업 이슈 번호

[CK-124](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-124)

## ✨ 작업 내용

- 투두리스트 모달에 전체 투두리스트 데이터 매핑 및 새로운 투두 추가 기능 구현 
- 인증피드 모달에 인증피드 추가 기능 구현 

![image](https://github.com/woowacourse-teams/2023-co-kirikiri/assets/81363031/597a5ef6-f695-4985-856c-baadf9f66cd9)

![image](https://github.com/woowacourse-teams/2023-co-kirikiri/assets/81363031/2b0374c7-c65a-4e08-9fc7-fb5510646069)

- 인증피드는 아직 전체보기 api 가 없기에 생성만 있어서 조금 어색해 보입니다..!

## 💬 리뷰어에게 남길 멘트

- pr을 반으로 나누고 작업했어야 하는데, 시간 관계상 한번에 처리하느라 사이즈가 큽니다 ㅠㅠ 


## 🚀 요구사항 분석

- 투두리스트 모달 구현
  -  투두리스트 추가 기능 구현 

- 인증피드 모달 구현
  -  인증피드 추가 기능 구현 

