### PR TITLE
[feat/CK-132] 각종 통신 에러 해결 및 투두리스트 변경점 대응 및 웹 접근성 향상

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,43 +15,51 @@ import RoadmapCreatePage from './pages/roadmapCreatePage/RoadmapCreatePage';
 import ToastProvider from '@components/_common/toastProvider/ToastProvider';
 import GoalRoomListPage from './pages/goalRoomListPage/GoalRoomListPage';
 import GoalRoomCreatePage from './pages/goalRoomCreatePage/GoalRoomCreatePage';
+import UserInfoProvider from '@components/_providers/UserInfoProvider';
+import MyPage from '@pages/myPage/MyPage';
 
 const App = () => {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <ToastProvider>
-        <BrowserRouter>
-          <ResponsiveContainer>
-            <PageLayout>
-            <Routes>
-              <Route path='/' element={<RoadmapListPage />} />
-              <Route path='/login' element={<LoginPage />} />
-              <Route path='/join' element={<SignUpPage />} />
-              <Route path='/roadmap-list' element={<RoadmapListPage />} />
-              <Route
-                path='/roadmap/:id'
-                element={
-                  <Suspense fallback={<Fallback />}>
-                    <RoadmapDetailPage />
-                  </Suspense>
-                }
-              />
-              <Route path='/roadmap/:id/goalroom-list' element={<GoalRoomListPage />} />
-              <Route path='/roadmap-create' element={<RoadmapCreatePage />} />
-              <Route
-                path='/roadmap/:id/goalroom-create'
-                element={<GoalRoomCreatePage />}
-              />
-              <Route
-                path='/goalroom-dashboard/:goalroomId'
-                element={<GoalRoomDashboardPage />}
-              />
-            </Routes>
-            </PageLayout>
-          </ResponsiveContainer>
-        </BrowserRouter>
-      </ToastProvider>
+      <UserInfoProvider>
+        <ToastProvider>
+          <BrowserRouter>
+            <ResponsiveContainer>
+              <PageLayout>
+                <Routes>
+                  <Route path='/' element={<RoadmapListPage />} />
+                  <Route path='/login' element={<LoginPage />} />
+                  <Route path='/join' element={<SignUpPage />} />
+                  <Route path='/roadmap-list' element={<RoadmapListPage />} />
+                  <Route
+                    path='/roadmap/:id'
+                    element={
+                      <Suspense fallback={<Fallback />}>
+                        <RoadmapDetailPage />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path='/roadmap/:id/goalroom-list'
+                    element={<GoalRoomListPage />}
+                  />
+                  <Route path='/roadmap-create' element={<RoadmapCreatePage />} />
+                  <Route
+                    path='/roadmap/:id/goalroom-create'
+                    element={<GoalRoomCreatePage />}
+                  />
+                  <Route
+                    path='/goalroom-dashboard/:goalroomId'
+                    element={<GoalRoomDashboardPage />}
+                  />
+                  <Route path='/myPage' element={<MyPage />} />
+                </Routes>
+              </PageLayout>
+            </ResponsiveContainer>
+          </BrowserRouter>
+        </ToastProvider>
+      </UserInfoProvider>
     </ThemeProvider>
   );
 };

--- a/client/src/apis/goalRoom.ts
+++ b/client/src/apis/goalRoom.ts
@@ -5,6 +5,7 @@ import {
   GoalRoomDetailResponse,
   GoalRoomTodoResponse,
   newTodoPayload,
+  GoalRoomTodoChangeStatusRequest,
 } from '@/myTypes/goalRoom/remote';
 import client from '@apis/axios/client';
 
@@ -39,6 +40,13 @@ export const getGoalRoomTodos = async (goalRoomId: string) => {
   );
 
   return data;
