### PR TITLE
[feat/CK-78] 로드맵 생성 시 이미지를 추가를 구현한다

### DIFF
--- a/backend/kirikiri/src/docs/asciidoc/roadmap.adoc
+++ b/backend/kirikiri/src/docs/asciidoc/roadmap.adoc
@@ -18,113 +18,146 @@ endif::[]
 == *1. 로드맵 생성 API*
 
 === *1-1* 성공
-operation::roadmap-create-api-test/정상적으로_로드맵을_생성한다[snippets='http-request,http-response,request-headers,request-fields,response-headers']
+
+operation::roadmap-create-api-test/정상적으로_로드맵을_생성한다[snippets='http-request,http-response,request-headers,request-parts,request-part-jsonData-fields,response-headers']
 
 === *1-2* 실패 - 카테고리 아이디가 유효하지 않음
+
 operation::roadmap-create-api-test/로드맵_생성시_유효하지_않은_카테고리_아이디를_입력하면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-3* 실패 - 회원이 존재하지 않음
+
 operation::roadmap-create-api-test/로드맵_생성시_존재하지_않은_회원이면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-4* 실패 - 카테고리를 입력하지 않음
+
 operation::roadmap-create-api-test/로드맵_생성시_카테고리_아이디를_입력하지_않으면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-5* 실패 - 로드맵 제목을 입력하지 않음
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_제목을_입력하지_않으면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-6* 실패 - 로드맵 제목의 길이가 40보다 큼
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_제목을_입력하지_않으면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-7* 실패 - 로드맵 소개글을 입력하지 않음
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_소개글을_입력하지_않으면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-8* 실패 - 로드맵 소개글의 길이가 150보다 큼
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_소개글의_길이가_150보다_크면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-9* 실패 - 로드맵 본문의 길이가 2000보다 큼
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_본문의_길이가_2000보다_크면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-10* 실패 - 로드맵 추천 소요 기간을 입력하지 않음
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_추천_소요기간을_입력하지_않으면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-11* 실패 - 로드맵 추천 소요 기간이 0보다 작거나 1000보다 큼
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_추천_소요기간이_0보다_작거나_1000보다_크면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-12* 실패 - 로드맵 난이도를 입력하지 않음
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_난이도를_입력하지_않으면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-13* 실패 - 로드맵 노드의 제목을 입력하지 않음
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_노드의_제목을_입력하지_않으면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-14* 실패 - 로드맵 노드의 설명을 입력하지 않음
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_노드의_설명을_입력하지_않으면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-15* 실패 - 로드맵 노드의 제목의 길이가 40보다 큼
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_노드의_제목의_길이가_40보다_크면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-16* 실패 - 로드맵 노드의 설명의 길이가 2000보다 큼
+
 operation::roadmap-create-api-test/로드맵_생성시_로드맵_노드의_설명의_길이가_2000보다_크면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-17* 실패 - 로드맵 태그의 이름에 중복이 있음
+
 operation::roadmap-create-api-test/로드맵_생성시_중복된_태그_이름이_있으면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-18* 실패 - 로드맵 태그의 개수가 5개 초과임
+
 operation::roadmap-create-api-test/로드맵_생성시_태그_개수가_5개_초과면_예외가_발생한다[snippets='http-request,http-response']
 
 === *1-19* 실패 - 로드맵 태그의 이름이 1자 미만 10자 초과임
+
 operation::roadmap-create-api-test/로드맵_생성시_태그_이름이_1미만_10초과면_예외가_발생한다[snippets='http-request,http-response']
 
 [[로드맵목록조회-API]]
 == *2. 로드맵 목록 조회 API*
 
 === *2-1* 성공
+
 operation::roadmap-read-api-test/로드맵_목록을_조건에_따라_조회한다[snippets='http-request,http-response,response-fields']
 
 === *2-2* 실패 - 카테고리 아이디가 유효하지 않음
+
 operation::roadmap-read-api-test/로드맵_목록_조회시_유효하지_않은_카테고리_아이디를_보내면_예외가_발생한다[snippets='http-request,http-response,response-fields']
 
 [[로드맵카테고리목록조회-API]]
 == *3. 로드맵 카테고리 목록 조회 API*
 
 === *3-1* 성공
+
 operation::roadmap-read-api-test/로드맵_카테고리_목록을_조회한다[snippets='http-request,http-response,response-fields']
 
 [[로드맵조회-API]]
 == *4. 로드맵 조회 API*
 
 === *4-1* 성공
+
 [[로드맵단일조회-API]]
 == *4. 로드맵 단일 조회 API*
 
 === *4-1* 성공
+
 operation::roadmap-read-api-test/단일_로드맵_정보를_조회한다[snippets='http-request,http-response,path-parameters,response-fields']
 
 === *4-2* 실패 - 로드맵 아이디가 유효하지 않음
+
 operation::roadmap-read-api-test/존재하지_않는_로드맵_아이디로_요청_시_예외를_반환한다[snippets='http-request,http-response,path-parameters,response-fields']
 
 [[로드맵리뷰생성-API]]
 == *5. 로드맵 리뷰 생성 API*
 
 === *5-1* 성공
+
 operation::roadmap-create-api-test/로드맵의_리뷰를_생성한다[snippets='http-request,path-parameters,request-headers,request-fields,http-response']
 
 === *5-2* 실패 - 유효하지 않은 로드맵 아이디인 경우
+
 operation::roadmap-create-api-test/로드맵_리뷰_생성시_존재하지_않은_로드맵이면_예외가_발생한다[snippets='http-request,http-response']
 
 === *5-3* 실패 - 별점이 null인 경우
+
 operation::roadmap-create-api-test/로드맵_리뷰_생성시_별점이_null이라면_예외가_발생한다[snippets='http-request,http-response']
 
 === *5-4* 실패 - 리뷰 내용이 1000자가 넘는 경우
+
 operation::roadmap-create-api-test/로드맵_리뷰_생성시_내용이_1000자가_넘으면_예외가_발생한다[snippets='http-request,http-response']
 
 === *5-5* 실패 - 리뷰 별점이 0~5 사이의 0.5씩 증가하는 값이 아닌 경우
+
 operation::roadmap-create-api-test/로드맵_리뷰_생성시_별점이_잘못된_값이면_예외가_발생한다[snippets='http-request,http-response']
 
 === *5-6* 실패 - 해당 로드맵의 생성자가 리뷰를 달려고 하는 경우
+
 operation::roadmap-create-api-test/로드맵_리뷰_생성시_로드맵_생성자가_리뷰를_달려고_하면_예외가_발생한다[snippets='http-request,http-response']
 
 === *5-7* 실패 - 로드맵을 완료한 골룸이 없는 경우
+
 operation::roadmap-create-api-test/로드맵_리뷰_생성시_완료한_골룸이_없으면_예외가_발생한다[snippets='http-request,http-response']
 
 === *5-8* 실패 - 해당 로드맵에 이미 리뷰를 단 적이 있는 경우
+
 operation::roadmap-create-api-test/로드맵_리뷰_생성시_이미_리뷰를_단적이_있으면_예외가_발생한다[snippets='http-request,http-response']

--- a/backend/kirikiri/src/main/java/co/kirikiri/common/config/AsyncConfig.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/common/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package co.kirikiri.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/common/config/WebConfig.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/common/config/WebConfig.java
@@ -2,12 +2,13 @@ package co.kirikiri.common.config;
 
 import co.kirikiri.common.interceptor.AuthInterceptor;
 import co.kirikiri.common.resolver.MemberIdentifierArgumentResolver;
-import java.util.List;
+import co.kirikiri.common.resolver.RoadmapSaveArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -15,6 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final AuthInterceptor authInterceptor;
     private final MemberIdentifierArgumentResolver memberIdentifierArgumentResolver;
