### PR TITLE
fix: 시작하지 않은 골룸 페이지 진입 시 인증 피드를 받아오지 못하는 버그 수정 및 사용자 골룸 조회 테스트 복원

### DIFF
--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/ImageDirType.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/ImageDirType.java
@@ -1,9 +1,9 @@
 package co.kirikiri.domain;
 
 public enum ImageDirType {
-    CHECK_FEED("goalroom/checkfeed/"),
-    ROADMAP_NODE("roadmap/"),
-    USER_PROFILE("member/profile/");
+    CHECK_FEED("goalroom/checkfeed"),
+    ROADMAP_NODE("roadmap"),
+    USER_PROFILE("member/profile");
 
     private final String dirName;
 

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/goalroom/GoalRoom.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/goalroom/GoalRoom.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -173,7 +174,7 @@ public class GoalRoom extends BaseUpdatedTimeEntity {
         return goalRoomToDos.findLast();
     }
 
-    public GoalRoomRoadmapNode getNodeByDate(final LocalDate date) {
+    public Optional<GoalRoomRoadmapNode> getNodeByDate(final LocalDate date) {
         return goalRoomRoadmapNodes.getNodeByDate(date);
     }
 

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/goalroom/GoalRoomRoadmapNodes.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/goalroom/GoalRoomRoadmapNodes.java
@@ -12,6 +12,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -71,13 +72,12 @@ public class GoalRoomRoadmapNodes {
         return (int) ChronoUnit.DAYS.between(getGoalRoomStartDate(), getGoalRoomEndDate()) + DATE_OFFSET;
     }
 
-    public GoalRoomRoadmapNode getNodeByDate(final LocalDate date) {
+    public Optional<GoalRoomRoadmapNode> getNodeByDate(final LocalDate date) {
         sortByStartDateAsc(values);
 
         return values.stream()
                 .filter(node -> node.isDayOfNode(date))
-                .findFirst()
-                .orElseThrow(() -> new BadRequestException("인증 피드는 노드 기간 내에만 작성할 수 있습니다."));
+                .findFirst();
     }
 
     public int size() {

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/FilePathRandomGenerator.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/FilePathRandomGenerator.java
@@ -14,7 +14,7 @@ public class FilePathRandomGenerator implements FilePathGenerator {
     public String makeFilePath(final Long id, final ImageDirType dirType) {
         final LocalDate currentDate = LocalDate.now();
         final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(
-                String.format("yyyy%s/MMdd", DIRECTORY_SEPARATOR));
+                String.format("yyyy%sMMdd", DIRECTORY_SEPARATOR));
         final String dateString = currentDate.format(formatter);
 
         return dateString + DIRECTORY_SEPARATOR + dirType.getDirName() + DIRECTORY_SEPARATOR + id

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomCreateService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomCreateService.java
@@ -147,7 +147,7 @@ public class GoalRoomCreateService {
 
         final GoalRoom goalRoom = findGoalRoomById(goalRoomId);
         final GoalRoomMember goalRoomMember = findGoalRoomMemberByGoalRoomAndIdentifier(goalRoom, identifier);
-        final GoalRoomRoadmapNode currentNode = goalRoom.getNodeByDate(LocalDate.now());
+        final GoalRoomRoadmapNode currentNode = getNodeByDate(goalRoom);
         final int currentMemberCheckCount = checkFeedRepository.countByGoalRoomMemberAndGoalRoomRoadmapNode(
                 goalRoomMember, currentNode);
         validateCheckCount(currentMemberCheckCount, goalRoomMember, currentNode);
@@ -181,6 +181,11 @@ public class GoalRoomCreateService {
     private GoalRoomMember findGoalRoomMemberByGoalRoomAndIdentifier(final GoalRoom goalRoom, final String identifier) {
         return goalRoomMemberRepository.findByGoalRoomAndMemberIdentifier(goalRoom, new Identifier(identifier))
                 .orElseThrow(() -> new NotFoundException("골룸에 해당 사용자가 존재하지 않습니다. 사용자 아이디 = " + identifier));
+    }
+
+    private GoalRoomRoadmapNode getNodeByDate(final GoalRoom goalRoom) {
+        return goalRoom.getNodeByDate(LocalDate.now())
+                .orElseThrow(() -> new BadRequestException("인증 피드는 노드 기간 내에만 작성할 수 있습니다."));
     }
 
     private int validateCheckCount(final int memberCheckCount, final GoalRoomMember member,

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomReadService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomReadService.java
@@ -79,7 +79,7 @@ public class GoalRoomReadService {
         final Member member = findMemberByIdentifier(new Identifier(identifier));
         validateMemberInGoalRoom(goalRoom, member);
 
-        final GoalRoomRoadmapNode currentGoalRoomRoadmapNode = goalRoom.getNodeByDate(LocalDate.now());
+        final GoalRoomRoadmapNode currentGoalRoomRoadmapNode = goalRoom.getNodeByDate(LocalDate.now()).get();
         final List<CheckFeed> checkFeeds = checkFeedRepository.findByGoalRoomRoadmapNode(currentGoalRoomRoadmapNode);
 
         return GoalRoomMapper.convertToMemberGoalRoomResponse(goalRoom, checkFeeds);

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
@@ -184,7 +184,8 @@ public class GoalRoomMapper {
 
     private static GoalRoomRoadmapNodesResponse convertToGoalRoomRoadmapNodesResponse(
             final GoalRoomRoadmapNodes nodes) {
-        final GoalRoomRoadmapNode currentNode = nodes.getNodeByDate(LocalDate.now());
+        final GoalRoomRoadmapNode currentNode = nodes.getNodeByDate(LocalDate.now())
+                .orElse(nodes.getNodeByDate(nodes.getGoalRoomStartDate()).get());
         if (!nodes.hasBackNode(currentNode)) {
             return new GoalRoomRoadmapNodesResponse(nodes.hasFrontNode(currentNode), nodes.hasBackNode(currentNode),
                     List.of(new GoalRoomRoadmapNodeResponse(currentNode.getId(),
@@ -192,7 +193,7 @@ public class GoalRoomMapper {
                             currentNode.getStartDate(), currentNode.getEndDate(), currentNode.getCheckCount())));
         }
 
-        final GoalRoomRoadmapNode nextNode = nodes.getNodeByDate(currentNode.getEndDate().plusDays(1));
+        final GoalRoomRoadmapNode nextNode = nodes.getNodeByDate(currentNode.getEndDate().plusDays(1)).get();
         return new GoalRoomRoadmapNodesResponse(nodes.hasFrontNode(currentNode), nodes.hasBackNode(nextNode),
                 List.of(new GoalRoomRoadmapNodeResponse(currentNode.getId(), currentNode.getRoadmapNode().getTitle(),
                                 currentNode.getStartDate(), currentNode.getEndDate(), currentNode.getCheckCount()),

--- a/backend/kirikiri/src/test/java/co/kirikiri/domain/goalroom/GoalRoomRoadmapNodesTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/domain/goalroom/GoalRoomRoadmapNodesTest.java
@@ -115,10 +115,10 @@ class GoalRoomRoadmapNodesTest {
         final GoalRoomRoadmapNodes goalRoomRoadmapNodes = 골룸_노드를_생성한다();
 
         assertAll(
-                () -> assertThat(goalRoomRoadmapNodes.getNodeByDate(TODAY))
+                () -> assertThat(goalRoomRoadmapNodes.getNodeByDate(TODAY).get())
                         .isEqualTo(new GoalRoomRoadmapNode(new Period(TODAY, TEN_DAY_LATER),
                                 10, new RoadmapNode("로드맵 제목 1", "로드맵 내용 1"))),
-                () -> assertThat(goalRoomRoadmapNodes.getNodeByDate(TEN_DAY_LATER))
+                () -> assertThat(goalRoomRoadmapNodes.getNodeByDate(TEN_DAY_LATER).get())
                         .isEqualTo(new GoalRoomRoadmapNode(new Period(TWENTY_DAY_LAYER, THIRTY_DAY_LATER),
                                 10, new RoadmapNode("로드맵 제목 2", "로드맵 내용 2")))
         );

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomReadIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomReadIntegrationTest.java
@@ -26,21 +26,29 @@ import co.kirikiri.domain.roadmap.RoadmapDifficulty;
 import co.kirikiri.domain.roadmap.RoadmapNode;
 import co.kirikiri.domain.roadmap.RoadmapNodes;
 import co.kirikiri.integration.helper.IntegrationTest;
-import co.kirikiri.persistence.goalroom.GoalRoomPendingMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomRepository;
-import co.kirikiri.persistence.member.MemberRepository;
 import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
-import co.kirikiri.persistence.roadmap.RoadmapContentRepository;
 import co.kirikiri.persistence.roadmap.RoadmapNodeRepository;
 import co.kirikiri.persistence.roadmap.RoadmapRepository;
 import co.kirikiri.service.GoalRoomCreateService;
 import co.kirikiri.service.dto.auth.request.LoginRequest;
 import co.kirikiri.service.dto.auth.response.AuthenticationResponse;
+import co.kirikiri.service.dto.goalroom.request.CheckFeedRequest;
+import co.kirikiri.service.dto.goalroom.request.GoalRoomCreateRequest;
+import co.kirikiri.service.dto.goalroom.request.GoalRoomRoadmapNodeRequest;
+import co.kirikiri.service.dto.goalroom.request.GoalRoomTodoRequest;
+import co.kirikiri.service.dto.goalroom.response.CheckFeedResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomCertifiedResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomNodeResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomResponse;
+import co.kirikiri.service.dto.goalroom.response.GoalRoomRoadmapNodeResponse;
+import co.kirikiri.service.dto.goalroom.response.GoalRoomRoadmapNodesResponse;
+import co.kirikiri.service.dto.goalroom.response.GoalRoomTodoResponse;
 import co.kirikiri.service.dto.member.request.GenderType;
 import co.kirikiri.service.dto.member.request.MemberJoinRequest;
+import co.kirikiri.service.dto.member.response.MemberGoalRoomForListResponse;
+import co.kirikiri.service.dto.member.response.MemberGoalRoomResponse;
+import co.kirikiri.service.dto.member.response.MemberResponse;
 import co.kirikiri.service.dto.roadmap.request.RoadmapDifficultyType;
 import co.kirikiri.service.dto.roadmap.request.RoadmapNodeSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
@@ -51,16 +59,24 @@ import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.restassured.common.mapper.TypeRef;
+import io.restassured.http.Header;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.io.File;
+import java.io.IOException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
+import org.apache.tomcat.util.http.fileupload.FileUtils;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 class GoalRoomReadIntegrationTest extends IntegrationTest {
 
@@ -80,31 +96,25 @@ class GoalRoomReadIntegrationTest extends IntegrationTest {
     private static final LocalDate 삼십일_후 = 오늘.plusDays(30);
     private static final int 정상적인_골룸_노드_인증_횟수 = (int) ChronoUnit.DAYS.between(오늘, 십일_후);
 
+    private final String storageLocation;
     private final GoalRoomCreateService goalRoomCreateService;
     private final RoadmapRepository roadmapRepository;
     private final GoalRoomRepository goalRoomRepository;
-    private final GoalRoomPendingMemberRepository goalRoomPendingMemberRepository;
     private final RoadmapCategoryRepository roadmapCategoryRepository;
-    private final RoadmapContentRepository roadmapContentRepository;
     private final RoadmapNodeRepository roadmapNodeRepository;
-    private final MemberRepository memberRepository;
 
-    public GoalRoomReadIntegrationTest(final GoalRoomCreateService goalRoomCreateService,
+    public GoalRoomReadIntegrationTest(@Value("${file.upload-dir}") final String storageLocation,
+                                       final GoalRoomCreateService goalRoomCreateService,
                                        final RoadmapRepository roadmapRepository,
                                        final GoalRoomRepository goalRoomRepository,
-                                       final GoalRoomPendingMemberRepository goalRoomPendingMemberRepository,
                                        final RoadmapCategoryRepository roadmapCategoryRepository,
-                                       final RoadmapContentRepository roadmapContentRepository,
-                                       final RoadmapNodeRepository roadmapNodeRepository,
-                                       final MemberRepository memberRepository) {
+                                       final RoadmapNodeRepository roadmapNodeRepository) {
+        this.storageLocation = storageLocation;
         this.goalRoomCreateService = goalRoomCreateService;
         this.roadmapRepository = roadmapRepository;
         this.goalRoomRepository = goalRoomRepository;
-        this.goalRoomPendingMemberRepository = goalRoomPendingMemberRepository;
         this.roadmapCategoryRepository = roadmapCategoryRepository;
-        this.roadmapContentRepository = roadmapContentRepository;
         this.roadmapNodeRepository = roadmapNodeRepository;
-        this.memberRepository = memberRepository;
     }
 
     @Test
@@ -166,6 +176,261 @@ class GoalRoomReadIntegrationTest extends IntegrationTest {
                 .isEqualTo(예상하는_골룸_응답값);
     }
 
+    @Test
+    void 사용자_단일_골룸을_조회한다() throws IOException {
+        // given
+        회원가입을_한다("identifier", "password1!", "코끼리", "010-1111-2222", GenderType.MALE, LocalDate.of(1999, 9, 9));
+        final String 액세스_토큰 = 로그인을_한다("identifier", "password1!");
+        final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다("여가");
+        final Long 로드맵_아이디 = 로드맵을_생성한다(액세스_토큰, 카테고리.getId(), "로드맵 제목", "로드맵 소개글",
+                "로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")));
+        final RoadmapNode 로드맵_노드 = roadmapNodeRepository.findAll().get(0);
+
+        final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
+        final List<GoalRoomRoadmapNodeRequest> 골룸_노드_별_기간_요청 = List.of(
+                new GoalRoomRoadmapNodeRequest(로드맵_노드.getId(), 정상적인_골룸_노드_인증_횟수, 오늘, 십일_후));
+        final GoalRoomCreateRequest 골룸_생성_요청 = new GoalRoomCreateRequest(로드맵_아이디, 정상적인_골룸_이름, 정상적인_골룸_제한_인원, 골룸_투두_요청,
+                골룸_노드_별_기간_요청);
+        final Long 골룸_아이디 = 골룸을_생성하고_아이디를_알아낸다(골룸_생성_요청, 액세스_토큰);
+
+        회원가입을_한다("identifier2", "password2@", "팔로워", "010-1234-5555", GenderType.FEMALE, LocalDate.of(2000, 1, 1));
+        final String 팔로워_액세스_토큰 = 로그인을_한다("identifier2", "password2@");
+        골룸_참가_요청(골룸_아이디, 팔로워_액세스_토큰);
+        goalRoomCreateService.startGoalRooms();
+
+        final MockMultipartFile 가짜_이미지_객체 = new MockMultipartFile("image", "originalFileName.jpeg",
+                "image/webp", "tempImage".getBytes());
+        final CheckFeedRequest 인증_피드_등록_요청 = new CheckFeedRequest(가짜_이미지_객체, "image description");
+        인증_피드_등록을_요청한다(인증_피드_등록_요청, 액세스_토큰, 골룸_아이디);
+        인증_피드_등록을_요청한다(인증_피드_등록_요청, 팔로워_액세스_토큰, 골룸_아이디);
+
+        // when
+        final ExtractableResponse<Response> 사용자_단일_골룸_조회_응답 = given().log().all()
+                .header(AUTHORIZATION, "Bearer " + 액세스_토큰)
+                .when()
+                .get(API_PREFIX + "/goal-rooms/{goalRoomId}/me", 골룸_아이디)
+                .then()
+                .log().all()
+                .extract();
+
+        // then
+        final MemberGoalRoomResponse 예상되는_응답 = new MemberGoalRoomResponse(정상적인_골룸_이름, "RUNNING", 1L,
+                2, 정상적인_골룸_제한_인원, 오늘, 십일_후, 1L,
+                new GoalRoomRoadmapNodesResponse(false, false,
+                        List.of(new GoalRoomRoadmapNodeResponse(1L, "로드맵 1주차", 오늘, 십일_후, 정상적인_골룸_노드_인증_횟수))),
+                List.of(new GoalRoomTodoResponse(1L, 정상적인_골룸_투두_컨텐츠, 오늘, 십일_후)),
+                List.of(
+                        new CheckFeedResponse(1L, "filePath1", "image description"),
+                        new CheckFeedResponse(2L, "filePath1", "image description")
+                ));
+        final MemberGoalRoomResponse 요청_응답값 = objectMapper.readValue(사용자_단일_골룸_조회_응답.asString(), new TypeReference<>() {
+        });
+
+        assertThat(요청_응답값)
+                .usingRecursiveComparison()
+                .ignoringFields("checkFeeds.imageUrl")
+                .isEqualTo(예상되는_응답);
+    }
+
+    @Test
+    void 골룸_시작_전에_사용자_단일_골룸_조회_시_인증_피드가_빈_응답을_반환한다() throws JsonProcessingException {
+        // given
+        회원가입을_한다("identifier", "password1!", "코끼리", "010-1111-2222", GenderType.MALE, LocalDate.of(1999, 9, 9));
+        final String 액세스_토큰 = 로그인을_한다("identifier", "password1!");
+        final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다("여가");
+        final Long 로드맵_아이디 = 로드맵을_생성한다(액세스_토큰, 카테고리.getId(), "로드맵 제목", "로드맵 소개글",
+                "로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")));
+        final RoadmapNode 로드맵_노드 = roadmapNodeRepository.findAll().get(0);
+
+        final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
+        final List<GoalRoomRoadmapNodeRequest> 골룸_노드_별_기간_요청 = List.of(
+                new GoalRoomRoadmapNodeRequest(로드맵_노드.getId(), 정상적인_골룸_노드_인증_횟수, 오늘, 십일_후));
+        final GoalRoomCreateRequest 골룸_생성_요청 = new GoalRoomCreateRequest(로드맵_아이디, 정상적인_골룸_이름, 정상적인_골룸_제한_인원, 골룸_투두_요청,
+                골룸_노드_별_기간_요청);
+        final Long 골룸_아이디 = 골룸을_생성하고_아이디를_알아낸다(골룸_생성_요청, 액세스_토큰);
+
+        회원가입을_한다("identifier2", "password2@", "팔로워", "010-1234-5555", GenderType.FEMALE, LocalDate.of(2000, 1, 1));
+        final String 팔로워_액세스_토큰 = 로그인을_한다("identifier2", "password2@");
+        골룸_참가_요청(골룸_아이디, 팔로워_액세스_토큰);
+
+        //when
+        final ExtractableResponse<Response> 사용자_단일_골룸_조회_응답 = given().log().all()
+                .header(AUTHORIZATION, "Bearer " + 액세스_토큰)
+                .when()
+                .get(API_PREFIX + "/goal-rooms/{goalRoomId}/me", 골룸_아이디)
+                .then()
+                .log().all()
+                .extract();
+
+        //then
+        final MemberGoalRoomResponse 예상되는_응답 = new MemberGoalRoomResponse(정상적인_골룸_이름, "RECRUITING", 1L,
+                2, 정상적인_골룸_제한_인원, 오늘, 십일_후, 1L,
+                new GoalRoomRoadmapNodesResponse(false, false,
+                        List.of(new GoalRoomRoadmapNodeResponse(1L, "로드맵 1주차", 오늘, 십일_후, 정상적인_골룸_노드_인증_횟수))),
+                List.of(new GoalRoomTodoResponse(1L, 정상적인_골룸_투두_컨텐츠, 오늘, 십일_후)), Collections.emptyList());
+        final MemberGoalRoomResponse 요청_응답값 = objectMapper.readValue(사용자_단일_골룸_조회_응답.asString(), new TypeReference<>() {
+        });
+
+        assertThat(요청_응답값)
+                .usingRecursiveComparison()
+                .ignoringFields("checkFeeds.imageUrl")
+                .isEqualTo(예상되는_응답);
+    }
+
+    @Test
+    void 사용자의_모든_골룸_목록을_조회한다() throws JsonProcessingException {
+        // given
+        회원가입을_한다("identifier", "password1!", "코끼리", "010-1111-2222", GenderType.MALE, LocalDate.of(1999, 9, 9));
+        final String 액세스_토큰 = 로그인을_한다("identifier", "password1!");
+        final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다("여가");
+        final Long 첫번째_로드맵_아이디 = 로드맵을_생성한다(액세스_토큰, 카테고리.getId(), "첫번째_로드맵 제목",
+                "첫번째_로드맵 소개글", "첫번째_로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("첫번째_로드맵 1주차", "첫번째_로드맵 1주차 내용")));
+        final RoadmapNode 첫번째_로드맵_노드 = roadmapNodeRepository.findAll().get(0);
+        final GoalRoomTodoRequest 첫번째_골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
+        final List<GoalRoomRoadmapNodeRequest> 첫번째_골룸_노드_별_기간_요청 = List.of(
+                new GoalRoomRoadmapNodeRequest(첫번째_로드맵_노드.getId(), 정상적인_골룸_노드_인증_횟수, 오늘, 십일_후));
+        final GoalRoomCreateRequest 첫번째_골룸_생성_요청 = new GoalRoomCreateRequest(첫번째_로드맵_아이디, 정상적인_골룸_이름,
+                정상적인_골룸_제한_인원, 첫번째_골룸_투두_요청, 첫번째_골룸_노드_별_기간_요청);
+        final Long 첫번째_골룸_아이디 = 골룸을_생성하고_아이디를_알아낸다(첫번째_골룸_생성_요청, 액세스_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵을_생성한다(액세스_토큰, 카테고리.getId(), "두번째_로드맵 제목",
+                "두번째_로드맵 소개글", "두번째_로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("두번째_로드맵 1주차", "두번째_로드맵 1주차 내용")));
+        final RoadmapNode 두번째_로드맵_노드 = roadmapNodeRepository.findAll().get(1);
+        final GoalRoomTodoRequest 두번째_골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 십일_후, 이십일_후);
+        final List<GoalRoomRoadmapNodeRequest> 두번째_골룸_노드_별_기간_요청 = List.of(
+                new GoalRoomRoadmapNodeRequest(두번째_로드맵_노드.getId(), 정상적인_골룸_노드_인증_횟수, 십일_후, 이십일_후));
+        final GoalRoomCreateRequest 두번째_골룸_생성_요청 = new GoalRoomCreateRequest(두번째_로드맵_아이디, 정상적인_골룸_이름,
+                정상적인_골룸_제한_인원, 두번째_골룸_투두_요청, 두번째_골룸_노드_별_기간_요청);
+        final Long 두번째_골룸_아이디 = 골룸을_생성하고_아이디를_알아낸다(두번째_골룸_생성_요청, 액세스_토큰);
+        goalRoomCreateService.startGoalRooms();
+        // when
+        final ExtractableResponse<Response> 사용자_단일_골룸_조회_응답 = given().log().all()
+                .header(AUTHORIZATION, "Bearer " + 액세스_토큰)
+                .when()
+                .get(API_PREFIX + "/goal-rooms/me")
+                .then()
+                .log().all()
+                .extract();
+        // then
+        final List<MemberGoalRoomForListResponse> 예상되는_응답 = List.of(
+                new MemberGoalRoomForListResponse(첫번째_골룸_아이디, 정상적인_골룸_이름, "RUNNING",
+                        1, 정상적인_골룸_제한_인원, LocalDateTime.now(), 오늘, 십일_후,
+                        new MemberResponse(1L, "코끼리")),
+                new MemberGoalRoomForListResponse(두번째_골룸_아이디, 정상적인_골룸_이름, "RECRUITING",
+                        1, 정상적인_골룸_제한_인원, LocalDateTime.now(), 십일_후, 이십일_후,
+                        new MemberResponse(1L, "코끼리")));
+        final List<MemberGoalRoomForListResponse> 요청_응답값 = objectMapper.readValue(사용자_단일_골룸_조회_응답.asString(),
+                new TypeReference<>() {
+                });
+        assertThat(요청_응답값)
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt")
+                .isEqualTo(예상되는_응답);
+    }
+
+    @Test
+    void 사용자가_참여한_골룸_중_모집_중인_골룸_목록을_조회한다() throws JsonProcessingException {
+        // given
+        회원가입을_한다("identifier", "password1!", "코끼리", "010-1111-2222", GenderType.MALE, LocalDate.of(1999, 9, 9));
+        final String 액세스_토큰 = 로그인을_한다("identifier", "password1!");
+        final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다("여가");
+        final Long 첫번째_로드맵_아이디 = 로드맵을_생성한다(액세스_토큰, 카테고리.getId(), "첫번째_로드맵 제목",
+                "첫번째_로드맵 소개글", "첫번째_로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("첫번째_로드맵 1주차", "첫번째_로드맵 1주차 내용")));
+        final RoadmapNode 첫번째_로드맵_노드 = roadmapNodeRepository.findAll().get(0);
+        final GoalRoomTodoRequest 첫번째_골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
+        final List<GoalRoomRoadmapNodeRequest> 첫번째_골룸_노드_별_기간_요청 = List.of(
+                new GoalRoomRoadmapNodeRequest(첫번째_로드맵_노드.getId(), 정상적인_골룸_노드_인증_횟수, 오늘, 십일_후));
+        final GoalRoomCreateRequest 첫번째_골룸_생성_요청 = new GoalRoomCreateRequest(첫번째_로드맵_아이디, 정상적인_골룸_이름,
+                정상적인_골룸_제한_인원, 첫번째_골룸_투두_요청, 첫번째_골룸_노드_별_기간_요청);
+        final Long 첫번째_골룸_아이디 = 골룸을_생성하고_아이디를_알아낸다(첫번째_골룸_생성_요청, 액세스_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵을_생성한다(액세스_토큰, 카테고리.getId(), "두번째_로드맵 제목",
+                "두번째_로드맵 소개글", "두번째_로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("두번째_로드맵 1주차", "두번째_로드맵 1주차 내용")));
+        final RoadmapNode 두번째_로드맵_노드 = roadmapNodeRepository.findAll().get(1);
+        final GoalRoomTodoRequest 두번째_골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 십일_후, 이십일_후);
+        final List<GoalRoomRoadmapNodeRequest> 두번째_골룸_노드_별_기간_요청 = List.of(
+                new GoalRoomRoadmapNodeRequest(두번째_로드맵_노드.getId(), 정상적인_골룸_노드_인증_횟수, 십일_후, 이십일_후));
+        final GoalRoomCreateRequest 두번째_골룸_생성_요청 = new GoalRoomCreateRequest(두번째_로드맵_아이디, 정상적인_골룸_이름,
+                정상적인_골룸_제한_인원, 두번째_골룸_투두_요청, 두번째_골룸_노드_별_기간_요청);
+        final Long 두번째_골룸_아이디 = 골룸을_생성하고_아이디를_알아낸다(두번째_골룸_생성_요청, 액세스_토큰);
+        goalRoomCreateService.startGoalRooms();
+        // when
+        final ExtractableResponse<Response> 사용자_단일_골룸_조회_응답 = given().log().all()
+                .header(AUTHORIZATION, "Bearer " + 액세스_토큰)
+                .queryParam("statusCond", "RECRUITING")
+                .when()
+                .get(API_PREFIX + "/goal-rooms/me")
+                .then()
+                .log().all()
+                .extract();
+        // then
+        final List<MemberGoalRoomForListResponse> 예상되는_응답 = List.of(
+                new MemberGoalRoomForListResponse(두번째_골룸_아이디, 정상적인_골룸_이름, "RECRUITING",
+                        1, 정상적인_골룸_제한_인원, LocalDateTime.now(), 십일_후, 이십일_후,
+                        new MemberResponse(1L, "코끼리")));
+        final List<MemberGoalRoomForListResponse> 요청_응답값 = objectMapper.readValue(사용자_단일_골룸_조회_응답.asString(),
+                new TypeReference<>() {
+                });
+        assertThat(요청_응답값)
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt")
+                .isEqualTo(예상되는_응답);
+    }
+
+    @Test
+    void 사용자가_참여한_골룸_중_진행_중인_골룸_목록을_조회한다() throws JsonProcessingException {
+        // given
+        회원가입을_한다("identifier", "password1!", "코끼리", "010-1111-2222", GenderType.MALE, LocalDate.of(1999, 9, 9));
+        final String 액세스_토큰 = 로그인을_한다("identifier", "password1!");
+        final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다("여가");
+        final Long 첫번째_로드맵_아이디 = 로드맵을_생성한다(액세스_토큰, 카테고리.getId(), "첫번째_로드맵 제목",
+                "첫번째_로드맵 소개글", "첫번째_로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("첫번째_로드맵 1주차", "첫번째_로드맵 1주차 내용")));
+        final RoadmapNode 첫번째_로드맵_노드 = roadmapNodeRepository.findAll().get(0);
+        final GoalRoomTodoRequest 첫번째_골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
+        final List<GoalRoomRoadmapNodeRequest> 첫번째_골룸_노드_별_기간_요청 = List.of(
+                new GoalRoomRoadmapNodeRequest(첫번째_로드맵_노드.getId(), 정상적인_골룸_노드_인증_횟수, 오늘, 십일_후));
+        final GoalRoomCreateRequest 첫번째_골룸_생성_요청 = new GoalRoomCreateRequest(첫번째_로드맵_아이디, 정상적인_골룸_이름,
+                정상적인_골룸_제한_인원, 첫번째_골룸_투두_요청, 첫번째_골룸_노드_별_기간_요청);
+        final Long 첫번째_골룸_아이디 = 골룸을_생성하고_아이디를_알아낸다(첫번째_골룸_생성_요청, 액세스_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵을_생성한다(액세스_토큰, 카테고리.getId(), "두번째_로드맵 제목",
+                "두번째_로드맵 소개글", "두번째_로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("두번째_로드맵 1주차", "두번째_로드맵 1주차 내용")));
+        final RoadmapNode 두번째_로드맵_노드 = roadmapNodeRepository.findAll().get(1);
+        final GoalRoomTodoRequest 두번째_골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 십일_후, 이십일_후);
+        final List<GoalRoomRoadmapNodeRequest> 두번째_골룸_노드_별_기간_요청 = List.of(
+                new GoalRoomRoadmapNodeRequest(두번째_로드맵_노드.getId(), 정상적인_골룸_노드_인증_횟수, 십일_후, 이십일_후));
+        final GoalRoomCreateRequest 두번째_골룸_생성_요청 = new GoalRoomCreateRequest(두번째_로드맵_아이디, 정상적인_골룸_이름,
+                정상적인_골룸_제한_인원, 두번째_골룸_투두_요청, 두번째_골룸_노드_별_기간_요청);
+        final Long 두번째_골룸_아이디 = 골룸을_생성하고_아이디를_알아낸다(두번째_골룸_생성_요청, 액세스_토큰);
+        goalRoomCreateService.startGoalRooms();
+        // when
+        final ExtractableResponse<Response> 사용자_단일_골룸_조회_응답 = given().log().all()
+                .header(AUTHORIZATION, "Bearer " + 액세스_토큰)
+                .queryParam("statusCond", "RUNNING")
+                .when()
+                .get(API_PREFIX + "/goal-rooms/me")
+                .then()
+                .log().all()
+                .extract();
+        // then
+        final List<MemberGoalRoomForListResponse> 예상되는_응답 = List.of(
+                new MemberGoalRoomForListResponse(첫번째_골룸_아이디, 정상적인_골룸_이름, "RUNNING",
+                        1, 정상적인_골룸_제한_인원, LocalDateTime.now(), 오늘, 십일_후,
+                        new MemberResponse(1L, "코끼리")));
+        final List<MemberGoalRoomForListResponse> 요청_응답값 = objectMapper.readValue(사용자_단일_골룸_조회_응답.asString(),
+                new TypeReference<>() {
+                });
+        assertThat(요청_응답값)
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt")
+                .isEqualTo(예상되는_응답);
+    }
+
     private Member 크리에이터를_저장한다() {
         final String 닉네임 = "코끼리";
         final String 전화번호 = "010-1234-5678";
@@ -205,6 +470,58 @@ class GoalRoomReadIntegrationTest extends IntegrationTest {
                 });
 
         return String.format(BEARER_TOKEN_FORMAT, 토큰_응답.accessToken());
+    }
+
+    private void 회원가입을_한다(final String 아이디, final String 비밀번호, final String 닉네임, final String 전화번호, final GenderType 성별,
+                          final LocalDate 생년월일) {
+        final MemberJoinRequest 회원가입_요청값 = new MemberJoinRequest(아이디, 비밀번호, 닉네임, 전화번호, 성별, 생년월일);
+        회원가입_요청(회원가입_요청값);
+    }
+
+    private ExtractableResponse<Response> 회원가입_요청(final MemberJoinRequest 회원가입_요청값) {
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .body(회원가입_요청값)
+                .post(API_PREFIX + "/members/join")
+                .then().log().all()
+                .extract();
+    }
+
+    private String 로그인을_한다(final String 아이디, final String 비밀번호) throws JsonProcessingException {
+        final LoginRequest 로그인_요청값 = new LoginRequest(아이디, 비밀번호);
+        final ExtractableResponse<Response> 로그인_응답값 = 로그인_요청(로그인_요청값);
+        return access_token을_받는다(로그인_응답값);
+    }
+
+    private ExtractableResponse<Response> 로그인_요청(final LoginRequest 로그인_요청값) {
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .body(로그인_요청값)
+                .post(API_PREFIX + "/auth/login")
+                .then().log().all()
+                .extract();
+    }
+
+    private String access_token을_받는다(final ExtractableResponse<Response> 로그인_응답) throws JsonProcessingException {
+        final AuthenticationResponse 토큰_응답값 = jsonToClass(로그인_응답.body().asString(), new TypeReference<>() {
+        });
+        return 토큰_응답값.accessToken();
+    }
+
+    private Long 로드맵을_생성한다(final String 토큰, final Long 카테고리_아이디, final String 로드맵_제목, final String 로드맵_소개글,
+                           final String 로드맵_본문,
+                           final RoadmapDifficultyType 난이도, final int 추천_소요_기간,
+                           final List<RoadmapNodeSaveRequest> 로드맵_노드들) {
+        final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리_아이디, 로드맵_제목, 로드맵_소개글, 로드맵_본문,
+                난이도, 추천_소요_기간, 로드맵_노드들, List.of(new RoadmapTagSaveRequest("태그")));
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 토큰);
+        return 로드맵_아이디를_반환한다(로드맵_생성_응답값);
+    }
+
+    private Long 로드맵_아이디를_반환한다(final ExtractableResponse<Response> 응답) {
+        return Long.parseLong(응답.header(HttpHeaders.LOCATION).split("/")[3]);
     }
 
     private RoadmapCategory 로드맵_카테고리를_저장한다(final String 카테고리_이름) {
@@ -303,32 +620,6 @@ class GoalRoomReadIntegrationTest extends IntegrationTest {
         return new GoalRoomCertifiedResponse("골룸", 1, 10, goalRoomNodeResponses, 31, true);
     }
 
-    private ExtractableResponse<Response> 회원가입_요청(final MemberJoinRequest 회원가입_요청값) {
-        return given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .body(회원가입_요청값)
-                .post(API_PREFIX + "/members/join")
-                .then().log().all()
-                .extract();
-    }
-
-    private ExtractableResponse<Response> 로그인_요청(final LoginRequest 로그인_요청값) {
-        return given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .body(로그인_요청값)
-                .post(API_PREFIX + "/auth/login")
-                .then().log().all()
-                .extract();
-    }
-
-    private String access_token을_받는다(final ExtractableResponse<Response> 로그인_응답) throws JsonProcessingException {
-        final AuthenticationResponse 토큰_응답값 = jsonToClass(로그인_응답.body().asString(), new TypeReference<>() {
-        });
-        return 토큰_응답값.accessToken();
-    }
-
     private ExtractableResponse<Response> 로드맵_생성_요청(final RoadmapSaveRequest 로드맵_생성_요청값, final String accessToken) {
         return given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
@@ -339,15 +630,66 @@ class GoalRoomReadIntegrationTest extends IntegrationTest {
                 .extract();
     }
 
-    private void 테스트용으로_생성된_파일을_제거한다(final String filePath) {
-        final File file = new File(filePath);
+    private Long 골룸을_생성하고_아이디를_알아낸다(final GoalRoomCreateRequest 골룸_생성_요청, final String 액세스_토큰) {
+        final ExtractableResponse<Response> 골룸_응답 = 골룸_생성(골룸_생성_요청, 액세스_토큰);
+        final String Location_헤더 = 골룸_응답.response().header("Location");
+        final Long 골룸_id = Long.parseLong(Location_헤더.substring(16));
+        return 골룸_id;
+    }
 
-        if (!file.exists() || !file.isFile()) {
-            throw new IllegalArgumentException("Invalid file path: " + filePath);
-        }
+    private ExtractableResponse<Response> 골룸_생성(final GoalRoomCreateRequest 골룸_생성_요청, final String 액세스_토큰) {
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .body(골룸_생성_요청)
+                .header(new Header(HttpHeaders.AUTHORIZATION, "Bearer " + 액세스_토큰))
+                .post(API_PREFIX + "/goal-rooms")
+                .then()
+                .log().all()
+                .extract();
+    }
 
-        if (!file.delete()) {
-            throw new RuntimeException("Failed to delete the file: " + filePath);
+    private ExtractableResponse<Response> 골룸_참가_요청(final Long 골룸_아이디, final String 팔로워_액세스_토큰) {
+        return given()
+                .log().all()
+                .header(AUTHORIZATION, "Bearer " + 팔로워_액세스_토큰)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .post(API_PREFIX + "/goal-rooms/{goalRoomId}/join", 골룸_아이디)
+                .then()
+                .log().all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> 인증_피드_등록을_요청한다(final CheckFeedRequest 인증_피드_등록_요청,
+                                                         final String 액세스_토큰, final Long 골룸_id) throws IOException {
+        final MultipartFile 가짜_이미지_객체 = 인증_피드_등록_요청.image();
+
+        final ExtractableResponse<Response> 인증_피드_등록_응답 = given().log().all()
+                .multiPart(가짜_이미지_객체.getName(), 가짜_이미지_객체.getOriginalFilename(),
+                        가짜_이미지_객체.getBytes(), 가짜_이미지_객체.getContentType())
+                .formParam("description", 인증_피드_등록_요청.description())
+                .header(AUTHORIZATION, "Bearer " + 액세스_토큰)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                .when()
+                .post(API_PREFIX + "/goal-rooms/{goalRoomId}/checkFeeds", 골룸_id)
+                .then()
+                .log().all()
+                .extract();
+
+        인증_피드_등록_응답.response().header("Location");
+        테스트용으로_생성된_파일을_제거한다();
+
+        return 인증_피드_등록_응답;
+    }
+
+    private void 테스트용으로_생성된_파일을_제거한다() {
+        final String rootPath = storageLocation;
+
+        try {
+            final File rootDir = new File(rootPath);
+            FileUtils.deleteDirectory(rootDir);
+        } catch (final IOException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/CheckFeedRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/CheckFeedRepositoryTest.java
@@ -218,6 +218,16 @@ class CheckFeedRepositoryTest {
         );
     }
 
+    @Test
+    void 골룸_노드값으로_null이_들어오면_빈_리스트를_반환한다() {
+        //given
+        //when
+        final List<CheckFeed> checkFeeds = checkFeedRepository.findByGoalRoomRoadmapNode(null);
+
+        //then
+        assertThat(checkFeeds).isEmpty();
+    }
+
     private Member 사용자를_저장한다(final String identifier, final String nickname) {
         final MemberProfile memberProfile = new MemberProfile(Gender.MALE,
                 LocalDate.of(1990, 1, 1), "010-1234-5678");


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-133](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-133)


## ✨ 작업 내용
- 참가한 골룸이 시작하지 않았을 때 사용자 골룸 단일 조회 시 인증 피드를 받아오지 못해 발생한 버그 해결
- `GoalRoomReadIntegrationTest`에서 사용자 골룸 단일/목록 조회 테스트 누락 복원


## 💬 리뷰어에게 남길 멘트
- 인증 피드 추가 메서드와 `getGoalRoomNodeByDate`를 공유해서 생긴 버그. 예외 처리를 도메인에서 하는 것이 아닌 Optional로 포장해서 서비스까지 넘긴 뒤에 메서드에서 처리했습니다.
- 일단 먼저 죄송합니다. 버그 수정 작업 중 찾았는데 사용자 골룸 단일/목록 조회 기능을 merge conflict 하면서 통합 테스트에서 누락한 걸 발견했습니다. 😱 아마 UI 창에서 하다 merge theirs와 같은 버튼을 눌렀던 것이 아닐까 생각합니다. 다른 테스트 부분들도 호다닥 살펴봤지만 엄청나게 삭제가 된 부분은 다행이 없었습니다. 다음부턴 더 주의하도록 하겠습니다. 😥😥 해당 부분은 [여기](https://github.com/woowacourse-teams/2023-co-kirikiri/pull/48/commits/26d7c7292aa66fc6cbacbd4cbb477bfb353c392b#diff-d98c5c388149e521b53d6afbcff72182af8ab83cb057fdd08503532a3a31d562)서 확인하실 수 있습니다.


## 🚀 요구사항 분석
- 사용자가 참가한 골룸이 시작하기 전이라도 단일 페이지를 조회할 수 있도록 수정한다