+};
+
+export const postToChangeTodoCheckStatus = async ({
+  goalRoomId,
+  todoId,
+}: GoalRoomTodoChangeStatusRequest) => {
+  return client.post(`/goal-rooms/${goalRoomId}/todos/${todoId}`);
 };
 
 export const postCreateNewTodo = (goalRoomId: string, body: newTodoPayload) => {

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -4,6 +4,7 @@ import type {
   UserLoginRequest,
   UserLoginResponse,
 } from '@myTypes/user/remote';
+import { UserInfoResponse } from '@myTypes/user/remote';
 
 export const signUp = (body: MemberJoinRequest) => {
   return client.post('/members/join', body);
@@ -11,4 +12,8 @@ export const signUp = (body: MemberJoinRequest) => {
 
 export const login = (body: UserLoginRequest) => {
   return client.post<UserLoginResponse>('/auth/login', body);
+};
+
+export const getUserInfo = () => {
+  return client.get<UserInfoResponse>('/members/me');
 };

--- a/client/src/components/_common/navBar/NavBar.styles.ts
+++ b/client/src/components/_common/navBar/NavBar.styles.ts
@@ -54,8 +54,15 @@ export const Item = styled(NavLink)`
 
 export const ItemIcon = styled.span`
   display: inline-block;
-  width: 1rem;
+  width: 2rem;
   margin-right: 0.5rem;
+`;
+
+export const UserProfileImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  box-shadow: ${({ theme }) => theme.shadows.threeD};
 `;
 
 export const Text = styled.span`

--- a/client/src/components/_common/navBar/NavBar.tsx
+++ b/client/src/components/_common/navBar/NavBar.tsx
@@ -1,11 +1,18 @@
 import SVGIcon from '@components/icons/SVGIcon';
 import * as S from './NavBar.styles';
+import { useUserInfoContext } from '@components/_providers/UserInfoProvider';
+import useValidationCheck from '@hooks/user/useValidationCheck';
+import isValidUserInfo from '@utils/user/isValidUserInfo';
+import { BASE_URL } from '@apis/axios/client';
 
 type NavBarProps = {
   isSwitchOn: boolean;
 };
 
 const NavBar = ({ isSwitchOn }: NavBarProps) => {
+  useValidationCheck();
+  const { userInfo } = useUserInfoContext();
+
   return (
     <S.NavBar isNavBarOpen={isSwitchOn}>
       <S.Nav>
@@ -28,14 +35,26 @@ const NavBar = ({ isSwitchOn }: NavBarProps) => {
             <S.Text>골룸</S.Text>
           </S.Item>
         </S.Links>
-        <S.Links>
-          <S.Item to='/login'>
-            <S.ItemIcon>
-              <SVGIcon name='LoginIcon' />
-            </S.ItemIcon>
-            <S.Text>로그인</S.Text>
-          </S.Item>
-        </S.Links>
+
+        {isValidUserInfo(userInfo) ? (
+          <S.Links>
+            <S.Item to='/myPage'>
+              <S.ItemIcon>
+                <S.UserProfileImage src={BASE_URL + userInfo.profileImageUrl} alt='' />
+              </S.ItemIcon>
+              <S.Text>{userInfo.nickname}</S.Text>
+            </S.Item>
+          </S.Links>
+        ) : (
+          <S.Links>
+            <S.Item to='/login'>
+              <S.ItemIcon>
+                <SVGIcon name='LoginIcon' />
+              </S.ItemIcon>
+              <S.Text>로그인</S.Text>
+            </S.Item>
+          </S.Links>
+        )}
       </S.Nav>
     </S.NavBar>
   );

--- a/client/src/components/_common/roadmapItem/RoadmapItem.tsx
+++ b/client/src/components/_common/roadmapItem/RoadmapItem.tsx
@@ -13,35 +13,51 @@ type RoadmapItemProps = {
 };
 
 const RoadmapItem = ({ item, hasBorder = true }: RoadmapItemProps) => {
-  const categoryIcon = <SVGIcon name={CategoriesInfo[item.category.id].iconName} />;
+  const categoryIcon = (
+    <div aria-label={CategoriesInfo[item.category.id].name}>
+      <SVGIcon name={CategoriesInfo[item.category.id].iconName} aria-hidden='true' />
+    </div>
+  );
   const difficultyIcon = (
-    <SVGIcon name={DIFFICULTY_ICON_NAME[item.difficulty]} size={50} />
+    <div aria-label={DIFFICULTY_ICON_NAME[item.difficulty]}>
+      <SVGIcon
+        name={DIFFICULTY_ICON_NAME[item.difficulty]}
+        size={50}
+        aria-hidden='true'
+      />
+    </div>
   );
 
   return (
-    <S.RoadmapItem hasBorder={hasBorder}>
+    <S.RoadmapItem hasBorder={hasBorder} aria-label='로드맵 항목'>
       <S.ItemHeader>
-        <S.AchieversCount>지금까지 1024명이 목표를 달성했어요!</S.AchieversCount>
-        <S.ReviewersCount>❤️ 240</S.ReviewersCount>
+        <S.AchieversCount aria-label='목표 달성률'>
+          지금까지 1024명이 목표를 달성했어요!
+        </S.AchieversCount>
+        <S.ReviewersCount aria-label='로드맵 좋아요 개수'>❤️ 240</S.ReviewersCount>
       </S.ItemHeader>
       <div>
-        <S.RoadmapTitle>{item.roadmapTitle}</S.RoadmapTitle>
-        <S.Description>{item.introduction}</S.Description>
+        <S.RoadmapTitle aria-label='로드맵 제목'>{item.roadmapTitle}</S.RoadmapTitle>
+        <S.Description aria-label='로드맵 소개'>{item.introduction}</S.Description>
       </div>
-      <S.ItemExtraInfos>
-        <S.ExtraInfoBox>{categoryIcon}</S.ExtraInfoBox>
-        <S.Difficulty>{difficultyIcon}</S.Difficulty>
-        <S.RecommendedRoadmapPeriod>
+      <S.ItemExtraInfos aria-label='로드맵 속성'>
+        <S.ExtraInfoBox aria-label='로드맵 카테고리 분류'>{categoryIcon}</S.ExtraInfoBox>
+        <S.Difficulty aria-label='로드맵 난이도'>{difficultyIcon}</S.Difficulty>
+        <S.RecommendedRoadmapPeriod aria-label='로드맵 진행 기간'>
           <div>{item.recommendedRoadmapPeriod}</div>
-          <div>Days</div>
+          <div aria-label='일'>Days</div>
         </S.RecommendedRoadmapPeriod>
       </S.ItemExtraInfos>
       <Link to={`/roadmap/${item.roadmapId}`}>
-        <Button>{hasBorder ? '자세히 보기' : '진행중인 골룸 보기'}</Button>
+        <Button aria-label={hasBorder ? '자세히 보기' : '진행중인 골룸 보기'}>
+          {hasBorder ? '자세히 보기' : '진행중인 골룸 보기'}
+        </Button>
       </Link>
-      <S.ItemFooter>
-        <S.CreatedBy>Created by {item.creator.name}</S.CreatedBy>
-        <S.Tags>
+      <S.ItemFooter aria-label='로드맵 추가 정보'>
+        <S.CreatedBy aria-label='로드맵 생성자'>
+          Created by {item.creator.name}
+        </S.CreatedBy>
+        <S.Tags aria-label='로드맵 태그 목록'>
           <span># Programming</span>
           <span># Study</span>
         </S.Tags>

--- a/client/src/components/_common/toastProvider/ToastProvider.tsx
+++ b/client/src/components/_common/toastProvider/ToastProvider.tsx
@@ -43,7 +43,7 @@ const ToastProvider = (props: PropsWithChildren) => {
 
       timeout.current = setTimeout(() => {
         setMessage((prev) => ({ ...prev, isShow: false }));
-      }, 1500);
+      }, 2000);
 
       return;
     }

--- a/client/src/components/_providers/UserInfoProvider.tsx
+++ b/client/src/components/_providers/UserInfoProvider.tsx
@@ -1,0 +1,32 @@
+import { createContext, PropsWithChildren, useContext, useState } from 'react';
+import { UserInfoResponse } from '@myTypes/user/remote';
+import { UserInfoContextType } from '@myTypes/_common/user';
+
+export const defaultUserInfo: UserInfoResponse = {
+  id: null,
+  nickname: '',
+  profileImageUrl: '',
+  gender: null,
+  identifier: '',
+  phoneNumber: '',
+  birthday: '',
+};
+
+export const userInfoContext = createContext<UserInfoContextType>({
+  userInfo: defaultUserInfo,
+  setUserInfo: () => {},
+});
+
+const UserInfoProvider = ({ children }: PropsWithChildren) => {
+  const [userInfo, setUserInfo] = useState<UserInfoResponse>(defaultUserInfo);
+
+  return (
+    <userInfoContext.Provider value={{ userInfo, setUserInfo }}>
+      {children}
+    </userInfoContext.Provider>
+  );
+};
+
+export const useUserInfoContext = () => useContext(userInfoContext);
+
+export default UserInfoProvider;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/singleTodo/SingleTodo.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/singleTodo/SingleTodo.tsx
@@ -2,20 +2,27 @@ import SVGIcon from '@components/icons/SVGIcon';
 import { GoalRoomTodo } from '@myTypes/goalRoom/internal';
 import * as S from './SingleTodo.styles';
 import useHover from '@hooks/_common/useHover';
-
-/*
-    TODO:
-     1. 투두리스트 생성 모달 구현
-     2. 투두리스트 실제 눌렀을 때 체크되는 기능 구현
-*/
+import { usePostChangeTodoCheckStatus } from '@hooks/queries/goalRoom';
+import useValidParams from '@hooks/_common/useValidParams';
+import { GoalRoomDashboardContentParams } from '@components/goalRoomDahsboardPage/goalRoomDashboardContent/GoalRoomDashboardContent';
 
 type SingleTodoProps = {
   todoContent: GoalRoomTodo;
 };
 
 const SingleTodo = ({ todoContent }: SingleTodoProps) => {
-  const { content, startDate, endDate } = todoContent;
+  const { goalroomId } = useValidParams<GoalRoomDashboardContentParams>();
+
+  const { content, startDate, endDate, check } = todoContent;
   const { isHovered, handleMouseEnter, handleMouseLeave } = useHover();
+  const { changeTodoCheckStatus } = usePostChangeTodoCheckStatus({
+    goalRoomId: goalroomId,
+    todoId: String(todoContent.id),
+  });
+
+  const handleTodoCheckButtonClick = () => {
+    changeTodoCheckStatus();
+  };
 
   return (
     <S.Todo>
@@ -23,8 +30,9 @@ const SingleTodo = ({ todoContent }: SingleTodoProps) => {
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         aria-label='hidden'
+        onClick={handleTodoCheckButtonClick}
       >
-        <SVGIcon name={isHovered ? 'CheckedCircle' : 'EmptyCircle'} />
+        <SVGIcon name={check.isChecked || isHovered ? 'CheckedCircle' : 'EmptyCircle'} />
       </S.TodoButton>
       <S.TodoContent>{content}</S.TodoContent>
       <S.TodoDate>

--- a/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
@@ -8,12 +8,12 @@ const GoalRoomList = () => {
   const { goalRoomList } = useGoalRoomList({ roadmapId: Number(id) });
 
   return (
-    <S.ListContainer>
+    <S.ListContainer role='main' aria-label='골룸 리스트'>
       <S.FilterBar>
-        <p>모집중인 골룸 {goalRoomList.length}개</p>
-        <p>마감 임박순</p>
+        <p aria-live='polite'>모집중인 골룸 {goalRoomList.length}개</p>
+        <p aria-live='polite'>마감 임박순</p>
       </S.FilterBar>
-      <S.ListWrapper>
+      <S.ListWrapper role='list' aria-label='골룸 리스트'>
         {goalRoomList.map((goalRoomInfo) => {
           return <GoalRoomItem {...goalRoomInfo} />;
         })}

--- a/client/src/components/loginPage/loginOptions/LoginOptions.tsx
+++ b/client/src/components/loginPage/loginOptions/LoginOptions.tsx
@@ -10,13 +10,13 @@ const LoginOptions = ({ toggleLoginForm }: LoginOptionsProps) => {
     <>
       <S.OathButtonContainer>
         <div>
-          <S.OathButton type='kakao'>
+          {/* <S.OathButton type='kakao'>
             <SVGIcon name='KakaoIcon' />
             카카오톡으로 3초 만에 로그인하기
           </S.OathButton>
           <S.OathButton type='google'>
             <SVGIcon name='GoogleIcon' /> 구글로 로그인하기
-          </S.OathButton>
+          </S.OathButton> */}
           <S.OathButton onClick={toggleLoginForm}>
             <SVGIcon name='PersonIcon' /> 아이디로 로그인하기
           </S.OathButton>

--- a/client/src/components/roadmapListPage/categories/Categories.styles.ts
+++ b/client/src/components/roadmapListPage/categories/Categories.styles.ts
@@ -21,7 +21,7 @@ export const CategoriesRow = styled.div`
   column-gap: 1.4rem;
 `;
 
-export const Category = styled.div<{ selected: boolean }>`
+export const Category = styled.button<{ selected: boolean }>`
   ${({ theme }) => theme.fonts.description5}
   cursor: pointer;
 

--- a/client/src/components/roadmapListPage/categories/Categories.tsx
+++ b/client/src/components/roadmapListPage/categories/Categories.tsx
@@ -6,7 +6,7 @@ import * as S from './Categories.styles';
 
 type CategoriesProps = {
   selectedCategoryId: SelectedCategoryId;
-  selectCategory: ({ currentTarget }: MouseEvent<HTMLDivElement>) => void;
+  selectCategory: ({ currentTarget }: MouseEvent<HTMLButtonElement>) => void;
 };
 
 const Categories = ({ selectedCategoryId, selectCategory }: CategoriesProps) => {
@@ -21,6 +21,8 @@ const Categories = ({ selectedCategoryId, selectCategory }: CategoriesProps) => 
         id={String(id)}
         onClick={selectCategory}
         selected={selectedCategoryId === id}
+        aria-label={name}
+        role='button'
       >
         <SVGIcon name={CategoriesInfo[id].iconName} />
         <S.CategoryName>{name}</S.CategoryName>
@@ -29,7 +31,7 @@ const Categories = ({ selectedCategoryId, selectCategory }: CategoriesProps) => 
   };
 
   return (
-    <S.Categories>
+    <S.Categories aria-label='카테고리 목록'>
       <S.CategoriesRow>{upCategories.map(renderCategory)}</S.CategoriesRow>
       <S.CategoriesRow>{downCategories.map(renderCategory)}</S.CategoriesRow>
     </S.Categories>

--- a/client/src/components/roadmapListPage/roadmapList/RoadmapList.tsx
+++ b/client/src/components/roadmapListPage/roadmapList/RoadmapList.tsx
@@ -11,7 +11,7 @@ const RoadmapList = ({ selectedCategoryId }: RoadmapListProps) => {
   const roadmapList = useRoadmapList(selectedCategoryId);
 
   return (
-    <S.RoadmapList>
+    <S.RoadmapList aria-label='로드맵 목록'>
       {roadmapList?.map((item) => (
         <RoadmapItem key={item.roadmapId} item={item} />
       ))}

--- a/client/src/components/roadmapListPage/roadmapListView/RoadmapListView.tsx
+++ b/client/src/components/roadmapListPage/roadmapListView/RoadmapListView.tsx
@@ -10,13 +10,14 @@ const RoadmapListView = () => {
   const [selectedCategoryId, selectCategory] = useSelectCategory();
 
   return (
-    <S.RoadmapListView>
+    <S.RoadmapListView aria-label='로드맵 뷰'>
       <Categories
         selectedCategoryId={selectedCategoryId}
         selectCategory={selectCategory}
+        aria-label='카테고리 선택'
       />
       <Suspense fallback={<Fallback />}>
-        <RoadmapList selectedCategoryId={selectedCategoryId} />
+        <RoadmapList selectedCategoryId={selectedCategoryId} aria-label='로드맵 리스트' />
       </Suspense>
     </S.RoadmapListView>
   );

--- a/client/src/components/signUpPage/SignUpForm.tsx
+++ b/client/src/components/signUpPage/SignUpForm.tsx
@@ -60,7 +60,7 @@ const SignUpForm = () => {
             <input
               name='phoneNumber'
               onChange={handleInputChange}
-              placeholder='휴대전화번호 ex) 01012345678'
+              placeholder='휴대전화번호 ex) 010-1234-5678'
             />
           </S.FormItem>
           <S.FormItem>
@@ -78,7 +78,7 @@ const SignUpForm = () => {
             <input
               name='birthday'
               onChange={handleInputChange}
-              placeholder='생년월일 6자리 ex) 950101'
+              placeholder='생년월일 8자리 ex) 19950101'
               type='number'
             />
           </S.FormItem>

--- a/client/src/hooks/queries/goalRoom.ts
+++ b/client/src/hooks/queries/goalRoom.ts
@@ -2,6 +2,7 @@ import {
   CreateGoalRoomRequest,
   newTodoPayload,
   GoalRoomListRequest,
+  GoalRoomTodoChangeStatusRequest,
 } from '@myTypes/goalRoom/remote';
 import {
   postCreateGoalRoom,
@@ -10,9 +11,11 @@ import {
   getGoalRoomTodos,
   postCreateNewCertificationFeed,
   getGoalRoomList,
+  postToChangeTodoCheckStatus,
 } from '@apis/goalRoom';
 import { useSuspendedQuery } from '@hooks/queries/useSuspendedQuery';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import useToast from '@hooks/_common/useToast';
 
 export const useGoalRoomList = (params: GoalRoomListRequest) => {
   const { data } = useSuspendedQuery(['goalRoomList'], () => getGoalRoomList(params));
@@ -70,6 +73,31 @@ export const useFetchGoalRoomTodos = (goalRoomId: string) => {
 
   return {
     goalRoomTodos: data,
+  };
+};
+
+export const usePostChangeTodoCheckStatus = ({
+  goalRoomId,
+  todoId,
+}: GoalRoomTodoChangeStatusRequest) => {
+  const queryClient = useQueryClient();
+  const { triggerToast } = useToast();
+
+  const { mutate } = useMutation(
+    () => postToChangeTodoCheckStatus({ goalRoomId, todoId }),
+    {
+      onSuccess() {
+        triggerToast({ message: '투두리스트 상태 변경 완료!' });
+        queryClient.invalidateQueries([
+          ['goalRoom', goalRoomId],
+          ['goalRoomTodos', goalRoomId],
+        ]);
+      },
+    }
+  );
+
+  return {
+    changeTodoCheckStatus: mutate,
   };
 };
 

--- a/client/src/hooks/queries/user.ts
+++ b/client/src/hooks/queries/user.ts
@@ -1,8 +1,14 @@
 import { useMutation } from '@tanstack/react-query';
-import { MemberJoinRequest, UserLoginRequest } from '@myTypes/user/remote';
-import { login, signUp } from '@apis/user';
+import {
+  MemberJoinRequest,
+  UserInfoResponse,
+  UserLoginRequest,
+} from '@myTypes/user/remote';
+import { getUserInfo, login, signUp } from '@apis/user';
 import { setCookie } from '@utils/_common/cookies';
 import useToast from '@hooks/_common/useToast';
+import { useUserInfoContext } from '@components/_providers/UserInfoProvider';
+import { AxiosResponse } from 'axios';
 
 export const useSignUp = () => {
   const { mutate } = useMutation(
@@ -24,6 +30,8 @@ export const useSignUp = () => {
 
 export const useLogin = () => {
   const { triggerToast } = useToast();
+  const { setUserInfo } = useUserInfoContext();
+
   const { mutate } = useMutation(
     (loginPayload: UserLoginRequest) => login(loginPayload),
     {
@@ -32,6 +40,10 @@ export const useLogin = () => {
         setCookie('access_token', accessToken);
         setCookie('refresh_token', refreshToken);
         triggerToast({ message: '로그인 성공!' });
+
+        getUserInfo().then((response: AxiosResponse<UserInfoResponse>) => {
+          setUserInfo(response.data);
+        });
       },
       onError() {
         // TODO: 로그인 실패 시 로직

--- a/client/src/hooks/roadmap/useSelectCategory.ts
+++ b/client/src/hooks/roadmap/useSelectCategory.ts
@@ -4,7 +4,7 @@ import { MouseEvent, useState } from 'react';
 export const useSelectCategory = () => {
   const [selectedCategoryId, setSelectedCategoryId] = useState<SelectedCategoryId>();
 
-  const selectCategory = ({ currentTarget }: MouseEvent<HTMLDivElement>) => {
+  const selectCategory = ({ currentTarget }: MouseEvent<HTMLButtonElement>) => {
     if (!currentTarget.id) return;
 
     const categoryId = Number(currentTarget.id);

--- a/client/src/hooks/user/useValidationCheck.ts
+++ b/client/src/hooks/user/useValidationCheck.ts
@@ -1,0 +1,16 @@
+import { useUserInfoContext } from '@components/_providers/UserInfoProvider';
+import { useEffect } from 'react';
+import isValidUserInfo from '@utils/user/isValidUserInfo';
+import logout from '@utils/user/logout';
+
+export const useValidationCheck = () => {
+  const { userInfo } = useUserInfoContext();
+
+  useEffect(() => {
+    if (!isValidUserInfo(userInfo)) {
+      logout();
+    }
+  }, [userInfo]);
+};
+
+export default useValidationCheck;

--- a/client/src/mocks/fixtures/goalRoom.ts
+++ b/client/src/mocks/fixtures/goalRoom.ts
@@ -42,18 +42,27 @@ const fixture: GoalRoomFixture = {
         content: '투두 내용 11',
         startDate: '2023-07-19',
         endDate: '2023-07-20',
+        check: {
+          isChecked: true,
+        },
       },
       {
         id: 2,
         content: '투두 내용 22',
         startDate: '2023-07-19',
         endDate: '2023-07-20',
+        check: {
+          isChecked: false,
+        },
       },
       {
         id: 3,
         content: '투두 내용 33',
         startDate: '2023-07-19',
         endDate: '2023-07-20',
+        check: {
+          isChecked: false,
+        },
       },
     ],
     checkFeeds: [

--- a/client/src/myTypes/_common/user.ts
+++ b/client/src/myTypes/_common/user.ts
@@ -1,0 +1,6 @@
+import { defaultUserInfo } from '@components/_providers/UserInfoProvider';
+
+export type UserInfoContextType = {
+  userInfo: typeof defaultUserInfo;
+  setUserInfo: React.Dispatch<React.SetStateAction<typeof defaultUserInfo>>;
+};

--- a/client/src/myTypes/goalRoom/internal.ts
+++ b/client/src/myTypes/goalRoom/internal.ts
@@ -25,6 +25,9 @@ export type GoalRoomTodo = {
   content: string;
   startDate: string;
   endDate: string;
+  check: {
+    isChecked: boolean;
+  };
 };
 
 export type CheckFeed = {

--- a/client/src/myTypes/goalRoom/remote.ts
+++ b/client/src/myTypes/goalRoom/remote.ts
@@ -39,7 +39,7 @@ export type CreateGoalRoomRequest = {
   roadmapContentId: number;
   name: string;
   limitedMemberCount: number;
-  goalRoomTodo: Omit<GoalRoomTodo, 'id'>;
+  goalRoomTodo: Partial<GoalRoomTodo>;
   goalRoomRoadmapNodeRequests: GoalRoomRoadmapNodeRequestsType[];
 };
 
@@ -65,3 +65,8 @@ export type newTodoPayload = {
 };
 
 export type GoalRoomTodoResponse = GoalRoomTodo[];
+
+export type GoalRoomTodoChangeStatusRequest = {
+  goalRoomId: string;
+  todoId: string;
+};

--- a/client/src/myTypes/user/remote.ts
+++ b/client/src/myTypes/user/remote.ts
@@ -16,3 +16,15 @@ export type UserLoginResponse = {
   accessToken: string;
   refreshToken: string;
 };
+
+export type UserGender = 'MALE' | 'FEMALE';
+
+export type UserInfoResponse = {
+  id: number | null;
+  nickname: string;
+  profileImageUrl: string;
+  gender: UserGender | null;
+  identifier: string;
+  phoneNumber: string;
+  birthday: string;
+};

--- a/client/src/pages/myPage/MyPage.tsx
+++ b/client/src/pages/myPage/MyPage.tsx
@@ -1,0 +1,5 @@
+const MyPage = () => {
+  return <div>MyPage</div>;
+};
+
+export default MyPage;

--- a/client/src/tests/utilTests/isValidUserInfo.test.ts
+++ b/client/src/tests/utilTests/isValidUserInfo.test.ts
@@ -1,0 +1,32 @@
+import isValidUserInfo from '@utils/user/isValidUserInfo';
+import { UserInfoResponse } from '@myTypes/user/remote';
+
+describe('사용자 정보 검증', () => {
+  it('모든 필드가 유효한 경우', () => {
+    const userInfo: UserInfoResponse = {
+      id: 1,
+      nickname: '테스트',
+      profileImageUrl: 'http://example.com/profile.jpg',
+      gender: 'MALE',
+      identifier: 'test',
+      phoneNumber: '010-1234-5678',
+      birthday: '1990-01-01',
+    };
+
+    expect(isValidUserInfo(userInfo)).toBe(true);
+  });
+
+  it('필드가 누락된 경우', () => {
+    const userInfo = {
+      id: null,
+      nickname: '',
+      profileImageUrl: 'http://example.com/profile.jpg',
+      gender: null,
+      identifier: '',
+      phoneNumber: '',
+      birthday: '',
+    };
+
+    expect(isValidUserInfo(userInfo)).toBe(false);
+  });
+});

--- a/client/src/utils/user/isValidUserInfo.ts
+++ b/client/src/utils/user/isValidUserInfo.ts
@@ -1,0 +1,7 @@
+import { UserInfoResponse } from '@myTypes/user/remote';
+
+const isValidUserInfo = (userInfo: UserInfoResponse): boolean => {
+  return Object.values(userInfo).every((value) => Boolean(value));
+};
+
+export default isValidUserInfo;


### PR DESCRIPTION
## 📌 작업 이슈 번호

[CK-132](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-132)

## ✨ 작업 내용

![image](https://github.com/woowacourse-teams/2023-co-kirikiri/assets/81363031/3f9bc939-3e93-4887-a6e7-764b64e18f90)

- 팀원분들이 로그인했는지 모르겠다는 피드백을 받아 로그인 성공 시 유저 정보를 받아 전역 컨텍스트에 저장 후 네브바에 도출했습닏다.
  - 로그인 성공시 연속적으로 유저 정보 받는 api 요청을 통해 받은 response 를 전역에 저장했습니다.
  - nav 컴포넌트에서 리렌더시마다 유저 정보가 아직 유효한지 검증 후 아니라면 로그아웃 처리를 합니다.
  - 로그인 성공 시 토스트 메세지를 도출합니다.

-  구현이 되어있지 않은 소셜 로그인 버튼을 주석처리하였습니다.
- 투두리스트에 완료되었는지 여부를 판단하는 필드와 변경할 수 있는 api 가 추가되어 이에 대응하는 코드를 작성했습니다.

- 로드맵 리스트 페이지의 웹 접근성을 대폭 향상하여 screen reader 사용 시 각 요소와 텍스트가 무엇을 뜻하는지 알 수 있도록 처리하였습니다. 

## 💬 리뷰어에게 남길 멘트

잘 부탁드립니다!

## 🚀 요구사항 분석

- 유저 auth 관련 통신 에러 해결 
- 투두리스트 변경점 대응
- 웹 접근성 향상 


