### PR TITLE
[feat/CK-130] 페이지 라우팅과 잔여 서버 연결을 처리한다

### DIFF
--- a/client/src/apis/goalRoom.ts
+++ b/client/src/apis/goalRoom.ts
@@ -5,6 +5,7 @@ import {
   GoalRoomDetailResponse,
   GoalRoomTodoResponse,
   newTodoPayload,
+  GoalRoomInfoResponse,
 } from '@/myTypes/goalRoom/remote';
 import client from '@apis/axios/client';
 
@@ -17,6 +18,13 @@ export const getGoalRoomList = async ({
   const { data } = await client.get<GoalRoomDetailResponse[]>(
     `/roadmaps/${roadmapId}/goal-rooms?filterCond=${filterCond}&lastCreatedAt=${lastCreatedAt}&size=${size}`
   );
+  return data;
+};
+
+export const getGoalRoomDetail = async (
+  goalRoomId: number
+): Promise<GoalRoomInfoResponse> => {
+  const { data } = await client.get<GoalRoomInfoResponse>(`/goal-rooms/${goalRoomId}`);
   return data;
 };
 

--- a/client/src/apis/roadmap.ts
+++ b/client/src/apis/roadmap.ts
@@ -13,7 +13,7 @@ export const getRoadmapList = async (
   size = 10,
   filterCond = 'LATEST'
 ) => {
-  const { data } = await client.get<RoadmapListResponse>(`/roadmaps`, {
+  const { data } = await client.get<RoadmapListResponse[]>(`/roadmaps`, {
     params: {
       ...(categoryId && { categoryId }),
       page,
@@ -25,7 +25,7 @@ export const getRoadmapList = async (
   return data;
 };
 
-export const getRoadmapById = async (id: number) => {
+export const getRoadmapDetail = async (id: number): Promise<RoadmapDetailResponse> => {
   const { data } = await client.get<RoadmapDetailResponse>(`/roadmaps/${id}`);
 
   return data;

--- a/client/src/components/_common/button/Button.tsx
+++ b/client/src/components/_common/button/Button.tsx
@@ -3,10 +3,15 @@ import * as S from './Button.styles';
 
 type ButtonProps = {
   variant?: 'primary';
+  onClick?: () => void;
 } & PropsWithChildren;
 
-const Button = ({ children, variant = 'primary' }: ButtonProps) => {
-  return <S.Button variant={variant}>{children}</S.Button>;
+const Button = ({ children, variant = 'primary', onClick }: ButtonProps) => {
+  return (
+    <S.Button variant={variant} onClick={onClick}>
+      {children}
+    </S.Button>
+  );
 };
 
 export default Button;

--- a/client/src/components/_common/dialog/dialog.tsx
+++ b/client/src/components/_common/dialog/dialog.tsx
@@ -49,8 +49,8 @@ export const DialogBackdrop = (props: PropsWithChildren<DialogBackdropProps>) =>
   const { isOpen, closeDialog } = useContextScope(DialogContext);
 
   useEffect(() => {
-    document.body.style.overflow = 'hidden';
-  }, []);
+    document.body.style.overflow = isOpen ? 'hidden' : 'auto';
+  }, [isOpen]);
 
   if (asChild) {
     return isOpen

--- a/client/src/components/_common/dialog/dialog.tsx
+++ b/client/src/components/_common/dialog/dialog.tsx
@@ -2,10 +2,13 @@ import { DialogContext } from '@/context/dialogContext';
 import { getCustomElement } from '@/hooks/_common/compound';
 import { useContextScope } from '@/hooks/_common/useContextScope';
 import { DialogBackdropProps, DialogTriggerProps } from '@/myTypes/_common/dialog';
-import { PropsWithChildren, ReactElement, useState } from 'react';
+import { PropsWithChildren, ReactElement, useEffect, useState } from 'react';
 
-export const DialogBox = ({ children }: PropsWithChildren) => {
-  const [isOpen, setIsOpen] = useState(false);
+export const DialogBox = ({
+  children,
+  defaultOpen = false,
+}: PropsWithChildren<{ defaultOpen?: boolean }>) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen ?? false);
 
   const openDialog = () => {
     setIsOpen(true);
@@ -44,6 +47,10 @@ export const DialogTrigger = (props: PropsWithChildren<DialogTriggerProps>) => {
 export const DialogBackdrop = (props: PropsWithChildren<DialogBackdropProps>) => {
   const { asChild = false, children, ...restProps } = props;
   const { isOpen, closeDialog } = useContextScope(DialogContext);
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+  }, []);
 
   if (asChild) {
     return isOpen

--- a/client/src/components/_common/roadmapItem/RoadmapItem.tsx
+++ b/client/src/components/_common/roadmapItem/RoadmapItem.tsx
@@ -1,6 +1,6 @@
 import type { RoadmapItemType } from '@myTypes/roadmap/internal';
 
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import SVGIcon from '@components/icons/SVGIcon';
 import { DIFFICULTY_ICON_NAME } from '@constants/roadmap/difficulty';
 import { CategoriesInfo } from '@constants/roadmap/category';
@@ -10,13 +10,23 @@ import * as S from './RoadmapItem.styles';
 type RoadmapItemProps = {
   item: RoadmapItemType;
   hasBorder?: boolean;
+  roadmapId: number;
 };
 
-const RoadmapItem = ({ item, hasBorder = true }: RoadmapItemProps) => {
+const RoadmapItem = ({ item, hasBorder = true, roadmapId }: RoadmapItemProps) => {
   const categoryIcon = <SVGIcon name={CategoriesInfo[item.category.id].iconName} />;
   const difficultyIcon = (
     <SVGIcon name={DIFFICULTY_ICON_NAME[item.difficulty]} size={50} />
   );
+  const navigate = useNavigate();
+
+  const moveGoalRoomListPage = () => {
+    if (hasBorder) {
+      navigate(`/roadmap/${roadmapId}`);
+      return;
+    }
+    navigate(`/roadmap/${roadmapId}/goalroom-list`);
+  };
 
   return (
     <S.RoadmapItem hasBorder={hasBorder}>
@@ -36,9 +46,9 @@ const RoadmapItem = ({ item, hasBorder = true }: RoadmapItemProps) => {
           <div>Days</div>
         </S.RecommendedRoadmapPeriod>
       </S.ItemExtraInfos>
-      <Link to={`/roadmap/${item.roadmapId}`}>
-        <Button>{hasBorder ? '자세히 보기' : '진행중인 골룸 보기'}</Button>
-      </Link>
+      <Button onClick={moveGoalRoomListPage}>
+        {hasBorder ? '자세히 보기' : '진행중인 골룸 보기'}
+      </Button>
       <S.ItemFooter>
         <S.CreatedBy>Created by {item.creator.name}</S.CreatedBy>
         <S.Tags>

--- a/client/src/components/_common/roadmapItem/RoadmapItem.tsx
+++ b/client/src/components/_common/roadmapItem/RoadmapItem.tsx
@@ -1,4 +1,4 @@
-import type { RoadmapItemType } from '@myTypes/roadmap/internal';
+import type { RoadmapDetailType } from '@myTypes/roadmap/internal';
 
 import { useNavigate } from 'react-router-dom';
 import SVGIcon from '@components/icons/SVGIcon';
@@ -8,7 +8,7 @@ import Button from '../button/Button';
 import * as S from './RoadmapItem.styles';
 
 type RoadmapItemProps = {
-  item: RoadmapItemType;
+  item: Omit<RoadmapDetailType, 'content'>;
   hasBorder?: boolean;
   roadmapId: number;
 };
@@ -52,8 +52,9 @@ const RoadmapItem = ({ item, hasBorder = true, roadmapId }: RoadmapItemProps) =>
       <S.ItemFooter>
         <S.CreatedBy>Created by {item.creator.name}</S.CreatedBy>
         <S.Tags>
-          <span># Programming</span>
-          <span># Study</span>
+          {item.tags.map((tag) => {
+            return <span># {tag.name}</span>;
+          })}
         </S.Tags>
       </S.ItemFooter>
     </S.RoadmapItem>

--- a/client/src/components/goalRoomCreatePage/createGoalRoom/CreateGoalRoom.tsx
+++ b/client/src/components/goalRoomCreatePage/createGoalRoom/CreateGoalRoom.tsx
@@ -6,18 +6,18 @@ import { useRoadmapDetail } from '@hooks/queries/roadmap';
 
 const CreateGoalRoom = () => {
   const { id: roadmapContentId } = useValidParams();
-  const detailData = useRoadmapDetail(Number(roadmapContentId));
+  const { roadmapInfo } = useRoadmapDetail(Number(roadmapContentId));
 
   return (
     <div>
       <PageSection title='선택된 로드맵' description='생성할 골룸이 연결된 로드맵입니다'>
         <S.RoadmapInfo>
-          &gt; {detailData?.roadmapTitle} / 생성자: {detailData?.creator.name}
+          &gt; {roadmapInfo.roadmapTitle} / 생성자: {roadmapInfo.creator.name}
         </S.RoadmapInfo>
       </PageSection>
       <CreateGoalRoomForm
         roadmapContentId={Number(roadmapContentId)}
-        nodes={detailData?.content.nodes || []}
+        nodes={roadmapInfo.content.nodes || []}
       />
     </div>
   );

--- a/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialog.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialog.tsx
@@ -6,17 +6,28 @@ import {
 import * as S from './goalRoomDetailDialog.styles';
 import GoalRoomDetailDialogContent from './GoalRoomDetailDialogContent';
 
-const GoalRoomDetailDialog = () => {
+type GoalRoomDetailDialogProps = {
+  closeGoalroomDetail: () => void;
+  goalRoomId: number;
+};
+
+const GoalRoomDetailDialog = ({
+  closeGoalroomDetail,
+  goalRoomId,
+}: GoalRoomDetailDialogProps) => {
   return (
     <DialogBox defaultOpen>
       <DialogBackdrop asChild>
         <S.BackDrop>
           <DialogContent>
-            <GoalRoomDetailDialogContent />
+            <GoalRoomDetailDialogContent
+              closeGoalroomDetail={closeGoalroomDetail}
+              goalRoomId={goalRoomId}
+            />
+            <S.EnterGoalRoomButton>17일동안 골룸 참여하기</S.EnterGoalRoomButton>
           </DialogContent>
         </S.BackDrop>
       </DialogBackdrop>
-      <S.EnterGoalRoomButton>17일동안 골룸 참여하기</S.EnterGoalRoomButton>
     </DialogBox>
   );
 };

--- a/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialog.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialog.tsx
@@ -1,0 +1,26 @@
+import {
+  DialogBackdrop,
+  DialogBox,
+  DialogContent,
+} from '@/components/_common/dialog/dialog';
+import * as S from './goalRoomDetailDialog.styles';
+import GoalRoomDetailDialogContent from './GoalRoomDetailDialogContent';
+
+const GoalRoomDetailDialog = () => {
+  return (
+    <>
+      <DialogBox defaultOpen>
+        <DialogBackdrop asChild>
+          <S.BackDrop>
+            <DialogContent>
+              <GoalRoomDetailDialogContent />
+            </DialogContent>
+          </S.BackDrop>
+        </DialogBackdrop>
+      </DialogBox>
+      <S.EnterGoalRoomButton>17일동안 골룸 참여하기</S.EnterGoalRoomButton>
+    </>
+  );
+};
+
+export default GoalRoomDetailDialog;

--- a/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialog.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialog.tsx
@@ -8,18 +8,16 @@ import GoalRoomDetailDialogContent from './GoalRoomDetailDialogContent';
 
 const GoalRoomDetailDialog = () => {
   return (
-    <>
-      <DialogBox defaultOpen>
-        <DialogBackdrop asChild>
-          <S.BackDrop>
-            <DialogContent>
-              <GoalRoomDetailDialogContent />
-            </DialogContent>
-          </S.BackDrop>
-        </DialogBackdrop>
-      </DialogBox>
+    <DialogBox defaultOpen>
+      <DialogBackdrop asChild>
+        <S.BackDrop>
+          <DialogContent>
+            <GoalRoomDetailDialogContent />
+          </DialogContent>
+        </S.BackDrop>
+      </DialogBackdrop>
       <S.EnterGoalRoomButton>17일동안 골룸 참여하기</S.EnterGoalRoomButton>
-    </>
+    </DialogBox>
   );
 };
 

--- a/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialogContent.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialogContent.tsx
@@ -1,26 +1,43 @@
 import { DialogTrigger } from '@/components/_common/dialog/dialog';
+import { useGoalRoomDetail } from '@/hooks/queries/goalRoom';
 import * as S from './goalRoomDetailDialog.styles';
 
-const GoalRoomDetailDialogContent = () => {
+type GoalRoomDetailDialogContentProps = {
+  closeGoalroomDetail: () => void;
+  goalRoomId: number;
+};
+
+const GoalRoomDetailDialogContent = ({
+  closeGoalroomDetail,
+  goalRoomId,
+}: GoalRoomDetailDialogContentProps) => {
+  const { goalRoomInfo } = useGoalRoomDetail(goalRoomId);
+
   return (
     <S.Container>
       <S.TitleWrapper>
         <div />
-        <S.Title>골룸입니당</S.Title>
+        <S.Title>{goalRoomInfo.name}</S.Title>
         <DialogTrigger asChild>
-          <S.CloseButton>X</S.CloseButton>
+          <S.CloseButton onClick={closeGoalroomDetail}>X</S.CloseButton>
         </DialogTrigger>
       </S.TitleWrapper>
       <S.Participant>
-        <p>7</p>/10
+        <p>{goalRoomInfo.currentMemberCount}</p>/{goalRoomInfo.limitedMemberCount}
       </S.Participant>
       <S.RoadmapContainer>
         <S.RoadmapTitle>🐘 로드맵 둘러보기🐘🐘</S.RoadmapTitle>
-        <S.NodeContainer>
-          <S.NodePeriod>2023-07-19 ~ 2023-07-30</S.NodePeriod>
-          <S.NodeTitle>로드맵 1주차</S.NodeTitle>
-          <S.FeedCount>인증횟수 17회</S.FeedCount>
-        </S.NodeContainer>
+        {goalRoomInfo.goalRoomNodes.map((node) => {
+          return (
+            <S.NodeContainer>
+              <S.NodePeriod>
+                {node.startDate} ~ {node.endDate}
+              </S.NodePeriod>
+              <S.NodeTitle>{node.title}</S.NodeTitle>
+              <S.FeedCount>인증횟수 {node.checkCount}회</S.FeedCount>
+            </S.NodeContainer>
+          );
+        })}
       </S.RoadmapContainer>
     </S.Container>
   );

--- a/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialogContent.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialogContent.tsx
@@ -1,9 +1,16 @@
+import { DialogTrigger } from '@/components/_common/dialog/dialog';
 import * as S from './goalRoomDetailDialog.styles';
 
 const GoalRoomDetailDialogContent = () => {
   return (
     <S.Container>
-      <S.Title>골룸입니당</S.Title>
+      <S.TitleWrapper>
+        <div />
+        <S.Title>골룸입니당</S.Title>
+        <DialogTrigger asChild>
+          <S.CloseButton>X</S.CloseButton>
+        </DialogTrigger>
+      </S.TitleWrapper>
       <S.Participant>
         <p>7</p>/10
       </S.Participant>

--- a/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialogContent.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomDetail/GoalRoomDetailDialogContent.tsx
@@ -1,0 +1,22 @@
+import * as S from './goalRoomDetailDialog.styles';
+
+const GoalRoomDetailDialogContent = () => {
+  return (
+    <S.Container>
+      <S.Title>골룸입니당</S.Title>
+      <S.Participant>
+        <p>7</p>/10
+      </S.Participant>
+      <S.RoadmapContainer>
+        <S.RoadmapTitle>🐘 로드맵 둘러보기🐘🐘</S.RoadmapTitle>
+        <S.NodeContainer>
+          <S.NodePeriod>2023-07-19 ~ 2023-07-30</S.NodePeriod>
+          <S.NodeTitle>로드맵 1주차</S.NodeTitle>
+          <S.FeedCount>인증횟수 17회</S.FeedCount>
+        </S.NodeContainer>
+      </S.RoadmapContainer>
+    </S.Container>
+  );
+};
+
+export default GoalRoomDetailDialogContent;

--- a/client/src/components/goalRoomListPage/goalRoomDetail/goalRoomDetailDialog.styles.ts
+++ b/client/src/components/goalRoomListPage/goalRoomDetail/goalRoomDetailDialog.styles.ts
@@ -29,6 +29,18 @@ export const Container = styled.section`
   border-radius: 30px;
 `;
 
+export const CloseButton = styled.button`
+  ${({ theme }) => theme.fonts.h1}
+  color: ${({ theme }) => theme.colors.main_dark};
+`;
+
+export const TitleWrapper = styled.div`
+  display: flex;
+  justify-content: space-around;
+  width: 100%;
+  padding: 0 1rem;
+`;
+
 export const Title = styled.h1`
   ${({ theme }) => theme.fonts.h1}
 `;

--- a/client/src/components/goalRoomListPage/goalRoomDetail/goalRoomDetailDialog.styles.ts
+++ b/client/src/components/goalRoomListPage/goalRoomDetail/goalRoomDetailDialog.styles.ts
@@ -1,0 +1,108 @@
+import styled from 'styled-components';
+
+export const BackDrop = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+
+  background-color: rgb(0, 0, 0, 0.5);
+`;
+
+export const Container = styled.section`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  width: 55rem;
+  height: 55rem;
+  padding-top: 3.5rem;
+
+  background-color: ${({ theme }) => theme.colors.white};
+  border-radius: 30px;
+`;
+
+export const Title = styled.h1`
+  ${({ theme }) => theme.fonts.h1}
+`;
+
+export const Participant = styled.h2`
+  ${({ theme }) => theme.fonts.h2}
+  display: flex;
+  margin-top: 0.7rem;
+
+  & p {
+    color: ${({ theme }) => theme.colors.main_dark};
+  }
+`;
+
+export const RoadmapContainer = styled.ul`
+  overflow: scroll;
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+  align-items: center;
+
+  width: 41rem;
+  min-height: 50rem;
+  margin-top: 3.3rem;
+
+  background-color: ${({ theme }) => theme.colors.gray100};
+  border-radius: 20px;
+`;
+
+export const RoadmapTitle = styled.h3`
+  ${({ theme }) => theme.fonts.button1}
+  margin-top: 3.3rem;
+`;
+
+export const NodeContainer = styled.li`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-around;
+
+  width: 27.5rem;
+  height: 10rem;
+  padding: 1.2rem 0;
+
+  border: 0.2rem solid ${({ theme }) => theme.colors.main_dark};
+  border-radius: 20px;
+`;
+
+export const NodeTitle = styled.div`
+  ${({ theme }) => theme.fonts.button1}
+`;
+
+export const NodePeriod = styled.div`
+  ${({ theme }) => theme.fonts.button1}
+  color: ${({ theme }) => theme.colors.main_dark};
+`;
+
+export const FeedCount = styled.div`
+  ${({ theme }) => theme.fonts.description4}
+  color: ${({ theme }) => theme.colors.gray300};
+`;
+
+export const EnterGoalRoomButton = styled.button`
+  ${({ theme }) => theme.fonts.h1}
+  position: absolute;
+  bottom: 4rem;
+  left: 50%;
+  transform: translate(-50%);
+
+  width: 39.4rem;
+  height: 7rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  background-color: ${({ theme }) => theme.colors.main_dark};
+  border-radius: 34px;
+`;

--- a/client/src/components/goalRoomListPage/goalRoomList/GoalRoomItem.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomList/GoalRoomItem.tsx
@@ -1,27 +1,45 @@
 import { GoalRoomDetailType } from '@/myTypes/goalRoom/internal';
+import { useState } from 'react';
+import GoalRoomDetailDialog from '../goalRoomDetail/GoalRoomDetailDialog';
 import * as S from './goalRoomList.styles';
 
 const GoalRoomItem = ({ ...goalRoomInfo }: GoalRoomDetailType) => {
+  const [showDetail, setShowDetail] = useState(false);
+  const showGoalroomDetail = () => {
+    setShowDetail(true);
+  };
+
+  const closeGoalroomDetail = () => {
+    setShowDetail(false);
+  };
   return (
-    <S.ItemContainer>
-      <S.Recruiting>모집중 (~{goalRoomInfo.startDate})</S.Recruiting>
-      <S.Name>{goalRoomInfo.name}</S.Name>
-      <S.RoadmapCreator>created by Woody ❤️</S.RoadmapCreator>
-      <S.RoadmapIntroduce>please save me</S.RoadmapIntroduce>
-      <S.Period>
-        진행기간{' '}
-        <p>
-          {goalRoomInfo.startDate} - {goalRoomInfo.endDate}
-        </p>
-      </S.Period>
-      <S.Particpant>
-        진행기간{' '}
-        <p>
-          {goalRoomInfo.startDate} - {goalRoomInfo.endDate}
-        </p>
-      </S.Particpant>
-      <S.DetailButton>자세히 보기</S.DetailButton>
-    </S.ItemContainer>
+    <>
+      <S.ItemContainer>
+        <S.Recruiting>모집중 (~{goalRoomInfo.startDate})</S.Recruiting>
+        <S.Name>{goalRoomInfo.name}</S.Name>
+        <S.RoadmapCreator>created by Woody ❤️</S.RoadmapCreator>
+        <S.RoadmapIntroduce>please save me</S.RoadmapIntroduce>
+        <S.Period>
+          진행기간
+          <p>
+            {goalRoomInfo.startDate} - {goalRoomInfo.endDate}
+          </p>
+        </S.Period>
+        <S.Particpant>
+          참여인원
+          <p>
+            {goalRoomInfo.currentMemberCount} / {goalRoomInfo.limitedMemberCount}
+          </p>
+        </S.Particpant>
+        <S.DetailButton onClick={showGoalroomDetail}>자세히 보기</S.DetailButton>
+      </S.ItemContainer>
+      {showDetail && (
+        <GoalRoomDetailDialog
+          closeGoalroomDetail={closeGoalroomDetail}
+          goalRoomId={goalRoomInfo.goalRoomId}
+        />
+      )}
+    </>
   );
 };
 

--- a/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
@@ -2,6 +2,7 @@ import * as S from './goalRoomList.styles';
 import GoalRoomItem from './GoalRoomItem';
 import { useGoalRoomList } from '@/hooks/queries/goalRoom';
 import useValidParams from '@/hooks/_common/useValidParams';
+import GoalRoomDetailDialog from '../goalRoomDetail/GoalRoomDetailDialog';
 
 const GoalRoomList = () => {
   const { id } = useValidParams<{ id: string }>();
@@ -18,6 +19,7 @@ const GoalRoomList = () => {
           return <GoalRoomItem {...goalRoomInfo} />;
         })}
       </S.ListWrapper>
+      <GoalRoomDetailDialog />
     </S.ListContainer>
   );
 };

--- a/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
@@ -2,7 +2,6 @@ import * as S from './goalRoomList.styles';
 import GoalRoomItem from './GoalRoomItem';
 import { useGoalRoomList } from '@/hooks/queries/goalRoom';
 import useValidParams from '@/hooks/_common/useValidParams';
-import GoalRoomDetailDialog from '../goalRoomDetail/GoalRoomDetailDialog';
 
 const GoalRoomList = () => {
   const { id } = useValidParams<{ id: string }>();
@@ -19,7 +18,6 @@ const GoalRoomList = () => {
           return <GoalRoomItem {...goalRoomInfo} />;
         })}
       </S.ListWrapper>
-      <GoalRoomDetailDialog />
     </S.ListContainer>
   );
 };

--- a/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
@@ -2,11 +2,16 @@ import * as S from './goalRoomList.styles';
 import GoalRoomItem from './GoalRoomItem';
 import { useGoalRoomList } from '@/hooks/queries/goalRoom';
 import useValidParams from '@/hooks/_common/useValidParams';
+import { useNavigate } from 'react-router-dom';
 
 const GoalRoomList = () => {
   const { id } = useValidParams<{ id: string }>();
   const { goalRoomList } = useGoalRoomList({ roadmapId: Number(id) });
+  const navigate = useNavigate();
 
+  const moveCreateGoalRoomPage = () => {
+    navigate(`/roadmap/${Number(id)}/goalroom-create`);
+  };
   return (
     <S.ListContainer>
       <S.FilterBar>
@@ -17,6 +22,9 @@ const GoalRoomList = () => {
         {goalRoomList.map((goalRoomInfo) => {
           return <GoalRoomItem {...goalRoomInfo} />;
         })}
+        <S.CreateGoalRoomButton onClick={moveCreateGoalRoomPage}>
+          골룸 생성하러 가기
+        </S.CreateGoalRoomButton>
       </S.ListWrapper>
     </S.ListContainer>
   );

--- a/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
+++ b/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
@@ -102,3 +102,19 @@ export const DetailButton = styled.button`
   background-color: ${({ theme }) => theme.colors.main_dark};
   border-radius: 85px;
 `;
+
+export const CreateGoalRoomButton = styled.button`
+  ${({ theme }) => theme.fonts.h1}
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translate(-50%);
+
+  width: 50%;
+  height: 5rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  background-color: ${({ theme }) => theme.colors.main_middle};
+  border-radius: 20px;
+`;

--- a/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
+++ b/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
@@ -1,3 +1,4 @@
+import media from '@/styles/media';
 import styled from 'styled-components';
 
 export const ListContainer = styled.section`
@@ -31,6 +32,11 @@ export const ListWrapper = styled.div`
   display: grid;
   grid-row-gap: 6rem;
   grid-template-columns: repeat(2, 1fr);
+
+  ${media.mobile`
+  grid-template-columns: repeat(1, 1fr);
+
+  `}
 `;
 
 export const Recruiting = styled.div`

--- a/client/src/components/roadmapCreatePage/roadmap/RoadmapItem.tsx
+++ b/client/src/components/roadmapCreatePage/roadmap/RoadmapItem.tsx
@@ -1,9 +1,13 @@
+import { ChangeEvent } from 'react';
 import * as S from './roadmap.styles';
 
 type RoadmapItemProps = {
   roadmapNumber: number;
   itemId: number;
-  getRoadmapItemTitle: (e: React.ChangeEvent<HTMLInputElement>, itemId: number) => void;
+  getRoadmapItemTitle: <T extends HTMLInputElement | HTMLTextAreaElement>(
+    e: React.ChangeEvent<T>,
+    itemId: number
+  ) => void;
 };
 
 const RoadmapItem = ({
@@ -17,15 +21,17 @@ const RoadmapItem = ({
         <S.RoadmapNumber>{roadmapNumber}</S.RoadmapNumber>
         <S.TitleFieldWrapper>
           <input
-            onChange={(e) => getRoadmapItemTitle(e, itemId)}
+            onChange={(e) => getRoadmapItemTitle<HTMLInputElement>(e, itemId)}
             maxLength={40}
             name='title'
           />
         </S.TitleFieldWrapper>
       </S.TitleWrapper>
       <S.BodyFieldWrapper>
-        <input
-          onChange={(e) => getRoadmapItemTitle(e, itemId)}
+        <S.NodeBodyInputField
+          onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+            getRoadmapItemTitle<HTMLTextAreaElement>(e, itemId)
+          }
           maxLength={2000}
           name='content'
         />

--- a/client/src/components/roadmapCreatePage/roadmap/roadmap.styles.ts
+++ b/client/src/components/roadmapCreatePage/roadmap/roadmap.styles.ts
@@ -45,6 +45,10 @@ export const BodyFieldWrapper = styled.div`
   border-radius: 2rem;
 `;
 
+export const NodeBodyInputField = styled.textarea`
+  width: 80%;
+`;
+
 export const AddButton = styled.button`
   width: 13rem;
   height: 4rem;

--- a/client/src/components/roadmapCreatePage/roadmapCreateForm/RoadmapCreateForm.tsx
+++ b/client/src/components/roadmapCreatePage/roadmapCreateForm/RoadmapCreateForm.tsx
@@ -36,7 +36,10 @@ const RoadmapCreateForm = () => {
 
   return (
     <RefProvider>
-      <form onSubmit={handleSubmit}>
+      <S.Title>
+        <p>로드맵</p>을 생성해주세요
+      </S.Title>
+      <S.Form onSubmit={handleSubmit}>
         <Category getSelectedCategoryId={getSelectedCategoryId} />
         <Title />
         <Description />
@@ -58,8 +61,10 @@ const RoadmapCreateForm = () => {
             <S.AddButton onClick={addNode}>로드맵 추가하기</S.AddButton>
           </>
         </Roadmap>
-        <button>done!!</button>
-      </form>
+        <S.ButtonWrapper>
+          <S.CompleteButton>로드맵 생성완료</S.CompleteButton>
+        </S.ButtonWrapper>
+      </S.Form>
     </RefProvider>
   );
 };

--- a/client/src/components/roadmapCreatePage/roadmapCreateForm/roadmapCreateForm.styles.ts
+++ b/client/src/components/roadmapCreatePage/roadmapCreateForm/roadmapCreateForm.styles.ts
@@ -1,8 +1,40 @@
 import styled from 'styled-components';
 
+export const Title = styled.h1`
+  display: flex;
+  ${({ theme }) => theme.fonts.nav_title}
+  margin-top: 5rem;
+
+  & p {
+    color: ${({ theme }) => theme.colors.main_dark};
+  }
+`;
+
 export const AddButton = styled.button`
   width: 13rem;
   height: 4rem;
   border: 0.1rem solid ${({ theme }) => theme.colors.main_dark};
   border-radius: 15px;
+`;
+
+export const Form = styled.form`
+  padding: 5rem 0 10rem 0;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin: 5rem 0 0 0;
+`;
+
+export const CompleteButton = styled.button`
+  ${({ theme }) => theme.fonts.h1}
+  width: 50%;
+  height: 5rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  background-color: ${({ theme }) => theme.colors.main_middle};
+  border-radius: 20px;
 `;

--- a/client/src/components/roadmapDetailPage/roadmapDetail/RoadmapDetail.tsx
+++ b/client/src/components/roadmapDetailPage/roadmapDetail/RoadmapDetail.tsx
@@ -4,6 +4,8 @@ import RoadmapItem from '../../_common/roadmapItem/RoadmapItem';
 import OpenNodeListButton from '../openNodeListButton/OpenNodeListButton';
 import Button from '../../_common/button/Button';
 import * as S from './RoadmapDetail.styles';
+import useValidParams from '@/hooks/_common/useValidParams';
+import { useNavigate } from 'react-router-dom';
 
 const DummyData: RoadmapItemType = {
   roadmapId: 1,
@@ -33,14 +35,21 @@ const DummyData: RoadmapItemType = {
 };
 
 const RoadmapDetail = () => {
+  const { id: roadmapId } = useValidParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const moveGoalRoomListPage = () => {
+    navigate(`/roadmap/${roadmapId}/goalroom-list`);
+  };
+
   return (
     <S.RoadmapDetail>
       <S.PageOnTop>
-        <RoadmapItem item={DummyData} hasBorder={false} />
+        <RoadmapItem item={DummyData} hasBorder={false} roadmapId={Number(roadmapId)} />
         <OpenNodeListButton />
       </S.PageOnTop>
       <S.RoadmapBody>데이터가 들어갈 예정</S.RoadmapBody>
-      <Button>진행중인 골룸 보기</Button>
+      <Button onClick={moveGoalRoomListPage}>진행중인 골룸 보기</Button>
     </S.RoadmapDetail>
   );
 };

--- a/client/src/components/roadmapDetailPage/roadmapDetail/RoadmapDetail.tsx
+++ b/client/src/components/roadmapDetailPage/roadmapDetail/RoadmapDetail.tsx
@@ -1,42 +1,15 @@
-import type { RoadmapItemType } from '@myTypes/roadmap/internal';
-
 import RoadmapItem from '../../_common/roadmapItem/RoadmapItem';
 import OpenNodeListButton from '../openNodeListButton/OpenNodeListButton';
 import Button from '../../_common/button/Button';
 import * as S from './RoadmapDetail.styles';
 import useValidParams from '@/hooks/_common/useValidParams';
 import { useNavigate } from 'react-router-dom';
-
-const DummyData: RoadmapItemType = {
-  roadmapId: 1,
-  roadmapTitle: '로드맵 제목1',
-  introduction: '로드맵 소개글1',
-  difficulty: 'NORMAL',
-  recommendedRoadmapPeriod: 10,
-  createdAt: [2023, 8, 2, 19, 17, 28, 81052591],
-  creator: {
-    id: 1,
-    name: '코끼리',
-  },
-  category: {
-    id: 1,
-    name: '여행',
-  },
-  tags: [
-    {
-      id: 1,
-      name: '태그1',
-    },
-    {
-      id: 2,
-      name: '태그2',
-    },
-  ],
-};
+import { useRoadmapDetail } from '@/hooks/queries/roadmap';
 
 const RoadmapDetail = () => {
   const { id: roadmapId } = useValidParams<{ id: string }>();
   const navigate = useNavigate();
+  const { roadmapInfo } = useRoadmapDetail(Number(roadmapId));
 
   const moveGoalRoomListPage = () => {
     navigate(`/roadmap/${roadmapId}/goalroom-list`);
@@ -45,10 +18,10 @@ const RoadmapDetail = () => {
   return (
     <S.RoadmapDetail>
       <S.PageOnTop>
-        <RoadmapItem item={DummyData} hasBorder={false} roadmapId={Number(roadmapId)} />
+        <RoadmapItem item={roadmapInfo} hasBorder={false} roadmapId={Number(roadmapId)} />
         <OpenNodeListButton />
       </S.PageOnTop>
-      <S.RoadmapBody>데이터가 들어갈 예정</S.RoadmapBody>
+      <S.RoadmapBody>{roadmapInfo.content.content}</S.RoadmapBody>
       <Button onClick={moveGoalRoomListPage}>진행중인 골룸 보기</Button>
     </S.RoadmapDetail>
   );

--- a/client/src/components/roadmapListPage/roadmapList/RoadmapList.styles.ts
+++ b/client/src/components/roadmapListPage/roadmapList/RoadmapList.styles.ts
@@ -8,3 +8,17 @@ export const RoadmapList = styled.div`
 
   margin-bottom: 8rem;
 `;
+
+export const CreateRoadmapButton = styled.button`
+  ${({ theme }) => theme.fonts.h1}
+  position: fixed;
+  top: 1rem;
+
+  width: 50%;
+  height: 5rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  background-color: ${({ theme }) => theme.colors.main_middle};
+  border-radius: 20px;
+`;

--- a/client/src/components/roadmapListPage/roadmapList/RoadmapList.tsx
+++ b/client/src/components/roadmapListPage/roadmapList/RoadmapList.tsx
@@ -15,6 +15,7 @@ const RoadmapList = ({ selectedCategoryId }: RoadmapListProps) => {
   const moveRoadmapCreatePage = () => {
     navigate('/roadmap-create');
   };
+
   return (
     <S.RoadmapList>
       {roadmapList?.map((item) => (

--- a/client/src/components/roadmapListPage/roadmapList/RoadmapList.tsx
+++ b/client/src/components/roadmapListPage/roadmapList/RoadmapList.tsx
@@ -13,7 +13,7 @@ const RoadmapList = ({ selectedCategoryId }: RoadmapListProps) => {
   return (
     <S.RoadmapList>
       {roadmapList?.map((item) => (
-        <RoadmapItem key={item.roadmapId} item={item} />
+        <RoadmapItem key={item.roadmapId} item={item} roadmapId={item.roadmapId} />
       ))}
     </S.RoadmapList>
   );

--- a/client/src/components/roadmapListPage/roadmapList/RoadmapList.tsx
+++ b/client/src/components/roadmapListPage/roadmapList/RoadmapList.tsx
@@ -2,6 +2,7 @@ import { useRoadmapList } from '@hooks/queries/roadmap';
 import RoadmapItem from '@components/_common/roadmapItem/RoadmapItem';
 import * as S from './RoadmapList.styles';
 import { SelectedCategoryId } from '@myTypes/roadmap/internal';
+import { useNavigate } from 'react-router-dom';
 
 type RoadmapListProps = {
   selectedCategoryId: SelectedCategoryId;
@@ -9,12 +10,19 @@ type RoadmapListProps = {
 
 const RoadmapList = ({ selectedCategoryId }: RoadmapListProps) => {
   const roadmapList = useRoadmapList(selectedCategoryId);
+  const navigate = useNavigate();
 
+  const moveRoadmapCreatePage = () => {
+    navigate('/roadmap-create');
+  };
   return (
     <S.RoadmapList>
       {roadmapList?.map((item) => (
         <RoadmapItem key={item.roadmapId} item={item} roadmapId={item.roadmapId} />
       ))}
+      <S.CreateRoadmapButton onClick={moveRoadmapCreatePage}>
+        로드맵 생성하러가기
+      </S.CreateRoadmapButton>
     </S.RoadmapList>
   );
 };

--- a/client/src/hooks/queries/goalRoom.ts
+++ b/client/src/hooks/queries/goalRoom.ts
@@ -10,6 +10,7 @@ import {
   getGoalRoomTodos,
   postCreateNewCertificationFeed,
   getGoalRoomList,
+  getGoalRoomDetail,
 } from '@apis/goalRoom';
 import { useSuspendedQuery } from '@hooks/queries/useSuspendedQuery';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -17,6 +18,13 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 export const useGoalRoomList = (params: GoalRoomListRequest) => {
   const { data } = useSuspendedQuery(['goalRoomList'], () => getGoalRoomList(params));
   return { goalRoomList: data };
+};
+
+export const useGoalRoomDetail = (goalRoomId: number) => {
+  const { data } = useSuspendedQuery(['goalRoomDetail'], () =>
+    getGoalRoomDetail(goalRoomId)
+  );
+  return { goalRoomInfo: data };
 };
 
 export const useFetchGoalRoom = (goalRoomId: string) => {

--- a/client/src/hooks/queries/roadmap.ts
+++ b/client/src/hooks/queries/roadmap.ts
@@ -1,6 +1,6 @@
 import { SelectedCategoryId } from '@myTypes/roadmap/internal';
 import { RoadmapValueType } from '@/myTypes/roadmap/remote';
-import { getRoadmapById, getRoadmapList, postCreateRoadmap } from '@apis/roadmap';
+import { getRoadmapDetail, getRoadmapList, postCreateRoadmap } from '@apis/roadmap';
 import QUERY_KEYS from '@constants/@queryKeys/queryKeys';
 import { useSuspendedQuery } from '@hooks/queries/useSuspendedQuery';
 import { useMutation } from '@tanstack/react-query';
@@ -21,10 +21,10 @@ export const useRoadmapList = (
 
 export const useRoadmapDetail = (id: number) => {
   const { data } = useSuspendedQuery([QUERY_KEYS.roadmap.detail, id], () =>
-    getRoadmapById(id)
+    getRoadmapDetail(id)
   );
 
-  return data;
+  return { roadmapInfo: data };
 };
 
 export const useCreateRoadmap = () => {

--- a/client/src/hooks/roadmap/useCollectRoadmapData.ts
+++ b/client/src/hooks/roadmap/useCollectRoadmapData.ts
@@ -2,6 +2,7 @@ import { DummyCategoryType } from '@/components/roadmapCreatePage/category/Categ
 import { DummyDifficultyType } from '@/components/roadmapCreatePage/difficulty/Difficulty';
 import { RoadmapValueType } from '@/myTypes/roadmap/remote';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useCreateRoadmap } from '../queries/roadmap';
 
 export const useCollectRoadmapData = () => {
@@ -16,6 +17,7 @@ export const useCollectRoadmapData = () => {
     roadmapNodes: [],
   });
   const [isSumbited, setIsSubmited] = useState(false);
+  const navigate = useNavigate();
   const { createRoadmap } = useCreateRoadmap();
 
   const getSelectedCategoryId = (category: keyof DummyCategoryType | null) => {
@@ -84,6 +86,7 @@ export const useCollectRoadmapData = () => {
   useEffect(() => {
     if (isSumbited) {
       createRoadmap(roadmapValue);
+      navigate('/');
     }
   }, [isSumbited]);
 

--- a/client/src/hooks/roadmap/useCollectRoadmapData.ts
+++ b/client/src/hooks/roadmap/useCollectRoadmapData.ts
@@ -43,8 +43,8 @@ export const useCollectRoadmapData = () => {
     });
   };
 
-  const getRoadmapItemTitle = (
-    e: React.ChangeEvent<HTMLInputElement>,
+  const getRoadmapItemTitle = <T extends HTMLInputElement | HTMLTextAreaElement>(
+    e: React.ChangeEvent<T>,
     itemId: number
   ) => {
     setRoadmapValue((prev) => {

--- a/client/src/mocks/fixtures/roadmapList.ts
+++ b/client/src/mocks/fixtures/roadmapList.ts
@@ -1,7 +1,7 @@
 import { RoadmapListResponse } from '@myTypes/roadmap/remote';
 
 type RoadmapsFixture = {
-  data: RoadmapListResponse;
+  data: any;
   getBrowsedRoadmaps: () => RoadmapListResponse;
 };
 

--- a/client/src/myTypes/goalRoom/internal.ts
+++ b/client/src/myTypes/goalRoom/internal.ts
@@ -1,5 +1,3 @@
-import { GoalRoomDetailResponse } from './remote';
-
 export type GoalRoomRecruitmentStatus =
   | 'RECRUITING'
   | 'RUNNING'
@@ -32,4 +30,34 @@ export type CheckFeed = {
   imageUrl: string;
 };
 
-export type GoalRoomDetailType = GoalRoomDetailResponse;
+type GoalRoomLeaderType = {
+  id: number;
+  name: string;
+};
+
+export type GoalRoomDetailType = {
+  goalRoomId: number;
+  name: string;
+  currentMemberCount: number;
+  limitedMemberCount: number;
+  createdAt: number[];
+  startDate: number[];
+  endDate: number[];
+  goalRoomLeader: GoalRoomLeaderType;
+};
+
+type GoalRoomNodesType = {
+  title: string;
+  startDate: number[];
+  endDate: number[];
+  checkCount: number;
+};
+
+export type GoalRoomInfoType = {
+  name: string;
+  currentMemberCount: number;
+  limitedMemberCount: number;
+  goalRoomNodes: GoalRoomNodesType[];
+  period: number;
+  isJoined: boolean;
+};

--- a/client/src/myTypes/goalRoom/remote.ts
+++ b/client/src/myTypes/goalRoom/remote.ts
@@ -1,5 +1,7 @@
 import {
   CheckFeed,
+  GoalRoomDetailType,
+  GoalRoomInfoType,
   GoalRoomRecruitmentStatus,
   GoalRoomRoadmap,
   GoalRoomTodo,
@@ -43,21 +45,10 @@ export type CreateGoalRoomRequest = {
   goalRoomRoadmapNodeRequests: GoalRoomRoadmapNodeRequestsType[];
 };
 
-type GoalRoomLeaderType = {
-  id: number;
-  name: string;
-};
+export type GoalRoomDetailResponse = GoalRoomDetailType;
 
-export type GoalRoomDetailResponse = {
-  goalRoomId: number;
-  name: string;
-  currentMemberCount: number;
-  limitedMemberCount: number;
-  createdAt: number[];
-  startDate: number[];
-  endDate: number[];
-  goalRoomLeader: GoalRoomLeaderType;
-};
+export type GoalRoomInfoResponse = GoalRoomInfoType;
+
 export type newTodoPayload = {
   content: string;
   startDate: string;

--- a/client/src/myTypes/roadmap/internal.ts
+++ b/client/src/myTypes/roadmap/internal.ts
@@ -43,6 +43,18 @@ export type RoadmapItemType = {
   tags: TagType[];
 };
 
+export type RoadmapDetailType = {
+  roadmapId: number;
+  category: CategoryType;
+  roadmapTitle: string;
+  introduction: string;
+  creator: CreatorType;
+  content: ContentType;
+  difficulty: keyof typeof DIFFICULTY_ICON_NAME;
+  recommendedRoadmapPeriod: number;
+  tags: TagType[];
+};
+
 export type PatternType = {
   rule: RegExp;
   message: string;

--- a/client/src/myTypes/roadmap/remote.ts
+++ b/client/src/myTypes/roadmap/remote.ts
@@ -1,9 +1,10 @@
 import type {
-  CreatorType,
-  CategoryType,
-  ContentType,
-  TagType,
+  // CreatorType,
+  // CategoryType,
+  // ContentType,
+  // TagType,
   RoadmapItemType,
+  RoadmapDetailType,
 } from './internal';
 
 type RoadmapNodes = {
@@ -21,18 +22,8 @@ export type RoadmapValueType = {
   roadmapNodes: RoadmapNodes[];
 };
 
-export type RoadmapListResponse = RoadmapItemType[];
+export type RoadmapListResponse = RoadmapItemType;
 
-export type RoadmapDetailResponse = {
-  roadmapId: number;
-  category: CategoryType;
-  roadmapTitle: string;
-  introduction: string;
-  creator: CreatorType;
-  content: ContentType;
-  difficulty: string;
-  recommendedRoadmapPeriod: number;
-  tags: TagType[];
-};
+export type RoadmapDetailResponse = RoadmapDetailType;
 
 export type RoadmapValueRequest = RoadmapValueType;


### PR DESCRIPTION
## 📌 작업 이슈 번호
CK-130


## ✨ 작업 내용
- 골룸 단일조회 UI
- 골룸 단일조회 서버연결
- 로드맵 목록조회 api로직 수정
- 로드맵 단일조회 서버연결
- 로드맵 생성페이지로 갈 수 있는 경로 생성
- 골룸 생성페이지로 갈 수 있는 경로 생성
- 그밖의 라우팅 처리


## 💬 리뷰어에게 남길 멘트
리팩토링 많이 필요해요


## 🚀 요구사항 분석


