### PR TITLE
[feat/CK-116] 골룸의 인증 피드를 전체 조회하는 기능을 구현한다

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = backend/kirikiri/src/main/resources/properties
 	url = https://github.com/co-kirikiri-backend/co-kirikiri-property
 	branch = main
+[submodule "backend/kirikiri/src/main/resources/properties"]
+	path = backend/kirikiri/src/main/resources/properties
+	url = https://github.com/co-kirikiri-backend/co-kirikiri-property
+	branch = main

--- a/backend/kirikiri/src/docs/asciidoc/goalroom.adoc
+++ b/backend/kirikiri/src/docs/asciidoc/goalroom.adoc
@@ -142,3 +142,18 @@ operation::goal-room-create-api-test/골룸_투두_추가시_리더가_아닌_�
 === *6-6* 실패 - 골룸 투두 추가시 컨텐츠가 250글자가 넘을 경우
 
 operation::goal-room-create-api-test/골룸_투두_추가시_컨텐츠가_250글자가_넘을_경우[snippets='http-request,http-response,request-headers,path-parameters,response-fields']
+
+[[골룸인증피드전체조회-API]]
+== *7. 골룸 인증 피드 전체 조회 API*
+
+=== *7-1* 성공
+
+operation::goal-room-read-api-test/골룸의_인증피드를_전체_조회한다[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
+=== *7-2* 실패 - 골룸 인증 피드 전체 조회 시 존재하지 않는 골룸인 경우
+
+operation::goal-room-read-api-test/골룸_인증피드_전체_조회_시_존재하지_않는_골룸일_경우_예외가_발생한다[snippets='http-request,http-response,response-fields']
+
+=== *7-3* 실패 - 골룸 인증 피드 전체 조회 시 해당 골룸에 참여하지 않은 사용자인 경우
+
+operation::goal-room-read-api-test/골룸_인증피드_전체_조회_시_골룸에_참여하지_않은_사용자일_경우_예외가_발생한다[snippets='http-request,http-response,response-fields']

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/GoalRoomController.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/GoalRoomController.java
@@ -8,6 +8,7 @@ import co.kirikiri.service.dto.goalroom.request.CheckFeedRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomCreateRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomTodoRequest;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomCertifiedResponse;
+import co.kirikiri.service.dto.goalroom.response.GoalRoomCheckFeedResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomMemberResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomResponse;
 import jakarta.validation.Valid;
@@ -86,5 +87,14 @@ public class GoalRoomController {
     public ResponseEntity<List<GoalRoomMemberResponse>> findGoalRoomMembers(@PathVariable final Long goalRoomId) {
         final List<GoalRoomMemberResponse> goalRoomMembers = goalRoomReadService.findGoalRoomMembers(goalRoomId);
         return ResponseEntity.ok(goalRoomMembers);
+    }
+
+    @Authenticated
+    @GetMapping("/{goalRoomId}/checkFeeds")
+    public ResponseEntity<List<GoalRoomCheckFeedResponse>> findGoalRoomCheckFeeds(
+            @MemberIdentifier final String identifier,
+            @PathVariable("goalRoomId") final Long goalRoomId) {
+        final List<GoalRoomCheckFeedResponse> response = goalRoomReadService.findGoalRoomCheckFeeds(identifier, goalRoomId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/BaseCreatedTimeEntity.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/BaseCreatedTimeEntity.java
@@ -14,4 +14,8 @@ public class BaseCreatedTimeEntity extends BaseEntity {
     @CreatedDate
     @Column(nullable = false, updatable = false)
     protected LocalDateTime createdAt;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/goalroom/CheckFeed.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/goalroom/CheckFeed.java
@@ -55,4 +55,8 @@ public class CheckFeed extends BaseCreatedTimeEntity {
     public String getDescription() {
         return description;
     }
+
+    public GoalRoomMember getGoalRoomMember() {
+        return goalRoomMember;
+    }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedQueryRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedQueryRepository.java
@@ -1,0 +1,11 @@
+package co.kirikiri.persistence.goalroom;
+
+import co.kirikiri.domain.goalroom.CheckFeed;
+import co.kirikiri.domain.goalroom.GoalRoomRoadmapNode;
+import java.util.List;
+
+public interface CheckFeedQueryRepository {
+
+    List<CheckFeed> findByGoalRoomRoadmapNodeWithGoalRoomMemberAndMemberImage(
+            final GoalRoomRoadmapNode goalRoomRoadmapNode);
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedQueryRepositoryImpl.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedQueryRepositoryImpl.java
@@ -1,0 +1,33 @@
+package co.kirikiri.persistence.goalroom;
+
+import static co.kirikiri.domain.goalroom.QCheckFeed.checkFeed;
+import static co.kirikiri.domain.goalroom.QGoalRoomMember.goalRoomMember;
+import static co.kirikiri.domain.member.QMember.member;
+import static co.kirikiri.domain.member.QMemberImage.memberImage;
+
+import co.kirikiri.domain.goalroom.CheckFeed;
+import co.kirikiri.domain.goalroom.GoalRoomRoadmapNode;
+import co.kirikiri.persistence.QuerydslRepositorySupporter;
+import java.util.List;
+
+public class CheckFeedQueryRepositoryImpl extends QuerydslRepositorySupporter implements CheckFeedQueryRepository {
+
+    public CheckFeedQueryRepositoryImpl() {
+        super(CheckFeed.class);
+    }
+
+    @Override
+    public List<CheckFeed> findByGoalRoomRoadmapNodeWithGoalRoomMemberAndMemberImage(
+            final GoalRoomRoadmapNode goalRoomRoadmapNode) {
+        return selectFrom(checkFeed)
+                .innerJoin(checkFeed.goalRoomMember, goalRoomMember)
+                .fetchJoin()
+                .innerJoin(goalRoomMember.member, member)
+                .fetchJoin()
+                .innerJoin(member.image, memberImage)
+                .fetchJoin()
+                .where(checkFeed.goalRoomRoadmapNode.eq(goalRoomRoadmapNode))
+                .orderBy(checkFeed.createdAt.desc())
+                .fetch();
+    }
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface CheckFeedRepository extends JpaRepository<CheckFeed, Long> {
+public interface CheckFeedRepository extends JpaRepository<CheckFeed, Long>, CheckFeedQueryRepository {
 
     @Query("SELECT cf"
             + " FROM CheckFeed cf"

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomQueryRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomQueryRepository.java
@@ -19,4 +19,6 @@ public interface GoalRoomQueryRepository {
     List<GoalRoom> findAllByStartDateNow();
 
     List<GoalRoom> findAllByStartDateWithGoalRoomRoadmapNode();
+
+    Optional<GoalRoom> findByIdWithNodes(Long goalRoomId);
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomQueryRepositoryImpl.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomQueryRepositoryImpl.java
@@ -73,6 +73,15 @@ public class GoalRoomQueryRepositoryImpl extends QuerydslRepositorySupporter imp
                 .fetch();
     }
 
+    @Override
+    public Optional<GoalRoom> findByIdWithNodes(final Long goalRoomId) {
+        return Optional.ofNullable(selectFrom(goalRoom)
+                .innerJoin(goalRoom.goalRoomRoadmapNodes.values, goalRoomRoadmapNode)
+                .fetchJoin()
+                .where(goalRoomIdCond(goalRoomId))
+                .fetchOne());
+    }
+
     private BooleanExpression goalRoomIdCond(final Long goalRoomId) {
         return goalRoom.id.eq(goalRoomId);
     }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomReadService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomReadService.java
@@ -1,16 +1,22 @@
 package co.kirikiri.service;
 
+import co.kirikiri.domain.goalroom.CheckFeed;
 import co.kirikiri.domain.goalroom.GoalRoom;
 import co.kirikiri.domain.goalroom.GoalRoomMember;
+import co.kirikiri.domain.goalroom.GoalRoomRoadmapNode;
 import co.kirikiri.domain.member.vo.Identifier;
+import co.kirikiri.exception.BadRequestException;
 import co.kirikiri.exception.NotFoundException;
+import co.kirikiri.persistence.goalroom.CheckFeedRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomPendingMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomRepository;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomCertifiedResponse;
+import co.kirikiri.service.dto.goalroom.response.GoalRoomCheckFeedResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomMemberResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomResponse;
 import co.kirikiri.service.mapper.GoalRoomMapper;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +30,7 @@ public class GoalRoomReadService {
     private final GoalRoomRepository goalRoomRepository;
     private final GoalRoomMemberRepository goalRoomMemberRepository;
     private final GoalRoomPendingMemberRepository goalRoomPendingMemberRepository;
+    private final CheckFeedRepository checkFeedRepository;
 
     public GoalRoomResponse findGoalRoom(final Long goalRoomId) {
         final GoalRoom goalRoom = findGoalRoomById(goalRoomId);
@@ -59,5 +66,24 @@ public class GoalRoomReadService {
         if (goalRoomMembers.isEmpty()) {
             throw new NotFoundException("존재하지 않는 골룸입니다. goalRoomId = " + goalRoomId);
         }
+    }
+
+    public List<GoalRoomCheckFeedResponse> findGoalRoomCheckFeeds(final String identifier, final Long goalRoomId) {
+        final GoalRoom goalRoom = findGoalRoomWithNodesById(goalRoomId);
+        validateJoinedMemberInRunningGoalRoom(goalRoom, identifier);
+        final GoalRoomRoadmapNode currentGoalRoomRoadmapNode = goalRoom.getNodeByDate(LocalDate.now());
+        final List<CheckFeed> checkFeeds = checkFeedRepository.findByGoalRoomRoadmapNodeWithGoalRoomMemberAndMemberImage(
+                currentGoalRoomRoadmapNode);
+        return GoalRoomMapper.convertToGoalRoomCheckFeedResponse(checkFeeds);
+    }
+
+    private GoalRoom findGoalRoomWithNodesById(final Long goalRoomId) {
+        return goalRoomRepository.findByIdWithNodes(goalRoomId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 골룸입니다. goalRoomId = " + goalRoomId));
+    }
+
+    private void validateJoinedMemberInRunningGoalRoom(final GoalRoom goalRoom, final String identifier) {
+        goalRoomMemberRepository.findByGoalRoomAndMemberIdentifier(goalRoom, new Identifier(identifier))
+                .orElseThrow(() -> new BadRequestException("골룸에 참여하지 않은 회원입니다."));
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/dto/goalroom/response/CheckFeedResponse.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/dto/goalroom/response/CheckFeedResponse.java
@@ -1,0 +1,12 @@
+package co.kirikiri.service.dto.goalroom.response;
+
+import java.time.LocalDateTime;
+
+public record CheckFeedResponse(
+        Long id,
+        String imageUrl,
+        String description,
+        LocalDateTime createdAt
+) {
+
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/dto/goalroom/response/GoalRoomCheckFeedResponse.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/dto/goalroom/response/GoalRoomCheckFeedResponse.java
@@ -1,0 +1,10 @@
+package co.kirikiri.service.dto.goalroom.response;
+
+import co.kirikiri.service.dto.member.response.MemberNameAndImageResponse;
+
+public record GoalRoomCheckFeedResponse(
+        MemberNameAndImageResponse member,
+        CheckFeedResponse checkFeed
+) {
+
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/dto/member/response/MemberNameAndImageResponse.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/dto/member/response/MemberNameAndImageResponse.java
@@ -1,0 +1,9 @@
+package co.kirikiri.service.dto.member.response;
+
+public record MemberNameAndImageResponse(
+        Long id,
+        String nickname,
+        String imageUrl
+) {
+
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
@@ -1,5 +1,6 @@
 package co.kirikiri.service.mapper;
 
+import co.kirikiri.domain.goalroom.CheckFeed;
 import co.kirikiri.domain.goalroom.GoalRoom;
 import co.kirikiri.domain.goalroom.GoalRoomMember;
 import co.kirikiri.domain.goalroom.GoalRoomRoadmapNode;
@@ -10,6 +11,7 @@ import co.kirikiri.domain.goalroom.vo.GoalRoomTodoContent;
 import co.kirikiri.domain.goalroom.vo.LimitedMemberCount;
 import co.kirikiri.domain.goalroom.vo.Period;
 import co.kirikiri.domain.member.Member;
+import co.kirikiri.domain.member.MemberImage;
 import co.kirikiri.persistence.goalroom.dto.GoalRoomFilterType;
 import co.kirikiri.persistence.goalroom.dto.RoadmapGoalRoomsFilterType;
 import co.kirikiri.service.dto.CustomPageRequest;
@@ -20,11 +22,14 @@ import co.kirikiri.service.dto.goalroom.GoalRoomRoadmapNodeDto;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomCreateRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomRoadmapNodeRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomTodoRequest;
+import co.kirikiri.service.dto.goalroom.response.CheckFeedResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomCertifiedResponse;
+import co.kirikiri.service.dto.goalroom.response.GoalRoomCheckFeedResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomForListResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomMemberResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomNodeResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomResponse;
+import co.kirikiri.service.dto.member.response.MemberNameAndImageResponse;
 import co.kirikiri.service.dto.member.response.MemberResponse;
 import co.kirikiri.service.dto.roadmap.RoadmapGoalRoomsFilterTypeDto;
 import co.kirikiri.service.dto.roadmap.response.RoadmapGoalRoomResponse;
@@ -153,5 +158,20 @@ public class GoalRoomMapper {
                 goalRoom.getCurrentPendingMemberCount(),
                 goalRoom.getLimitedMemberCount().getValue(), goalRoom.getCreatedAt(), goalRoom.getStartDate(),
                 goalRoom.getEndDate(), convertToMemberResponse(goalRoom));
+    }
+
+    public static List<GoalRoomCheckFeedResponse> convertToGoalRoomCheckFeedResponse(final List<CheckFeed> checkFeeds) {
+        return checkFeeds.stream()
+                .map(checkFeed -> {
+                    final GoalRoomMember goalRoomMember = checkFeed.getGoalRoomMember();
+                    final Member member = goalRoomMember.getMember();
+                    final MemberImage memberImage = member.getImage();
+                    return new GoalRoomCheckFeedResponse(
+                            new MemberNameAndImageResponse(member.getId(), member.getNickname().getValue(),
+                                    memberImage.getServerFilePath()),
+                            new CheckFeedResponse(checkFeed.getId(), checkFeed.getServerFilePath(),
+                                    checkFeed.getDescription(), checkFeed.getCreatedAt()));
+                })
+                .toList();
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/CheckFeedRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/CheckFeedRepositoryTest.java
@@ -16,6 +16,7 @@ import co.kirikiri.domain.goalroom.vo.Period;
 import co.kirikiri.domain.member.EncryptedPassword;
 import co.kirikiri.domain.member.Gender;
 import co.kirikiri.domain.member.Member;
+import co.kirikiri.domain.member.MemberImage;
 import co.kirikiri.domain.member.MemberProfile;
 import co.kirikiri.domain.member.vo.Identifier;
 import co.kirikiri.domain.member.vo.Nickname;
@@ -218,11 +219,71 @@ class CheckFeedRepositoryTest {
         );
     }
 
+    @Test
+    void 골룸의_특정_노드_동안_등록된_인증_피드들을_등록한_사용자의_정보와_함께_조회한다() {
+        //given
+        final Member creator = 사용자를_저장한다("cokiri", "코끼리");
+        final RoadmapCategory category = 카테고리를_저장한다("여가");
+        final Roadmap roadmap = 로드맵을_저장한다(creator, category);
+
+        final RoadmapContents roadmapContents = roadmap.getContents();
+        final RoadmapContent targetRoadmapContent = roadmapContents.getValues().get(0);
+        final Member member = 사용자를_저장한다("participant", "참여자");
+        final GoalRoom goalRoom = 골룸을_저장한다(targetRoadmapContent, member);
+
+        final GoalRoomMember leader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom, creator);
+        final GoalRoomMember joinedMember = new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), goalRoom,
+                member);
+        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+
+        final GoalRoomRoadmapNode goalRoomRoadmapNode1 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(0);
+        final GoalRoomRoadmapNode goalRoomRoadmapNode2 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(1);
+
+        인증_피드를_저장한다(goalRoomRoadmapNode1, joinedMember);
+        인증_피드를_저장한다(goalRoomRoadmapNode1, joinedMember);
+        인증_피드를_저장한다(goalRoomRoadmapNode1, joinedMember);
+        인증_피드를_저장한다(goalRoomRoadmapNode2, leader);
+        인증_피드를_저장한다(goalRoomRoadmapNode2, leader);
+        인증_피드를_저장한다(goalRoomRoadmapNode2, leader);
+
+        //when
+        final List<CheckFeed> checkFeeds1 = checkFeedRepository.findByGoalRoomRoadmapNodeWithGoalRoomMemberAndMemberImage(
+                goalRoomRoadmapNode1);
+        final List<CheckFeed> checkFeeds2 = checkFeedRepository.findByGoalRoomRoadmapNodeWithGoalRoomMemberAndMemberImage(
+                goalRoomRoadmapNode2);
+
+        //then
+        final CheckFeed expected1 = new CheckFeed("src/test/resources/testImage", ImageContentType.JPEG,
+                "originalFileName", "인증 피드 본문", goalRoomRoadmapNode1, joinedMember);
+        final CheckFeed expected2 = new CheckFeed("src/test/resources/testImage", ImageContentType.JPEG,
+                "originalFileName", "인증 피드 본문", goalRoomRoadmapNode2, leader);
+
+        assertAll(
+                () -> assertThat(checkFeeds1).hasSize(3)
+                        .usingRecursiveComparison()
+                        .ignoringFields("id", "createdAt")
+                        .isEqualTo(List.of(expected1, expected1, expected1)),
+                () -> assertThat(checkFeeds1.get(0).getGoalRoomMember().getMember().getNickname().getValue())
+                        .isEqualTo("참여자"),
+                () -> assertThat(checkFeeds1.get(0).getGoalRoomMember().getMember().getImage().getServerFilePath())
+                        .isEqualTo("serverFilePath"),
+                () -> assertThat(checkFeeds2).hasSize(3)
+                        .usingRecursiveComparison()
+                        .ignoringFields("id", "createdAt")
+                        .isEqualTo(List.of(expected2, expected2, expected2)),
+                () -> assertThat(checkFeeds2.get(0).getGoalRoomMember().getMember().getNickname().getValue())
+                        .isEqualTo("코끼리"),
+                () -> assertThat(checkFeeds2.get(0).getGoalRoomMember().getMember().getImage().getServerFilePath())
+                        .isEqualTo("serverFilePath")
+        );
+    }
+
     private Member 사용자를_저장한다(final String identifier, final String nickname) {
+        final MemberImage memberImage = new MemberImage("originalFileName", "serverFilePath", ImageContentType.PNG);
         final MemberProfile memberProfile = new MemberProfile(Gender.MALE,
                 LocalDate.of(1990, 1, 1), "010-1234-5678");
         final Member creator = new Member(new Identifier(identifier), new EncryptedPassword(new Password("password1!")),
-                new Nickname(nickname), memberProfile);
+                new Nickname(nickname), memberImage, memberProfile);
         return memberRepository.save(creator);
     }
 


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-116](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-116)

## ✨ 작업 내용
- 골룸의 인증 피드를 전체 조회하는 기능을 구현했습니다.


## 💬 리뷰어에게 남길 멘트
- 구현하면서 크게 고민했던 부분이 없는것 같네요..! 간단한 기능이여서 금방 리뷰하실 수 있을 것 같아요!!
잘부탁드립니다🙇‍♀️


## 🚀 요구사항 분석
- [x]  골룸의 인증피드를 전체 조회한다.
    - [x]  현재 진행중인 노드에 해당하는 인증피드를 전체 조회한다.
    - [x]  이미지 id, 이미지 경로, 설명, 등록한 사용자 id, 등록한 사용자 닉네임, 등록한 사용자 프로필 이미지 경로, 등록한 날짜
    - [x]  최신순으로 조회한다.
- [x]  이미 시작한 골룸이여야 한다.
- [x]  사용자가 참여한 골룸이여야 한다.