+    private final RoadmapSaveArgumentResolver roadmapSaveArgumentResolver;
 
     @Override
     public void addInterceptors(final InterceptorRegistry interceptorRegistry) {
@@ -23,6 +25,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(roadmapSaveArgumentResolver);
         argumentResolvers.add(memberIdentifierArgumentResolver);
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/common/resolver/RoadmapSaveArgumentResolver.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/common/resolver/RoadmapSaveArgumentResolver.java
@@ -1,0 +1,108 @@
+package co.kirikiri.common.resolver;
+
+import co.kirikiri.exception.BadRequestException;
+import co.kirikiri.exception.ServerException;
+import co.kirikiri.service.dto.roadmap.request.RoadmapNodeSaveRequest;
+import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+import org.springframework.web.multipart.MultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RoadmapSaveArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.getParameterType().equals(RoadmapSaveRequest.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest nativeWebRequest, final WebDataBinderFactory binderFactory) throws MethodArgumentNotValidException {
+        final HttpServletRequest request = (HttpServletRequest) nativeWebRequest.getNativeRequest();
+        checkIsMultipart(request);
+        final MultipartHttpServletRequest multipartRequest = (MultipartHttpServletRequest) request;
+        final RoadmapSaveRequest roadmapSaveRequest = makeRoadmapSaveRequest(multipartRequest);
+        validateRequest(parameter, nativeWebRequest, binderFactory, roadmapSaveRequest);
+        return roadmapSaveRequest;
+    }
+
+    private void checkIsMultipart(final HttpServletRequest request) {
+        final MultipartResolver multipartResolver = new StandardServletMultipartResolver();
+        if (!multipartResolver.isMultipart(request)) {
+            throw new BadRequestException("multipart/form-data 형식으로 들어와야합니다.");
+        }
+    }
+
+    private RoadmapSaveRequest makeRoadmapSaveRequest(final MultipartHttpServletRequest multipartRequest) {
+        final String jsonData = extractJsonData(getJsonData(multipartRequest));
+        final RoadmapSaveRequest roadmapSaveRequest = bindRoadmapSaveRequest(jsonData);
+        for (final RoadmapNodeSaveRequest roadmapNode : roadmapSaveRequest.roadmapNodes()) {
+            final List<MultipartFile> images = multipartRequest.getFiles(roadmapNode.getTitle());
+            roadmapNode.setImages(images);
+        }
+        return roadmapSaveRequest;
+    }
+
+    private void validateRequest(final MethodParameter parameter, final NativeWebRequest nativeWebRequest, final WebDataBinderFactory binderFactory, final RoadmapSaveRequest roadmapSaveRequest) throws MethodArgumentNotValidException {
+        final WebDataBinder binder = findWebDataBinder(nativeWebRequest, binderFactory, roadmapSaveRequest);
+        binder.validate();
+
+        if (binder.getBindingResult().hasErrors()) {
+            throw new MethodArgumentNotValidException(parameter, binder.getBindingResult());
+        }
+    }
+
+    private WebDataBinder findWebDataBinder(final NativeWebRequest nativeWebRequest, final WebDataBinderFactory binderFactory, final RoadmapSaveRequest roadmapSaveRequest) {
+        try {
+            return binderFactory.createBinder(nativeWebRequest, roadmapSaveRequest, "roadmapSaveRequest");
+        } catch (final Exception e) {
+            throw new ServerException("Request Validation 실패");
+        }
+    }
+
+    private RoadmapSaveRequest bindRoadmapSaveRequest(final String jsonData) {
+        final RoadmapSaveRequest roadmapSaveRequest;
+        try {
+            roadmapSaveRequest = objectMapper.readValue(jsonData, RoadmapSaveRequest.class);
+        } catch (final JsonProcessingException e) {
+            throw new BadRequestException("바인딩 실패");
+        }
+        return roadmapSaveRequest;
+    }
+
+    private MultipartFile getJsonData(final MultipartHttpServletRequest multipartRequest) {
+        try {
+            return multipartRequest.getFile("jsonData");
+        } catch (final NullPointerException exception) {
+            throw new BadRequestException("로드맵 생성 시 jsonData는 필수입니다.");
+        }
+    }
+
+    private String extractJsonData(final MultipartFile file) {
+        try {
+            return new String(file.getBytes(), StandardCharsets.UTF_8);
+        } catch (final IOException e) {
+            throw new ServerException("Json 데이터 바인등에 실패 하였습니다.");
+        }
+    }
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/GlobalExceptionHandler.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/GlobalExceptionHandler.java
@@ -7,7 +7,6 @@ import co.kirikiri.exception.NotFoundException;
 import co.kirikiri.exception.ServerException;
 import co.kirikiri.service.dto.ErrorResponse;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import java.util.List;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -59,7 +59,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidFormatException.class)
     public ResponseEntity<ErrorResponse> handleInvalidFormatException(final InvalidFormatException exception) {
-        log.error(exception.getMessage(), exception);
+        log.warn(exception.getMessage(), exception);
         final ErrorResponse errorResponse = new ErrorResponse(exception.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
@@ -12,10 +12,9 @@ import co.kirikiri.service.dto.roadmap.response.RoadmapCategoryResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapForListResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import jakarta.validation.Valid;
-import java.net.URI;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -25,6 +24,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/roadmaps")
@@ -34,10 +35,9 @@ public class RoadmapController {
     private final RoadmapCreateService roadmapCreateService;
     private final RoadmapReadService roadmapReadService;
 
-    @PostMapping
     @Authenticated
-    public ResponseEntity<Void> create(@MemberIdentifier final String identifier,
-                                       @RequestBody @Valid final RoadmapSaveRequest request) {
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> create(final RoadmapSaveRequest request, @MemberIdentifier final String identifier) {
         final Long roadmapId = roadmapCreateService.create(request, identifier);
         return ResponseEntity.created(URI.create("/api/roadmaps/" + roadmapId)).build();
     }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/ImageContentType.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/ImageContentType.java
@@ -1,5 +1,8 @@
 package co.kirikiri.domain;
 
+import co.kirikiri.exception.BadRequestException;
+import java.util.Arrays;
+
 public enum ImageContentType {
 
     JPG("image/jpg"),
@@ -12,5 +15,21 @@ public enum ImageContentType {
 
     ImageContentType(final String extension) {
         this.extension = extension;
+    }
+
+    public static ImageContentType findByOriginalFileName(final String originalFilename) {
+        final String extension = findExtension(originalFilename);
+        return Arrays.stream(values())
+                .filter(it -> it.extension.contains(extension))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException("허용되지 않는 확장자입니다."));
+    }
+
+    private static String findExtension(final String originalFilename) {
+        try {
+            return originalFilename.substring(originalFilename.lastIndexOf('.') + 1);
+        } catch (final StringIndexOutOfBoundsException exception) {
+            throw new BadRequestException("파일 이름에 확장자가 포함되지 않았습니다.");
+        }
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/Roadmap.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/Roadmap.java
@@ -11,10 +11,11 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import java.util.Objects;
+import java.util.Optional;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -148,6 +149,10 @@ public class Roadmap extends BaseEntity {
 
     public void delete() {
         this.status = RoadmapStatus.DELETED;
+    }
+
+    public Optional<RoadmapContent> findLastRoadmapContent() {
+        return this.contents.findLastRoadmapContent();
     }
 
     public Member getCreator() {

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapContent.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapContent.java
@@ -8,10 +8,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.util.Optional;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -75,6 +75,10 @@ public class RoadmapContent extends BaseUpdatedTimeEntity {
 
     public Optional<RoadmapNode> findRoadmapNodeById(final Long id) {
         return nodes.findById(id);
+    }
+
+    public Optional<RoadmapNode> findRoadmapNodeByTitle(final String title) {
+        return nodes.findByTitle(title);
     }
 
     public String getContent() {

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapContents.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapContents.java
@@ -5,10 +5,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,6 +25,13 @@ public class RoadmapContents {
 
     public void add(final RoadmapContent content) {
         this.values.add(content);
+    }
+
+    public Optional<RoadmapContent> findLastRoadmapContent() {
+        if (values.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(values.get(values.size() - 1));
     }
 
     public List<RoadmapContent> getValues() {

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapNodeImages.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapNodeImages.java
@@ -5,13 +5,12 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
+import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
 @Embeddable
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class RoadmapNodeImages {
 
     @OneToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
@@ -24,6 +23,10 @@ public class RoadmapNodeImages {
 
     public void addAll(final RoadmapNodeImages images) {
         this.values.addAll(new ArrayList<>(images.values));
+    }
+
+    public void add(final RoadmapNodeImage roadmapNodeImage) {
+        this.values.add(roadmapNodeImage);
     }
 
     public List<RoadmapNodeImage> getValues() {

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapNodes.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapNodes.java
@@ -4,11 +4,11 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -43,7 +43,13 @@ public class RoadmapNodes {
 
     public Optional<RoadmapNode> findById(final Long roadmapNodeId) {
         return values.stream()
-                .filter(it -> roadmapNodeId.equals(it.getId()))
+                .filter(it -> it.getId().equals(roadmapNodeId))
+                .findAny();
+    }
+
+    public Optional<RoadmapNode> findByTitle(final String title) {
+        return values.stream()
+                .filter(it -> it.getTitle().equals(title))
                 .findAny();
     }
 

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/FilePathGenerator.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/FilePathGenerator.java
@@ -1,0 +1,5 @@
+package co.kirikiri.service;
+
+public interface FilePathGenerator {
+    String makeFilePath(final Long id, final ImageDirType dirType);
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/FilePathRandomGenerator.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/FilePathRandomGenerator.java
@@ -14,7 +14,7 @@ public class FilePathRandomGenerator implements FilePathGenerator {
     public String makeFilePath(final Long id, final ImageDirType dirType) {
         final LocalDate currentDate = LocalDate.now();
         final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(
-                String.format("yyyy%s/MMdd", DIRECTORY_SEPARATOR));
+                String.format("yyyy%sMMdd", DIRECTORY_SEPARATOR));
         final String dateString = currentDate.format(formatter);
 
         return dateString + DIRECTORY_SEPARATOR + dirType.getDirName() + DIRECTORY_SEPARATOR + id

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/FilePathRandomGenerator.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/FilePathRandomGenerator.java
@@ -1,0 +1,23 @@
+package co.kirikiri.service;
+
+import org.springframework.stereotype.Component;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Component
+public class FilePathRandomGenerator implements FilePathGenerator {
+
+    private static final String DIRECTORY_SEPARATOR = "/";
+
+    @Override
+    public String makeFilePath(final Long id, final ImageDirType dirType) {
+        final LocalDate currentDate = LocalDate.now();
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(
+                String.format("yyyy%s/MMdd", DIRECTORY_SEPARATOR));
+        final String dateString = currentDate.format(formatter);
+
+        return dateString + DIRECTORY_SEPARATOR + dirType.getDirName() + DIRECTORY_SEPARATOR + id
+                + DIRECTORY_SEPARATOR + UUID.randomUUID() + "_";
+    }
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/FileService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/FileService.java
@@ -1,0 +1,59 @@
+package co.kirikiri.service;
+
+import co.kirikiri.exception.ServerException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Service
+@Transactional
+public class FileService {
+
+    private final String storageLocation;
+    private final String imagePathPrefix;
+    private final FilePathGenerator filePathGenerator;
+
+    public FileService(@Value("${file.upload-dir}") final String storageLocation,
+                       @Value("${file.server-path}") final String imagePathPrefix,
+                       final FilePathGenerator filePathGenerator) {
+        this.storageLocation = storageLocation;
+        this.imagePathPrefix = imagePathPrefix;
+        this.filePathGenerator = filePathGenerator;
+    }
+
+    public String uploadFileAndReturnPath(final MultipartFile multiPartFile, final ImageDirType dirType, final Long id) {
+        final String originalName = multiPartFile.getOriginalFilename();
+        final String fileName = originalName.substring(originalName.lastIndexOf("\\") + 1);
+        final String filePath = filePathGenerator.makeFilePath(id, dirType);
+        final String saveFileName = storageLocation + filePath + fileName;
+        final Path savePath = Path.of(saveFileName);
+        makePathDirectories(savePath);
+        trasferFilePath(multiPartFile, savePath);
+        return imagePathPrefix + filePath + fileName;
+    }
+
+    private void makePathDirectories(final Path path) {
+        final Path parentDir = path.getParent();
+        if (Files.exists(parentDir)) {
+            return;
+        }
+
+        try {
+            Files.createDirectories(parentDir);
+        } catch (final IOException e) {
+            throw new ServerException("파일 저장 중에 문제가 생겼습니다. (파일 경로)");
+        }
+    }
+
+    private void trasferFilePath(final MultipartFile multiPartFile, final Path savePath) {
+        try {
+            multiPartFile.transferTo(savePath);
+        } catch (final IOException e) {
+            throw new ServerException("파일 저장 중에 문제가 생겼습니다. (파일 경로 수정)");
+        }
+    }
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomCreateService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomCreateService.java
@@ -23,11 +23,11 @@ import co.kirikiri.service.dto.goalroom.GoalRoomRoadmapNodeDto;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomCreateRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomTodoRequest;
 import co.kirikiri.service.mapper.GoalRoomMapper;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 
 @Service
 @Transactional
@@ -100,8 +100,7 @@ public class GoalRoomCreateService {
         return goalRoomRepository.findById(goalRoomId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 골룸입니다. goalRoomId = " + goalRoomId));
     }
-
-    @Transactional
+    
     public Long addGoalRoomTodo(final Long goalRoomId, final String identifier,
                                 final GoalRoomTodoRequest goalRoomTodoRequest) {
         final Member member = findMemberByIdentifier(identifier);

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/ImageDirType.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/ImageDirType.java
@@ -1,9 +1,9 @@
 package co.kirikiri.service;
 
 public enum ImageDirType {
-    CHECK_FEED("goalroom/checkfeed/"),
-    ROADMAP_NODE("roadmap/"),
-    USER_PROFILE("member/profile/");
+    CHECK_FEED("goalroom/checkfeed"),
+    ROADMAP_NODE("roadmap"),
+    USER_PROFILE("member/profile");
 
     private final String dirName;
 

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/ImageDirType.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/ImageDirType.java
@@ -1,0 +1,17 @@
+package co.kirikiri.service;
+
+public enum ImageDirType {
+    CHECK_FEED("goalroom/checkfeed/"),
+    ROADMAP_NODE("roadmap/"),
+    USER_PROFILE("member/profile/");
+
+    private final String dirName;
+
+    ImageDirType(final String dirName) {
+        this.dirName = dirName;
+    }
+
+    public String getDirName() {
+        return dirName;
+    }
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapCreateEventListener.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapCreateEventListener.java
@@ -1,0 +1,81 @@
+package co.kirikiri.service;
+
+import co.kirikiri.domain.ImageContentType;
+import co.kirikiri.domain.roadmap.Roadmap;
+import co.kirikiri.domain.roadmap.RoadmapContent;
+import co.kirikiri.domain.roadmap.RoadmapNode;
+import co.kirikiri.domain.roadmap.RoadmapNodeImage;
+import co.kirikiri.domain.roadmap.RoadmapNodeImages;
+import co.kirikiri.exception.BadRequestException;
+import co.kirikiri.exception.ServerException;
+import co.kirikiri.persistence.roadmap.RoadmapContentRepository;
+import co.kirikiri.service.dto.roadmap.RoadmapNodeSaveDto;
+import co.kirikiri.service.event.RoadmapCreateEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RoadmapCreateEventListener {
+
+    private final RoadmapContentRepository roadmapContentRepository;
+    private final FileService fileService;
+
+    @Async
+    @TransactionalEventListener
+    @Transactional
+    public void handleRoadmapCreate(final RoadmapCreateEvent roadmapCreateEvent) {
+        saveRoadmapNodeImage(roadmapCreateEvent);
+    }
+
+    private void saveRoadmapNodeImage(final RoadmapCreateEvent roadmapCreateEvent) {
+        final RoadmapContent lastRoadmapContent = findLastRoadmapContent(roadmapCreateEvent.roadmap());
+        for (final RoadmapNodeSaveDto roadmapNodeSaveDto : roadmapCreateEvent.roadmapSaveDto().roadmapNodes()) {
+            final RoadmapNode roadmapNode = findRoadmapNodeByTitle(lastRoadmapContent, roadmapNodeSaveDto);
+            final RoadmapNodeImages roadmapNodeImages = makeRoadmapNodeImages(roadmapNodeSaveDto, roadmapNode);
+            roadmapNode.addImages(roadmapNodeImages);
+        }
+
+        roadmapContentRepository.save(lastRoadmapContent);
+    }
+
+    private RoadmapContent findLastRoadmapContent(final Roadmap roadmap) {
+        return roadmap.findLastRoadmapContent()
+                .orElseThrow(() -> new ServerException("로드맵 컨텐츠가 존재하지 않습니다."));
+    }
+
+    private RoadmapNode findRoadmapNodeByTitle(final RoadmapContent lastRoadmapContent, final RoadmapNodeSaveDto roadmapNodeSaveDto) {
+        return lastRoadmapContent.findRoadmapNodeByTitle(roadmapNodeSaveDto.title())
+                .orElseThrow(() -> new BadRequestException("해당 제목을 가지고있는 로드맵 노드가 없습니다. title = " + roadmapNodeSaveDto.title()));
+    }
+
+    private RoadmapNodeImages makeRoadmapNodeImages(final RoadmapNodeSaveDto roadmapNodeSaveDto, final RoadmapNode roadmapNode) {
+        final List<MultipartFile> images = roadmapNodeSaveDto.multipartFiles();
+        final RoadmapNodeImages roadmapNodeImages = new RoadmapNodeImages();
+        for (final MultipartFile image : images) {
+            final RoadmapNodeImage roadmapNodeImage = saveRoadmapNodeImage(roadmapNode, image);
+            roadmapNodeImages.add(roadmapNodeImage);
+        }
+        return roadmapNodeImages;
+    }
+
+    private RoadmapNodeImage saveRoadmapNodeImage(final RoadmapNode roadmapNode, final MultipartFile image) {
+        final String path = fileService.uploadFileAndReturnPath(image, ImageDirType.ROADMAP_NODE, roadmapNode.getId());
+        final String originalFilename = findOriginalFilename(image);
+        final ImageContentType imageContentType = ImageContentType.findByOriginalFileName(originalFilename);
+        return new RoadmapNodeImage(findOriginalFilename(image), path, imageContentType);
+    }
+
+    private String findOriginalFilename(final MultipartFile image) {
+        final String originalFilename = image.getOriginalFilename();
+        if (originalFilename == null) {
+            throw new BadRequestException("원본 파일 이름이 존재하지 않습니다.");
+        }
+        return originalFilename;
+    }
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapCreateService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapCreateService.java
@@ -28,11 +28,13 @@ import co.kirikiri.service.dto.roadmap.RoadmapSaveDto;
 import co.kirikiri.service.dto.roadmap.RoadmapTagSaveDto;
 import co.kirikiri.service.dto.roadmap.request.RoadmapReviewSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
+import co.kirikiri.service.event.RoadmapCreateEvent;
 import co.kirikiri.service.mapper.RoadmapMapper;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 
 @Service
 @Transactional
@@ -44,14 +46,18 @@ public class RoadmapCreateService {
     private final RoadmapReviewRepository roadmapReviewRepository;
     private final GoalRoomMemberRepository goalRoomMemberRepository;
     private final RoadmapCategoryRepository roadmapCategoryRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public Long create(final RoadmapSaveRequest request, final String identifier) {
         final Member member = findMemberByIdentifier(identifier);
         final RoadmapCategory roadmapCategory = findRoadmapCategoryById(request.categoryId());
         final RoadmapSaveDto roadmapSaveDto = RoadmapMapper.convertToRoadmapSaveDto(request);
         final Roadmap roadmap = createRoadmap(member, roadmapSaveDto, roadmapCategory);
+        roadmapRepository.save(roadmap);
 
-        return roadmapRepository.save(roadmap).getId();
+        applicationEventPublisher.publishEvent(new RoadmapCreateEvent(roadmap, roadmapSaveDto));
+
+        return roadmap.getId();
     }
 
     private Member findMemberByIdentifier(final String identifier) {
@@ -104,7 +110,6 @@ public class RoadmapCreateService {
                 roadmapCategory);
     }
 
-    @Transactional
     public void createReview(final Long roadmapId, final String identifier, final RoadmapReviewSaveRequest request) {
         final Roadmap roadmap = findRoadmapById(roadmapId);
         final GoalRoomMember goalRoomMember = findCompletedGoalRoomMember(roadmapId, identifier);
@@ -142,5 +147,4 @@ public class RoadmapCreateService {
                     "이미 작성한 리뷰가 존재합니다. roadmapId = " + roadmap.getId() + " memberId = " + member.getId());
         }
     }
-
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/RoadmapNodeImageDto.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/RoadmapNodeImageDto.java
@@ -1,0 +1,10 @@
+package co.kirikiri.service.dto.roadmap;
+
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+
+public record RoadmapNodeImageDto(
+        Long roadmapNodeId,
+        List<MultipartFile> images
+) {
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/RoadmapNodeSaveDto.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/RoadmapNodeSaveDto.java
@@ -1,8 +1,12 @@
 package co.kirikiri.service.dto.roadmap;
 
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+
 public record RoadmapNodeSaveDto(
         String title,
-        String content
+        String content,
+        List<MultipartFile> multipartFiles
 ) {
 
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/request/RoadmapNodeSaveRequest.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/request/RoadmapNodeSaveRequest.java
@@ -1,14 +1,26 @@
 package co.kirikiri.service.dto.roadmap.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
 
-public record RoadmapNodeSaveRequest(
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class RoadmapNodeSaveRequest {
 
-        @NotBlank(message = "로드맵 노드의 제목을 입력해주세요.")
-        String title,
+    @NotBlank(message = "로드맵 노드의 제목을 입력해주세요.")
+    private String title;
 
-        @NotBlank(message = "로드맵 노드의 설명을 입력해주세요.")
-        String content
-) {
+    @NotBlank(message = "로드맵 노드의 설명을 입력해주세요.")
+    private String content;
 
+    private List<MultipartFile> images;
+
+    public void setImages(final List<MultipartFile> images) {
+        this.images = images;
+    }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/event/RoadmapCreateEvent.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/event/RoadmapCreateEvent.java
@@ -1,0 +1,10 @@
+package co.kirikiri.service.event;
+
+import co.kirikiri.domain.roadmap.Roadmap;
+import co.kirikiri.service.dto.roadmap.RoadmapSaveDto;
+
+public record RoadmapCreateEvent(
+        Roadmap roadmap,
+        RoadmapSaveDto roadmapSaveDto
+) {
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/RoadmapMapper.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/RoadmapMapper.java
@@ -25,9 +25,9 @@ import co.kirikiri.service.dto.roadmap.response.RoadmapForListResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapNodeResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapTagResponse;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RoadmapMapper {
@@ -44,7 +44,7 @@ public final class RoadmapMapper {
     }
 
     private static RoadmapNodeSaveDto convertToRoadmapNodesSaveDto(final RoadmapNodeSaveRequest request) {
-        return new RoadmapNodeSaveDto(request.title(), request.content());
+        return new RoadmapNodeSaveDto(request.getTitle(), request.getContent(), request.getImages());
     }
 
     private static RoadmapTagSaveDto convertToRoadmapTagSaveDto(final RoadmapTagSaveRequest request) {

--- a/backend/kirikiri/src/test/java/co/kirikiri/controller/RoadmapCreateApiTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/controller/RoadmapCreateApiTest.java
@@ -644,13 +644,13 @@ class RoadmapCreateApiTest extends ControllerTestHelper {
 
     private void 로드맵_생성_요청(final RoadmapSaveRequest request, final ResultMatcher httpStatus) throws Exception {
         final String jsonRequest = objectMapper.writeValueAsString(request);
-        final MockMultipartFile jsonData = new MockMultipartFile("jsonData", "", MediaType.APPLICATION_JSON_VALUE, jsonRequest.getBytes());
-        
+        final MockMultipartFile jsonDataFile = new MockMultipartFile("jsonData", "", "application/json",
+                objectMapper.writeValueAsBytes(request));
+
         final List<RequestPartDescriptor> MULTIPART_FORM_데이터_설명_리스트 = new ArrayList<>();
         MULTIPART_FORM_데이터_설명_리스트.add(partWithName("jsonData").description("로드맵 생성 요청 json 데이터"));
 
-        MockMultipartHttpServletRequestBuilder httpServletRequestBuilder = multipart(API_PREFIX + "/roadmaps")
-                .file(jsonData);
+        MockMultipartHttpServletRequestBuilder httpServletRequestBuilder = multipart(API_PREFIX + "/roadmaps");
 
         for (final RoadmapNodeSaveRequest roadmapNode : request.roadmapNodes()) {
             final String 로드맵_노드_제목 = roadmapNode.getTitle() != null ? roadmapNode.getTitle() : "name";
@@ -664,14 +664,14 @@ class RoadmapCreateApiTest extends ControllerTestHelper {
         }
 
         mockMvc.perform(httpServletRequestBuilder
+                        .file(jsonDataFile)
+                        .param("jsonData", jsonRequest)
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
                         .contextPath(API_PREFIX))
                 .andExpect(httpStatus)
                 .andDo(documentationResultHandler.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("access token")
-                        ),
+                        requestHeaders(headerWithName("Authorization").description("access token")),
                         requestParts(MULTIPART_FORM_데이터_설명_리스트),
                         requestPartFields("jsonData",
                                 fieldWithPath("categoryId").description("로드맵 카테고리 아이디"),

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomCreateIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomCreateIntegrationTest.java
@@ -23,19 +23,21 @@ import co.kirikiri.service.dto.roadmap.request.RoadmapDifficultyType;
 import co.kirikiri.service.dto.roadmap.request.RoadmapNodeSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapTagSaveRequest;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.restassured.http.Header;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.time.LocalDate;
-import java.time.Month;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
+import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 class GoalRoomCreateIntegrationTest extends IntegrationTest {
 
@@ -65,7 +67,7 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 정상적으로_골룸을_생성한다() {
+    void 정상적으로_골룸을_생성한다() throws IOException {
         //given
         final String 액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
@@ -87,12 +89,12 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 골룸_생성_시_컨텐츠_id가_빈값일_경우() throws JsonProcessingException {
+    void 골룸_생성_시_컨텐츠_id가_빈값일_경우() throws IOException {
         //given
         final String 액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
         final RoadmapSaveRequest 로드맵_생성_요청 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글", "로드맵 본문",
-                RoadmapDifficultyType.DIFFICULT, 30, List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")),
+                RoadmapDifficultyType.DIFFICULT, 30, List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         로드맵_생성(로드맵_생성_요청, 액세스_토큰);
         final RoadmapNode 로드맵_노드 = 로드맵_노드();
@@ -117,12 +119,12 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 골룸_생성_시_골룸_이름이_빈값일_경우() throws JsonProcessingException {
+    void 골룸_생성_시_골룸_이름이_빈값일_경우() throws IOException {
         //given
         final String 액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
         final RoadmapSaveRequest 로드맵_생성_요청 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글", "로드맵 본문",
-                RoadmapDifficultyType.DIFFICULT, 30, List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")),
+                RoadmapDifficultyType.DIFFICULT, 30, List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         로드맵_생성(로드맵_생성_요청, 액세스_토큰);
         final RoadmapNode 로드맵_노드 = 로드맵_노드();
@@ -147,12 +149,12 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 골룸_생성_시_골룸_제한_인원이_빈값일_경우() throws JsonProcessingException {
+    void 골룸_생성_시_골룸_제한_인원이_빈값일_경우() throws IOException {
         //given
         final String 액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
         final RoadmapSaveRequest 로드맵_생성_요청 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글", "로드맵 본문",
-                RoadmapDifficultyType.DIFFICULT, 30, List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")),
+                RoadmapDifficultyType.DIFFICULT, 30, List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         로드맵_생성(로드맵_생성_요청, 액세스_토큰);
         final RoadmapNode 로드맵_노드 = 로드맵_노드();
@@ -177,7 +179,7 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 골룸_생성_시_골룸_이름이_40자_초과인_경우() {
+    void 골룸_생성_시_골룸_이름이_40자_초과인_경우() throws IOException {
         //given
         final String 액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
@@ -203,14 +205,14 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 골룸_생성_시_노드_별_기간_수와_로드맵_노드의_수가_맞지_않을때() {
+    void 골룸_생성_시_노드_별_기간_수와_로드맵_노드의_수가_맞지_않을때() throws IOException {
         //given
         final String 액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
         final RoadmapSaveRequest 로드맵_생성_요청 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글", "로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용"),
-                        new RoadmapNodeSaveRequest("로드맵 2주차", "로드맵 2주차 내용")),
+                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", null),
+                        new RoadmapNodeSaveRequest("로드맵 2주차", "로드맵 2주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         final Long 로드맵_id = 로드맵을_생성하고_id를_알아낸다(액세스_토큰, 로드맵_생성_요청);
         final RoadmapNode 로드맵_노드 = 로드맵_노드();
@@ -232,7 +234,7 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 골룸_생성_시_제한_인원이_20명_초과일때() {
+    void 골룸_생성_시_제한_인원이_20명_초과일때() throws IOException {
         //given
         final String 액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
@@ -284,7 +286,7 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
 //        assertThat(참가_요청에_대한_응답.statusCode()).isEqualTo(HttpStatus.OK.value());
 //    }
     @Test
-    void 골룸에_참가_요청을_보낸다() {
+    void 골룸에_참가_요청을_보낸다() throws IOException {
         //given
         final String 리더_액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
@@ -329,7 +331,7 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 인원이_가득_찬_골룸에_참가_요청을_보내면_예외가_발생한다() {
+    void 인원이_가득_찬_골룸에_참가_요청을_보내면_예외가_발생한다() throws IOException {
         //given
         final String 리더_액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
@@ -361,7 +363,7 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 모집_중이지_않은_골룸에_참가_요청을_보내면_예외가_발생한다() {
+    void 모집_중이지_않은_골룸에_참가_요청을_보내면_예외가_발생한다() throws IOException {
         //given
         final String 리더_액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
@@ -396,7 +398,7 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 이미_참여한_골룸에_참가_요청을_보내면_예외가_발생한다() {
+    void 이미_참여한_골룸에_참가_요청을_보내면_예외가_발생한다() throws IOException {
         //given
         final String 리더_액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
@@ -423,7 +425,7 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 정상적으로_골룸에_투두리스트를_추가한다() {
+    void 정상적으로_골룸에_투두리스트를_추가한다() throws IOException {
         // given
         final String 액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
@@ -444,7 +446,7 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 골룸에_팔로워가_투두_리스트를_추가할때_예외를_던진다() throws JsonProcessingException {
+    void 골룸에_팔로워가_투두_리스트를_추가할때_예외를_던진다() throws IOException {
         // given
         final String 골룸_리더_액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final MemberJoinRequest 팔로워_회원가입_요청 = new MemberJoinRequest("identifier1", "password12!@#$%", "follower",
@@ -469,7 +471,7 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 종료된_골룸에_투두_리스트를_추가할때_예외를_던진다() throws JsonProcessingException {
+    void 종료된_골룸에_투두_리스트를_추가할때_예외를_던진다() throws IOException {
         //given
         final String 골룸_리더_액세스_토큰 = 회원을_생성하고_로그인을_한다(회원가입_요청, 로그인_요청);
         final RoadmapCategory 카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
@@ -492,16 +494,37 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
         assertThat(골룸_추가_응답_바디).isEqualTo(new ErrorResponse("이미 종료된 골룸입니다."));
     }
 
-    private ExtractableResponse<Response> 로드맵_생성(final RoadmapSaveRequest 로드맵_생성_요청, final String 액세스_토큰) {
-        return given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .body(로드맵_생성_요청)
-                .header(new Header(HttpHeaders.AUTHORIZATION, 액세스_토큰))
-                .post(API_PREFIX + "/roadmaps")
-                .then()
+    private ExtractableResponse<Response> 로드맵_생성(final RoadmapSaveRequest 로드맵_생성_요청값, final String 액세스_토큰)
+            throws IOException {
+        final String jsonRequest = objectMapper.writeValueAsString(로드맵_생성_요청값);
+
+        RequestSpecification requestSpecification = given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                .multiPart("jsonData", "jsonData.json", jsonRequest, MediaType.APPLICATION_JSON_VALUE);
+
+        requestSpecification = makeRequestSpecification(로드맵_생성_요청값, requestSpecification);
+
+        return requestSpecification
                 .log().all()
+                .post(API_PREFIX + "/roadmaps")
+                .then().log().all()
                 .extract();
+    }
+
+    private RequestSpecification makeRequestSpecification(final RoadmapSaveRequest 로드맵_생성_요청값, RequestSpecification requestSpecification) throws IOException {
+        if (로드맵_생성_요청값.roadmapNodes() == null) {
+            return requestSpecification;
+        }
+        for (final RoadmapNodeSaveRequest roadmapNode : 로드맵_생성_요청값.roadmapNodes()) {
+            final String 로드맵_노드_제목 = roadmapNode.getTitle() != null ? roadmapNode.getTitle() : "name";
+            final MockMultipartFile 가짜_이미지_객체 = new MockMultipartFile(로드맵_노드_제목, "originalFileName.jpeg",
+                    "image/jpeg", "tempImage".getBytes());
+            requestSpecification = requestSpecification
+                    .multiPart(가짜_이미지_객체.getName(), 가짜_이미지_객체.getOriginalFilename(),
+                            가짜_이미지_객체.getBytes(), 가짜_이미지_객체.getContentType());
+        }
+        return requestSpecification;
     }
 
     private ExtractableResponse<Response> 골룸_생성(final GoalRoomCreateRequest 골룸_생성_요청, final String 액세스_토큰) {
@@ -555,11 +578,10 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
                 .extract();
     }
 
-    private Long 로드맵을_생성하고_id를_알아낸다(final String 액세스_토큰, final RoadmapSaveRequest 로드맵_생성_요청) {
+    private Long 로드맵을_생성하고_id를_알아낸다(final String 액세스_토큰, final RoadmapSaveRequest 로드맵_생성_요청) throws IOException {
         final ExtractableResponse<Response> 로드맵_응답 = 로드맵_생성(로드맵_생성_요청, 액세스_토큰);
         final String Location_헤더 = 로드맵_응답.response().header("Location");
-        final Long 로드맵_id = Long.parseLong(Location_헤더.substring(14));
-        return 로드맵_id;
+        return Long.parseLong(Location_헤더.substring(14));
     }
 
     private ExtractableResponse<Response> 골룸_참가_요청(final Long 골룸_아이디, final String 팔로워_액세스_토큰) {
@@ -578,9 +600,9 @@ class GoalRoomCreateIntegrationTest extends IntegrationTest {
         return roadmapCategoryRepository.save(로드맵_카테고리);
     }
 
-    private Long 로드맵_생성(final String 액세스_토큰, final RoadmapCategory 카테고리) {
+    private Long 로드맵_생성(final String 액세스_토큰, final RoadmapCategory 카테고리) throws IOException {
         final RoadmapSaveRequest 로드맵_생성_요청 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글", "로드맵 본문",
-                RoadmapDifficultyType.DIFFICULT, 30, List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")),
+                RoadmapDifficultyType.DIFFICULT, 30, List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         return 로드맵을_생성하고_id를_알아낸다(액세스_토큰, 로드맵_생성_요청);
     }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapCreateIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapCreateIntegrationTest.java
@@ -46,10 +46,7 @@ import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.Month;
-import java.util.List;
+import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -57,8 +54,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.Collections;
+import java.util.List;
 
-public class RoadmapCreateIntegrationTest extends IntegrationTest {
+class RoadmapCreateIntegrationTest extends IntegrationTest {
 
     private static final String IDENTIFIER = "identifier1";
     private static final String PASSWORD = "password1!";
@@ -93,11 +97,11 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 정상적으로_로드맵을_생성한다() {
+    void 정상적으로_로드맵을_생성한다() throws IOException {
         // when
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글",
                 "로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")),
+                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 로그인_토큰);
 
@@ -108,14 +112,14 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 본문의_값이_없는_로드맵이_정상적으로_생성한다() {
+    void 본문의_값이_없는_로드맵이_정상적으로_생성한다() throws IOException {
         // given
         final String 로드맵_본문 = null;
 
         // when
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글", 로드맵_본문,
                 RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")),
+                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", Collections.emptyList())),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 로그인_토큰);
 
@@ -126,7 +130,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_생성시_잘못된_빈값을_넘기면_실패한다() {
+    void 로드맵_생성시_잘못된_빈값을_넘기면_실패한다() throws IOException {
         // given
         final Long 카테고리_id = null;
         final String 로드맵_제목 = null;
@@ -139,7 +143,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
         // when
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리_id, 로드맵_제목, 로드맵_소개글, "로드맵 본문",
                 로드맵_난이도, 추천_소요_기간,
-                List.of(new RoadmapNodeSaveRequest(로드맵_노드_제목, 로드맵_노드_설명)),
+                List.of(new RoadmapNodeSaveRequest(로드맵_노드_제목, 로드맵_노드_설명, Collections.emptyList())),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 로그인_토큰);
 
@@ -161,14 +165,14 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 존재하지_않는_카테고리_아이디를_입력한_경우_실패한다() {
+    void 존재하지_않는_카테고리_아이디를_입력한_경우_실패한다() throws IOException {
         // given
         final long 카테고리_id = 2L;
 
         // when
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리_id, "로드맵 제목", "로드맵 소개글", "로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")),
+                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", Collections.emptyList())),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 로그인_토큰);
 
@@ -181,13 +185,13 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 제목의_길이가_40보다_크면_실패한다() {
+    void 제목의_길이가_40보다_크면_실패한다() throws IOException {
         // given
         final String 로드맵_제목 = "a".repeat(41);
 
         // when
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리.getId(), 로드맵_제목, "로드맵 소개글", "로드맵 본문",
-                RoadmapDifficultyType.DIFFICULT, 30, List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")),
+                RoadmapDifficultyType.DIFFICULT, 30, List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", Collections.emptyList())),
                 List.of(new RoadmapTagSaveRequest("태그")));
         final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 로그인_토큰);
 
@@ -199,14 +203,14 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 소개글의_길이가_150보다_크면_실패한다() {
+    void 소개글의_길이가_150보다_크면_실패한다() throws IOException {
         // given
         final String 로드맵_소개글 = "a".repeat(151);
 
         // when
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", 로드맵_소개글, "로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")),
+                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", Collections.emptyList())),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 로그인_토큰);
 
@@ -218,14 +222,14 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 본문의_길이가_2000보다_크면_실패한다() {
+    void 본문의_길이가_2000보다_크면_실패한다() throws IOException {
         // given
         final String 로드맵_본문 = "a".repeat(2001);
 
         // when
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글", 로드맵_본문,
                 RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")),
+                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", Collections.emptyList())),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 로그인_토큰);
 
@@ -237,7 +241,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 추천_소요_기간이_0보다_작으면_실패한다() {
+    void 추천_소요_기간이_0보다_작으면_실패한다() throws IOException {
         // given
         final Integer 추천_소요_기간 = -1;
 
@@ -245,7 +249,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글",
                 "로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 추천_소요_기간,
-                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용")),
+                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", Collections.emptyList())),
                 List.of(new RoadmapTagSaveRequest("태그1")));
         final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 로그인_토큰);
 
@@ -257,7 +261,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_노드를_입력하지_않으면_실패한다() {
+    void 로드맵_노드를_입력하지_않으면_실패한다() throws IOException {
         // given
         final List<RoadmapNodeSaveRequest> 로드맵_노드들 = null;
 
@@ -274,11 +278,11 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_노드의_제목의_길이가_40보다_크면_실패한다() {
+    void 로드맵_노드의_제목의_길이가_40보다_크면_실패한다() throws IOException {
         // given
         final String 로드맵_노드_제목 = "a".repeat(41);
         final List<RoadmapNodeSaveRequest> 로드맵_노드들 = List.of(
-                new RoadmapNodeSaveRequest(로드맵_노드_제목, "로드맵 1주차 내용"));
+                new RoadmapNodeSaveRequest(로드맵_노드_제목, "로드맵 1주차 내용", Collections.emptyList()));
 
         // when
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글",
@@ -293,11 +297,11 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_노드의_설명의_길이가_2000보다_크면_실패한다() {
+    void 로드맵_노드의_설명의_길이가_2000보다_크면_실패한다() throws IOException {
         // given
         final String 로드맵_노드_설명 = "a".repeat(2001);
         final List<RoadmapNodeSaveRequest> 로드맵_노드들 = List.of(
-                new RoadmapNodeSaveRequest("로드맵 노드 제목", 로드맵_노드_설명));
+                new RoadmapNodeSaveRequest("로드맵 노드 제목", 로드맵_노드_설명, Collections.emptyList()));
         로드맵_카테고리를_저장한다("여행");
 
         // when
@@ -313,7 +317,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_리뷰를_생성한다() {
+    void 로드맵_리뷰를_생성한다() throws IOException {
         // given
         final Member 크리에이터 = 회원가입("크리에이터", "creator");
         final Member 리더 = 회원가입("리더", "leader");
@@ -363,7 +367,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_리뷰_생성시_별점이_잘못된_값이면_예외가_발생한다() {
+    void 로드맵_리뷰_생성시_별점이_잘못된_값이면_예외가_발생한다() throws IOException {
         // given
         final Member 크리에이터 = 회원가입("크리에이터", "creator");
         final Member 리더 = 회원가입("리더", "leader");
@@ -395,7 +399,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_리뷰_생성시_내용이_1000자가_넘으면_예외가_발생한다() {
+    void 로드맵_리뷰_생성시_내용이_1000자가_넘으면_예외가_발생한다() throws IOException {
         // given
         final Member 크리에이터 = 회원가입("크리에이터", "creator");
         final Member 리더 = 회원가입("리더", "leader");
@@ -444,7 +448,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_리뷰_생성시_완료한_골룸이_없다면_예외가_발생한다() {
+    void 로드맵_리뷰_생성시_완료한_골룸이_없다면_예외가_발생한다() throws IOException {
         // given
         final Member 크리에이터 = 회원가입("크리에이터", "creator");
         final Member 리더 = 회원가입("리더", "leader");
@@ -477,7 +481,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_리뷰_생성시_로드맵_생성자가_리뷰를_달려고_하면_예외가_발생한다() {
+    void 로드맵_리뷰_생성시_로드맵_생성자가_리뷰를_달려고_하면_예외가_발생한다() throws IOException {
         // given
         final Member 크리에이터 = 회원가입("크리에이터", "creator");
         final Member 리더 = 회원가입("리더", "leader");
@@ -509,7 +513,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_리뷰_생성시_이미_리뷰를_단적이_있으면_예외가_발생한다() {
+    void 로드맵_리뷰_생성시_이미_리뷰를_단적이_있으면_예외가_발생한다() throws IOException {
         // given
         final Member 크리에이터 = 회원가입("크리에이터", "creator");
         final Member 리더 = 회원가입("리더", "leader");
@@ -543,7 +547,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_태그_이름이_중복되면_예외가_발생한다() {
+    void 로드맵_태그_이름이_중복되면_예외가_발생한다() throws IOException {
         // given
         final List<RoadmapTagSaveRequest> 태그_저장_요청 = List.of(new RoadmapTagSaveRequest("태그"),
                 new RoadmapTagSaveRequest("태그"));
@@ -551,7 +555,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
         // when
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글", "로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 노드 제목", "로드맵 노드 설명")), 태그_저장_요청);
+                List.of(new RoadmapNodeSaveRequest("로드맵 노드 제목", "로드맵 노드 설명", Collections.emptyList())), 태그_저장_요청);
         final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 로그인_토큰);
 
         // then
@@ -562,7 +566,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 로드맵_태그_개수가_5개_초과면_예외가_발생한다() {
+    void 로드맵_태그_개수가_5개_초과면_예외가_발생한다() throws IOException {
         // given
         final List<RoadmapTagSaveRequest> 태그_저장_요청 = List.of(new RoadmapTagSaveRequest("태그1"),
                 new RoadmapTagSaveRequest("태그2"), new RoadmapTagSaveRequest("태그3"),
@@ -572,7 +576,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
         // when
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글", "로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 노드 제목", "로드맵 노드 설명")), 태그_저장_요청);
+                List.of(new RoadmapNodeSaveRequest("로드맵 노드 제목", "로드맵 노드 설명", Collections.emptyList())), 태그_저장_요청);
         final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 로그인_토큰);
 
         // then
@@ -584,7 +588,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
 
     @ParameterizedTest
     @ValueSource(ints = {0, 11})
-    void 로드맵_태그_이름의_길이가_1자_미만_10자_초과면_예외가_발생한다(final int nameLength) {
+    void 로드맵_태그_이름의_길이가_1자_미만_10자_초과면_예외가_발생한다(final int nameLength) throws IOException {
         // given
         final String 태그_이름 = "a".repeat(nameLength);
         final List<RoadmapTagSaveRequest> 태그_저장_요청 = List.of(new RoadmapTagSaveRequest(태그_이름));
@@ -592,7 +596,7 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
         // when
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글", "로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 노드 제목", "로드맵 노드 설명")), 태그_저장_요청);
+                List.of(new RoadmapNodeSaveRequest("로드맵 노드 제목", "로드맵 노드 설명", Collections.emptyList())), 태그_저장_요청);
         final ExtractableResponse<Response> 로드맵_생성_응답값 = 로드맵_생성_요청(로드맵_생성_요청값, 로그인_토큰);
 
         // then
@@ -642,15 +646,37 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
         return String.format(BEARER_TOKEN_FORMAT, 토큰_응답.accessToken());
     }
 
-    private ExtractableResponse<Response> 로드맵_생성_요청(final RoadmapSaveRequest 로드맵_생성_요청값,
-                                                    final String accessToken) {
-        return given().log().all()
+    private ExtractableResponse<Response> 로드맵_생성_요청(final RoadmapSaveRequest 로드맵_생성_요청값, final String accessToken)
+            throws IOException {
+        final String jsonRequest = objectMapper.writeValueAsString(로드맵_생성_요청값);
+
+        RequestSpecification requestSpecification = given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(로드맵_생성_요청값).log().all()
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE + "; charset=utf-8")
+                .multiPart("jsonData", "jsonData.json", jsonRequest, MediaType.APPLICATION_JSON_VALUE);
+
+        requestSpecification = makeRequestSpecification(로드맵_생성_요청값, requestSpecification);
+
+        return requestSpecification
+                .log().all()
                 .post(API_PREFIX + "/roadmaps")
                 .then().log().all()
                 .extract();
+    }
+
+    private RequestSpecification makeRequestSpecification(final RoadmapSaveRequest 로드맵_생성_요청값, RequestSpecification requestSpecification) throws IOException {
+        if (로드맵_생성_요청값.roadmapNodes() == null) {
+            return requestSpecification;
+        }
+        for (final RoadmapNodeSaveRequest roadmapNode : 로드맵_생성_요청값.roadmapNodes()) {
+            final String 로드맵_노드_제목 = roadmapNode.getTitle() != null ? roadmapNode.getTitle() : "name";
+            final MockMultipartFile 가짜_이미지_객체 = new MockMultipartFile(로드맵_노드_제목, "originalFileName.jpeg",
+                    "image/jpeg", "tempImage".getBytes());
+            requestSpecification = requestSpecification
+                    .multiPart(가짜_이미지_객체.getName(), 가짜_이미지_객체.getOriginalFilename(),
+                            가짜_이미지_객체.getBytes(), 가짜_이미지_객체.getContentType());
+        }
+        return requestSpecification;
     }
 
     private void 응답_상태_코드_검증(final ExtractableResponse<Response> 응답, final HttpStatus http_상태) {
@@ -669,8 +695,8 @@ public class RoadmapCreateIntegrationTest extends IntegrationTest {
     private RoadmapSaveRequest 로드맵_저장_요청을_생성한다() {
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(카테고리.getId(), "로드맵 제목", "로드맵 소개글", "로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용"),
-                        new RoadmapNodeSaveRequest("로드맵 2주차", "로드맵 2주차 내용")),
+                List.of(new RoadmapNodeSaveRequest("로드맵 1주차", "로드맵 1주차 내용", Collections.emptyList()),
+                        new RoadmapNodeSaveRequest("로드맵 2주차", "로드맵 2주차 내용", Collections.emptyList())),
                 List.of(new RoadmapTagSaveRequest("태그")));
         return 로드맵_생성_요청값;
     }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/IntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/IntegrationTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 public class IntegrationTest {
-
+    
     protected final String AUTHORIZATION = "Authorization";
     protected final String LOCATION = "Location";
     protected final String BEARER_TOKEN_FORMAT = "Bearer %s";

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomServiceIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomServiceIntegrationTest.java
@@ -32,12 +32,12 @@ import co.kirikiri.persistence.goalroom.GoalRoomRepository;
 import co.kirikiri.persistence.member.MemberRepository;
 import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
 import co.kirikiri.persistence.roadmap.RoadmapRepository;
+import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import org.junit.jupiter.api.Test;
 
-public class GoalRoomServiceIntegrationTest extends IntegrationTest {
+class GoalRoomServiceIntegrationTest extends IntegrationTest {
 
     private static final LocalDate TODAY = LocalDate.now();
 

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/RoadmapCreateEventListenerTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/RoadmapCreateEventListenerTest.java
@@ -1,0 +1,151 @@
+package co.kirikiri.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import co.kirikiri.domain.member.EncryptedPassword;
+import co.kirikiri.domain.member.Gender;
+import co.kirikiri.domain.member.Member;
+import co.kirikiri.domain.member.MemberProfile;
+import co.kirikiri.domain.member.vo.Identifier;
+import co.kirikiri.domain.member.vo.Nickname;
+import co.kirikiri.domain.member.vo.Password;
+import co.kirikiri.domain.roadmap.Roadmap;
+import co.kirikiri.domain.roadmap.RoadmapCategory;
+import co.kirikiri.domain.roadmap.RoadmapContent;
+import co.kirikiri.domain.roadmap.RoadmapDifficulty;
+import co.kirikiri.domain.roadmap.RoadmapNode;
+import co.kirikiri.domain.roadmap.RoadmapNodes;
+import co.kirikiri.exception.BadRequestException;
+import co.kirikiri.exception.ServerException;
+import co.kirikiri.persistence.roadmap.RoadmapContentRepository;
+import co.kirikiri.service.dto.roadmap.RoadmapNodeSaveDto;
+import co.kirikiri.service.dto.roadmap.RoadmapSaveDto;
+import co.kirikiri.service.dto.roadmap.RoadmapTagSaveDto;
+import co.kirikiri.service.dto.roadmap.request.RoadmapDifficultyType;
+import co.kirikiri.service.event.RoadmapCreateEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import java.time.LocalDate;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class RoadmapCreateEventListenerTest {
+
+    private static final Member member = new Member(1L, new Identifier("identifier1"),
+            new EncryptedPassword(new Password("password1!")), new Nickname("닉네임"),
+            new MemberProfile(Gender.FEMALE, LocalDate.of(1999, 6, 8), "010-1234-5678"));
+
+    @Mock
+    private RoadmapContentRepository roadmapContentRepository;
+
+    @Mock
+    private FileService fileService;
+
+    @InjectMocks
+    private RoadmapCreateEventListener roadmapCreateEventListener;
+
+    @Test
+    void 정상적으로_로드맵_노드_이미지를_저장한다() {
+        final RoadmapContent roadmapContent = new RoadmapContent("roadmapContent");
+        final RoadmapNode roadmapNode = new RoadmapNode("roadmapNodeTitle", "roadmapNodeContent");
+        roadmapContent.addNodes(new RoadmapNodes(List.of(roadmapNode)));
+
+        final Roadmap roadmap = new Roadmap("roadmapTitle", "inroduction", 10,
+                RoadmapDifficulty.DIFFICULT, member, new RoadmapCategory("category"));
+
+        final MultipartFile imageFile = new MockMultipartFile(roadmapNode.getTitle(),
+                "originalFileName.jpeg", "image/jpeg", "tempImage".getBytes());
+        final RoadmapNodeSaveDto roadmapNodeSaveDto = new RoadmapNodeSaveDto(roadmapNode.getTitle(), roadmapNode.getContent(), List.of(imageFile));
+        final RoadmapSaveDto roadmapSaveDto = new RoadmapSaveDto(1L, roadmap.getTitle(), roadmap.getIntroduction(),
+                roadmapContent.getContent(), RoadmapDifficultyType.DIFFICULT, 10, List.of(roadmapNodeSaveDto), List.of(new RoadmapTagSaveDto("tag")));
+
+        roadmap.addContent(roadmapContent);
+
+        final RoadmapCreateEvent roadmapCreateEvent = new RoadmapCreateEvent(roadmap, roadmapSaveDto);
+
+        // When
+        roadmapCreateEventListener.handleRoadmapCreate(roadmapCreateEvent);
+
+        // Then
+        verify(roadmapContentRepository, times(1)).save(roadmapContent);
+    }
+
+    @Test
+    void 로드맵에_컨텐츠가_존재하지_않을_경우_예외를_던진다() {
+        //given
+        final Roadmap roadmap = new Roadmap("roadmapTitle", "inroduction", 10,
+                RoadmapDifficulty.DIFFICULT, member, new RoadmapCategory("category"));
+
+        final MultipartFile imageFile = new MockMultipartFile("roadmapNodeTitle",
+                "originalFileName.jpeg", "image/jpeg", "tempImage".getBytes());
+        final RoadmapNodeSaveDto roadmapNodeSaveDto = new RoadmapNodeSaveDto("roadmapNodeTitle", "roadmapNodeContent", List.of(imageFile));
+        final RoadmapSaveDto roadmapSaveDto = new RoadmapSaveDto(1L, roadmap.getTitle(), roadmap.getIntroduction(),
+                "roadmapNodeContent", RoadmapDifficultyType.DIFFICULT, 10, List.of(roadmapNodeSaveDto), List.of(new RoadmapTagSaveDto("tag")));
+
+        final RoadmapCreateEvent roadmapCreateEvent = new RoadmapCreateEvent(roadmap, roadmapSaveDto);
+
+        //when
+        //then
+        assertThatThrownBy(() -> roadmapCreateEventListener.handleRoadmapCreate(roadmapCreateEvent))
+                .isInstanceOf(ServerException.class);
+    }
+
+    @Test
+    void 로드맵_노드_제목을_가진_노드가_로드맵에_존재하지_않을때_예외를_던진다() {
+        //given
+        final RoadmapContent roadmapContent = new RoadmapContent("roadmapContent");
+        final RoadmapNode roadmapNode = new RoadmapNode("roadmapNodeTitle", "roadmapNodeContent");
+        roadmapContent.addNodes(new RoadmapNodes(List.of(roadmapNode)));
+
+        final Roadmap roadmap = new Roadmap("roadmapTitle", "inroduction", 10,
+                RoadmapDifficulty.DIFFICULT, member, new RoadmapCategory("category"));
+
+        final MultipartFile imageFile = new MockMultipartFile(roadmapNode.getTitle(),
+                "originalFileName.jpeg", "image/jpeg", "tempImage".getBytes());
+        final RoadmapNodeSaveDto roadmapNodeSaveDto = new RoadmapNodeSaveDto("Wrong Title", roadmapNode.getContent(), List.of(imageFile));
+        final RoadmapSaveDto roadmapSaveDto = new RoadmapSaveDto(1L, roadmap.getTitle(), roadmap.getIntroduction(),
+                roadmapContent.getContent(), RoadmapDifficultyType.DIFFICULT, 10, List.of(roadmapNodeSaveDto), List.of(new RoadmapTagSaveDto("tag")));
+
+        roadmap.addContent(roadmapContent);
+
+        final RoadmapCreateEvent roadmapCreateEvent = new RoadmapCreateEvent(roadmap, roadmapSaveDto);
+
+        //when
+        //then
+        assertThatThrownBy(() -> roadmapCreateEventListener.handleRoadmapCreate(roadmapCreateEvent))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    void 로드맵_노드_이미지에_원본_파일_이름이_없을_경우_예외를_던진다() {
+        //given
+        final RoadmapContent roadmapContent = new RoadmapContent("roadmapContent");
+        final RoadmapNode roadmapNode = new RoadmapNode("roadmapNodeTitle", "roadmapNodeContent");
+        roadmapContent.addNodes(new RoadmapNodes(List.of(roadmapNode)));
+
+        final Roadmap roadmap = new Roadmap("roadmapTitle", "inroduction", 10,
+                RoadmapDifficulty.DIFFICULT, member, new RoadmapCategory("category"));
+
+        final MultipartFile imageFile = new MockMultipartFile(roadmapNode.getTitle(), null,
+                "image/jpeg", "tempImage".getBytes());
+        final RoadmapNodeSaveDto roadmapNodeSaveDto = new RoadmapNodeSaveDto("Wrong Title", roadmapNode.getContent(), List.of(imageFile));
+        final RoadmapSaveDto roadmapSaveDto = new RoadmapSaveDto(1L, roadmap.getTitle(), roadmap.getIntroduction(),
+                roadmapContent.getContent(), RoadmapDifficultyType.DIFFICULT, 10, List.of(roadmapNodeSaveDto), List.of(new RoadmapTagSaveDto("tag")));
+
+        roadmap.addContent(roadmapContent);
+
+        final RoadmapCreateEvent roadmapCreateEvent = new RoadmapCreateEvent(roadmap, roadmapSaveDto);
+
+        //when
+        //then
+        assertThatThrownBy(() -> roadmapCreateEventListener.handleRoadmapCreate(roadmapCreateEvent))
+                .isInstanceOf(BadRequestException.class);
+    }
+}

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/RoadmapCreateServiceTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/RoadmapCreateServiceTest.java
@@ -1,6 +1,5 @@
 package co.kirikiri.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,15 +38,17 @@ import co.kirikiri.service.dto.roadmap.request.RoadmapNodeSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapReviewSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapTagSaveRequest;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class RoadmapCreateServiceTest {
@@ -71,6 +72,9 @@ class RoadmapCreateServiceTest {
     @Mock
     private RoadmapCategoryRepository roadmapCategoryRepository;
 
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
     @InjectMocks
     private RoadmapCreateService roadmapService;
 
@@ -85,7 +89,7 @@ class RoadmapCreateServiceTest {
         final RoadmapCategory category = new RoadmapCategory(1L, "여가");
 
         final List<RoadmapNodeSaveRequest> roadmapNodes = List.of(
-                new RoadmapNodeSaveRequest("로드맵 노드1 제목", "로드맵 노드1 설명"));
+                new RoadmapNodeSaveRequest("로드맵 노드1 제목", "로드맵 노드1 설명", Collections.emptyList()));
         final List<RoadmapTagSaveRequest> roadmapTags = List.of(new RoadmapTagSaveRequest("태그 1"));
         final RoadmapSaveRequest request = new RoadmapSaveRequest(1L, roadmapTitle, roadmapIntroduction, roadmapContent,
                 difficulty, requiredPeriod, roadmapNodes, roadmapTags);
@@ -99,8 +103,7 @@ class RoadmapCreateServiceTest {
                 .thenReturn(Optional.of(member));
 
         // expect
-        assertThat(roadmapService.create(request, "identifier1"))
-                .isEqualTo(1L);
+        assertDoesNotThrow(() -> roadmapService.create(request, "identifier1"));
     }
 
     @Test
@@ -108,7 +111,7 @@ class RoadmapCreateServiceTest {
         // given
         final RoadmapSaveRequest request = new RoadmapSaveRequest(10L, "로드맵 제목", "로드맵 소개글", "로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 노드1", "로드맵 노드1 설명")),
+                List.of(new RoadmapNodeSaveRequest("로드맵 노드1", "로드맵 노드1 설명", Collections.emptyList())),
                 List.of(new RoadmapTagSaveRequest("태그 1")));
 
         given(memberRepository.findByIdentifier(any()))
@@ -124,7 +127,7 @@ class RoadmapCreateServiceTest {
         // given
         final RoadmapSaveRequest request = new RoadmapSaveRequest(10L, "로드맵 제목", "로드맵 소개글", "로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("로드맵 노드1", "로드맵 노드1 설명")),
+                List.of(new RoadmapNodeSaveRequest("로드맵 노드1", "로드맵 노드1 설명", Collections.emptyList())),
                 List.of(new RoadmapTagSaveRequest("태그 1")));
 
         given(memberRepository.findByIdentifier(any()))

--- a/backend/kirikiri/src/test/resources/application.yml
+++ b/backend/kirikiri/src/test/resources/application.yml
@@ -10,6 +10,10 @@ spring:
     hibernate:
       ddl-auto: create-drop
     open-in-view: false
+  servlet:
+    multipart:
+      max-file-size: 10MB
+
 logging:
   level:
     org:
@@ -34,3 +38,7 @@ image:
     serverFilePath: /api/default-member-image
     imageContentType: PNG
     extension: .png
+
+file:
+  upload-dir: src/test/resources/static/images/
+  server-path: http://localhost/images/


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-116](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-78)


## ✨ 작업 내용
- 요청이 `multipart/form-data`로 오도록 수정했습니다. 기존에 로드맵 생성 시 받던 `RoadmapSaveRequest`는 jsonData라는 name(multipart/form-data의 name)을 가지도록 수정 했습니다. 그리고 각 노드의 사진들은 해당 노드의 title을 name으로 해서 보내도록 했습니다. 
- 이렇게 받은 데이터들을 `RoadmapSaveArgumentResolver`에서 완전한 `RoadmapSaveRequest`로 바인딩 하도록 했습니다. jsonData로 받는 `RoadmapSaveRequest`는 이미지 파일들이 없는 상태인데 `RoadmapSaveArgumentResolver`에서 넣어준다고 생각하시면 됩니다.
- 요청 `Content-Type`과 형식이 완전 달라져서 통합테스트와 api test를 대거 수정했습니다.
- 기존에 `roadmap`을 생성하는 로직을 그대로 두고, 다른 쓰레드로 분리하여 파일들을 저장하도록 Spring 이벤트를 활용 했습니다. 이는 비동기로 동작하며 아예 별도의 쓰레드에서 동작합니다. 이 쓰레드는 `Event Publisher`부분의 트랜잭션이 커밋 된 후 실행 되도록 설정되어있습니다.
- FileService에서 동시성 문제를 일부 해결 했습니다. 하지만 통합테스트를 여러개 돌리면 `Thread.Sleep()` 도중에 `interrupt()`를 당해서 자꾸 `InterruptedException`이  발생하는데 이 문제는 아직 해결하지 못했습니다ㅠㅠ 


## 💬 리뷰어에게 남길 멘트
- 생각보다 작업 단위가 굉장히 컸던 것 같습니다.. Spring event에 익숙하지 않아서 배우면서 했던 탓에 그랬던 것 같습니다. 그래서 조금 미숙한 부분이 있을 것 같은데 지적해주시면 좋을 것 같습니다!
- `RoadmapCreateApiTest`에서 `로드맵_생성_요청` 부분에서  기존에 보내던 요청인 `RoadmapSaveRequest`를 담은 `jsonData` 부분을 `.file`, `.param`에 모두 넣어줘야 docs를 사용할 수 있더라고요..! 왜 그런지는 아직 발견 못했습니다ㅠㅠ
- 위에서도 얘기했지만 `FileService`에서 아직 path가 생성되지 않았을 경우 threadSleep을 통해서 기다렸다가 다시 실행하는 부분이 있습니다. 통합 테스트 여러개를 한번에 돌릴 경우에 threadSleep하는 도중에 interrupt를 당해서 `InterruptedException`을 발생 시킵니다. 멀티 쓰레드 환경에서 뭔가 잘못된다는 것 같은데 아직 해결을 못했습니다ㅠㅠ
- 통합테스트를 돌리고 생기는 file들을 삭제하도록 하고싶은데 실제 io 되는 시간보다 쓰레드가 끝나는 시간이 훨씬 빨라서 쉽지 않네요! 좋은 아이디어 있으시면 추천 부탁드립니다!
- 프론트 요청으로 로드맵 단일 조회 시 로드맵 노드 id 내려주기로 했는데 이미 있더라고요..? 혹시 썬샷이 작업하신건가요??

## 🚀 요구사항 분석

- [x] 로드맵 노드 당 사진을 추가한다
    - [x] 최대 사진 개수 : 2개
    - [x] 최대 사진 용량 : 10mb
- [x] 로드맵 노드에 사진은 없을 수 있다.
- [x] 파일 업로드와 로드맵 저장의 트랜잭션을 분리한다.
- [x] 파일 업로드는 비동기로 다른 쓰레드로 저장한다.


