### PR TITLE
fix: 사용자 골룸 단일 조회 버그 fix

### DIFF
--- a/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomReadService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomReadService.java
@@ -3,13 +3,13 @@ package co.kirikiri.service;
 import co.kirikiri.domain.goalroom.CheckFeed;
 import co.kirikiri.domain.goalroom.GoalRoom;
 import co.kirikiri.domain.goalroom.GoalRoomMember;
-import co.kirikiri.domain.goalroom.GoalRoomToDos;
 import co.kirikiri.domain.goalroom.GoalRoomRoadmapNode;
 import co.kirikiri.domain.goalroom.GoalRoomStatus;
+import co.kirikiri.domain.goalroom.GoalRoomToDos;
 import co.kirikiri.domain.member.Member;
 import co.kirikiri.domain.member.vo.Identifier;
-import co.kirikiri.exception.ForbiddenException;
 import co.kirikiri.exception.BadRequestException;
+import co.kirikiri.exception.ForbiddenException;
 import co.kirikiri.exception.NotFoundException;
 import co.kirikiri.persistence.goalroom.CheckFeedRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomMemberRepository;
@@ -111,7 +111,7 @@ public class GoalRoomReadService {
         final Member member = findMemberByIdentifier(new Identifier(identifier));
         validateMemberInGoalRoom(goalRoom, member);
 
-        final GoalRoomRoadmapNode currentGoalRoomRoadmapNode = goalRoom.getNodeByDate(LocalDate.now()).get();
+        final GoalRoomRoadmapNode currentGoalRoomRoadmapNode = findCurrentGoalRoomNode(goalRoom);
         final List<CheckFeed> checkFeeds = checkFeedRepository.findByGoalRoomRoadmapNode(currentGoalRoomRoadmapNode);
         final List<Long> checkedTodoIds = findMemberCheckedGoalRoomToDoIds(goalRoomId, identifier);
         return GoalRoomMapper.convertToMemberGoalRoomResponse(goalRoom, checkFeeds, checkedTodoIds);
@@ -131,6 +131,11 @@ public class GoalRoomReadService {
         if (!goalRoom.isGoalRoomMember(member)) {
             throw new BadRequestException("해당 골룸에 참여하지 않은 사용자입니다.");
         }
+    }
+
+    private GoalRoomRoadmapNode findCurrentGoalRoomNode(final GoalRoom goalRoom) {
+        return goalRoom.getNodeByDate(LocalDate.now())
+                .orElse(null);
     }
 
     public List<MemberGoalRoomForListResponse> findMemberGoalRooms(final String identifier) {

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomReadIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomReadIntegrationTest.java
@@ -310,16 +310,12 @@ class GoalRoomReadIntegrationTest extends IntegrationTest {
                 List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")));
         final RoadmapNode 로드맵_노드 = roadmapNodeRepository.findAll().get(0);
 
-        final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
+        final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 십일_후, 이십일_후);
         final List<GoalRoomRoadmapNodeRequest> 골룸_노드_별_기간_요청 = List.of(
-                new GoalRoomRoadmapNodeRequest(로드맵_노드.getId(), 정상적인_골룸_노드_인증_횟수, 오늘, 십일_후));
-        final GoalRoomCreateRequest 골룸_생성_요청 = new GoalRoomCreateRequest(로드맵_아이디, 정상적인_골룸_이름, 정상적인_골룸_제한_인원, 골룸_투두_요청,
-                골룸_노드_별_기간_요청);
+                new GoalRoomRoadmapNodeRequest(로드맵_노드.getId(), 정상적인_골룸_노드_인증_횟수, 십일_후, 이십일_후));
+        final GoalRoomCreateRequest 골룸_생성_요청 = new GoalRoomCreateRequest(로드맵_아이디, 정상적인_골룸_이름,
+                정상적인_골룸_제한_인원, 골룸_투두_요청, 골룸_노드_별_기간_요청);
         final Long 골룸_아이디 = 골룸_생성(골룸_생성_요청, 액세스_토큰);
-
-        회원가입을_한다("identifier2", "password2@", "팔로워", "010-1234-5555", GenderType.FEMALE, LocalDate.of(2000, 1, 1));
-        final String 팔로워_액세스_토큰 = 로그인을_한다("identifier2", "password2@");
-        골룸_참가_요청(골룸_아이디, 팔로워_액세스_토큰);
 
         //when
         final ExtractableResponse<Response> 사용자_단일_골룸_조회_응답 = given().log().all()
@@ -332,10 +328,11 @@ class GoalRoomReadIntegrationTest extends IntegrationTest {
 
         //then
         final MemberGoalRoomResponse 예상되는_응답 = new MemberGoalRoomResponse(정상적인_골룸_이름, "RECRUITING", 1L,
-                2, 정상적인_골룸_제한_인원, 오늘, 십일_후, 1L,
+                1, 정상적인_골룸_제한_인원, 십일_후, 이십일_후, 1L,
                 new GoalRoomRoadmapNodesResponse(false, false,
-                        List.of(new GoalRoomRoadmapNodeResponse(1L, "로드맵 1주차", 오늘, 십일_후, 정상적인_골룸_노드_인증_횟수))),
-                List.of(new GoalRoomTodoResponse(1L, 정상적인_골룸_투두_컨텐츠, 오늘, 십일_후, new GoalRoomToDoCheckResponse(false))),
+                        List.of(new GoalRoomRoadmapNodeResponse(1L, "로드맵 1주차", 십일_후, 이십일_후, 정상적인_골룸_노드_인증_횟수))),
+                List.of(new GoalRoomTodoResponse(1L, 정상적인_골룸_투두_컨텐츠, 십일_후, 이십일_후,
+                        new GoalRoomToDoCheckResponse(false))),
                 Collections.emptyList());
         final MemberGoalRoomResponse 요청_응답값 = objectMapper.readValue(사용자_단일_골룸_조회_응답.asString(), new TypeReference<>() {
         });


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-133](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-133)


## ✨ 작업 내용
- 참가한 골룸이 시작하지 않았을 때 사용자 골룸 단일 조회 시 인증 피드를 받아오지 못해 발생한 버그 해결


## 💬 리뷰어에게 남길 멘트
- 인증 피드 추가 메서드와 `getGoalRoomNodeByDate`를 공유해서 생긴 버그. 예외 처리를 도메인에서 하는 것이 아닌 Optional로 포장해서 서비스까지 넘긴 뒤에 메서드에서 처리했습니다.


## 🚀 요구사항 분석
- 사용자가 참가한 골룸이 시작하기 전이라도 단일 페이지를 조회할 수 있도록 수정한다

