### PR TITLE
[feat/CK-114] 로드맵 리뷰를 조회하는 기능을 구현한다

### DIFF
--- a/backend/kirikiri/src/docs/asciidoc/roadmap.adoc
+++ b/backend/kirikiri/src/docs/asciidoc/roadmap.adoc
@@ -193,3 +193,14 @@ operation::roadmap-read-api-test/로드맵의_골룸_목록을_조건에_따라_
 === *8-2* 실패 - 존재하지 않는 로드맵인 경우
 
 operation::roadmap-read-api-test/로드맵의_골룸_목록을_조건에_따라_조회할_때_로드맵이_존재하지_않으면_예외가_발생한다[snippets='http-request,query-parameters,http-response,response-fields']
+
+[[로드맵리뷰조회-API]]
+== *9. 로드맵의 리뷰 목록 조회 API*
+
+=== *9-1* 성공
+
+operation::roadmap-read-api-test/로드맵의_리뷰들을_조회한다[snippets='http-request,http-response,path-parameters,response-fields']
+
+=== *9-1* 실패 - 존재하지 않는 로드맵인 경우
+
+operation::roadmap-read-api-test/로드맵_리뷰_조회_시_유효하지_않은_로드맵_아이디일_경우_예외를_반환한다[snippets='http-request,http-response,path-parameters,response-fields']

--- a/backend/kirikiri/src/docs/asciidoc/roadmap.adoc
+++ b/backend/kirikiri/src/docs/asciidoc/roadmap.adoc
@@ -199,8 +199,8 @@ operation::roadmap-read-api-test/로드맵의_골룸_목록을_조건에_따라_
 
 === *9-1* 성공
 
-operation::roadmap-read-api-test/로드맵의_리뷰들을_조회한다[snippets='http-request,http-response,path-parameters,response-fields']
+operation::roadmap-read-api-test/로드맵의_리뷰들을_조회한다[snippets='http-request,http-response,path-parameters,query-parameters,response-fields']
 
 === *9-1* 실패 - 존재하지 않는 로드맵인 경우
 
-operation::roadmap-read-api-test/로드맵_리뷰_조회_시_유효하지_않은_로드맵_아이디일_경우_예외를_반환한다[snippets='http-request,http-response,path-parameters,response-fields']
+operation::roadmap-read-api-test/로드맵_리뷰_조회_시_유효하지_않은_로드맵_아이디일_경우_예외를_반환한다[snippets='http-request,http-response,path-parameters,query-parameters,response-fields']

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
@@ -15,6 +15,7 @@ import co.kirikiri.service.dto.roadmap.response.RoadmapCategoryResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapForListResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapGoalRoomResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
+import co.kirikiri.service.dto.roadmap.response.RoadmapReviewResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
@@ -106,6 +107,12 @@ public class RoadmapController {
     ) {
         final List<RoadmapGoalRoomResponse> responses = roadmapReadService.findRoadmapGoalRoomsByFilterType(
                 roadmapId, roadmapGoalRoomsFilterTypeDto, scrollRequest);
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/{roadmapId}/reviews")
+    public ResponseEntity<List<RoadmapReviewResponse>> findRoadmapReview(@PathVariable final Long roadmapId) {
+        final List<RoadmapReviewResponse> responses = roadmapReadService.findRoadmapReviews(roadmapId);
         return ResponseEntity.ok(responses);
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
@@ -111,8 +111,10 @@ public class RoadmapController {
     }
 
     @GetMapping("/{roadmapId}/reviews")
-    public ResponseEntity<List<RoadmapReviewResponse>> findRoadmapReview(@PathVariable final Long roadmapId) {
-        final List<RoadmapReviewResponse> responses = roadmapReadService.findRoadmapReviews(roadmapId);
+    public ResponseEntity<List<RoadmapReviewResponse>> findRoadmapReview(
+            @PathVariable final Long roadmapId,
+            @ModelAttribute final CustomScrollRequest scrollRequest) {
+        final List<RoadmapReviewResponse> responses = roadmapReadService.findRoadmapReviews(roadmapId, scrollRequest);
         return ResponseEntity.ok(responses);
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/BaseUpdatedTimeEntity.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/BaseUpdatedTimeEntity.java
@@ -13,5 +13,5 @@ public class BaseUpdatedTimeEntity extends BaseCreatedTimeEntity {
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/BaseUpdatedTimeEntity.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/BaseUpdatedTimeEntity.java
@@ -13,5 +13,5 @@ public class BaseUpdatedTimeEntity extends BaseCreatedTimeEntity {
 
     @LastModifiedDate
     @Column(nullable = false)
-    protected LocalDateTime updatedAt;
+    private LocalDateTime updatedAt;
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapReview.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapReview.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -72,5 +73,21 @@ public class RoadmapReview extends BaseUpdatedTimeEntity {
 
     public boolean isNotSameRoadmap(final Roadmap roadmap) {
         return this.roadmap == null || !this.roadmap.equals(roadmap);
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Double getRate() {
+        return rate;
+    }
+
+    public String getMemberNickname() {
+        return member.getNickname().getValue();
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapReview.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapReview.java
@@ -87,7 +87,7 @@ public class RoadmapReview extends BaseUpdatedTimeEntity {
         return member.getNickname().getValue();
     }
 
-    public LocalDateTime getUpdatedAt() {
-        return updatedAt;
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapReviewQueryRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapReviewQueryRepository.java
@@ -1,0 +1,13 @@
+package co.kirikiri.persistence.roadmap;
+
+import co.kirikiri.domain.roadmap.Roadmap;
+import co.kirikiri.domain.roadmap.RoadmapReview;
+import co.kirikiri.persistence.dto.RoadmapLastValueDto;
+import java.util.List;
+
+public interface RoadmapReviewQueryRepository {
+
+    List<RoadmapReview> findRoadmapReviewWithMemberByRoadmapOrderByLatest(final Roadmap roadmap,
+                                                                          final RoadmapLastValueDto lastValue,
+                                                                          final int pageSize);
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapReviewQueryRepositoryImpl.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapReviewQueryRepositoryImpl.java
@@ -1,0 +1,50 @@
+package co.kirikiri.persistence.roadmap;
+
+import static co.kirikiri.domain.member.QMember.member;
+import static co.kirikiri.domain.roadmap.QRoadmap.roadmap;
+import static co.kirikiri.domain.roadmap.QRoadmapReview.roadmapReview;
+
+import co.kirikiri.domain.roadmap.Roadmap;
+import co.kirikiri.domain.roadmap.RoadmapReview;
+import co.kirikiri.persistence.QuerydslRepositorySupporter;
+import co.kirikiri.persistence.dto.RoadmapLastValueDto;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class RoadmapReviewQueryRepositoryImpl extends QuerydslRepositorySupporter implements
+        RoadmapReviewQueryRepository {
+
+    public RoadmapReviewQueryRepositoryImpl() {
+        super(RoadmapReview.class);
+    }
+
+    @Override
+    public List<RoadmapReview> findRoadmapReviewWithMemberByRoadmapOrderByLatest(final Roadmap roadmap,
+                                                                                 final RoadmapLastValueDto lastValue,
+                                                                                 final int pageSize) {
+        return selectFrom(roadmapReview)
+                .innerJoin(roadmapReview.member, member)
+                .fetchJoin()
+                .where(roadmapCond(roadmap), lessThanLastValue(lastValue))
+                .limit(pageSize)
+                .orderBy(orderByCreatedAtDesc())
+                .fetch();
+    }
+
+    private BooleanExpression roadmapCond(final Roadmap roadmap) {
+        return roadmapReview.roadmap.eq(roadmap);
+    }
+
+    private BooleanExpression lessThanLastValue(final RoadmapLastValueDto lastValue) {
+        if (lastValue == null) {
+            return null;
+        }
+        return roadmap.createdAt.lt(lastValue.getLastCreatedAt());
+    }
+
+    private OrderSpecifier<LocalDateTime> orderByCreatedAtDesc() {
+        return roadmapReview.createdAt.desc();
+    }
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapReviewRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapReviewRepository.java
@@ -3,13 +3,10 @@ package co.kirikiri.persistence.roadmap;
 import co.kirikiri.domain.member.Member;
 import co.kirikiri.domain.roadmap.Roadmap;
 import co.kirikiri.domain.roadmap.RoadmapReview;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RoadmapReviewRepository extends JpaRepository<RoadmapReview, Long> {
+public interface RoadmapReviewRepository extends JpaRepository<RoadmapReview, Long>, RoadmapReviewQueryRepository {
 
     Optional<RoadmapReview> findByRoadmapAndMember(final Roadmap roadmap, final Member member);
-
-    List<RoadmapReview> findByRoadmapOrderByUpdatedAtDesc(final Roadmap roadmap);
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapReviewRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapReviewRepository.java
@@ -3,10 +3,13 @@ package co.kirikiri.persistence.roadmap;
 import co.kirikiri.domain.member.Member;
 import co.kirikiri.domain.roadmap.Roadmap;
 import co.kirikiri.domain.roadmap.RoadmapReview;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoadmapReviewRepository extends JpaRepository<RoadmapReview, Long> {
 
     Optional<RoadmapReview> findByRoadmapAndMember(final Roadmap roadmap, final Member member);
+
+    List<RoadmapReview> findByRoadmapOrderByUpdatedAtDesc(final Roadmap roadmap);
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapReadService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapReadService.java
@@ -26,6 +26,7 @@ import co.kirikiri.service.dto.roadmap.response.RoadmapCategoryResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapForListResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapGoalRoomResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
+import co.kirikiri.service.dto.roadmap.response.RoadmapReviewResponse;
 import co.kirikiri.service.mapper.GoalRoomMapper;
 import co.kirikiri.service.mapper.RoadmapMapper;
 import java.util.List;
@@ -120,5 +121,9 @@ public class RoadmapReadService {
         final List<GoalRoom> goalRoomsWithPendingMembers = goalRoomRepository.findGoalRoomsWithPendingMembersByRoadmapAndCond(
                 roadmap, filterType, goalRoomLastValueDto, scrollRequest.size());
         return GoalRoomMapper.convertToRoadmapGoalRoomResponses(goalRoomsWithPendingMembers);
+    }
+
+    public List<RoadmapReviewResponse> findRoadmapReviews(final Long roadmapId) {
+        return null;
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapReadService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapReadService.java
@@ -126,9 +126,12 @@ public class RoadmapReadService {
         return GoalRoomMapper.convertToRoadmapGoalRoomResponses(goalRoomsWithPendingMembers);
     }
 
-    public List<RoadmapReviewResponse> findRoadmapReviews(final Long roadmapId) {
+    public List<RoadmapReviewResponse> findRoadmapReviews(final Long roadmapId,
+                                                          final CustomScrollRequest scrollRequest) {
         final Roadmap roadmap = findRoadmapById(roadmapId);
-        final List<RoadmapReview> roadmapReviews = roadmapReviewRepository.findByRoadmapOrderByUpdatedAtDesc(roadmap);
-        return GoalRoomMapper.convertToRoadmapReviewResponses(roadmapReviews);
+        final RoadmapLastValueDto roadmapLastValueDto = RoadmapLastValueDto.create(scrollRequest);
+        final List<RoadmapReview> roadmapReviews = roadmapReviewRepository.findRoadmapReviewWithMemberByRoadmapOrderByLatest(
+                roadmap, roadmapLastValueDto, scrollRequest.size());
+        return RoadmapMapper.convertToRoadmapReviewResponses(roadmapReviews);
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapReadService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapReadService.java
@@ -6,6 +6,7 @@ import co.kirikiri.domain.member.vo.Identifier;
 import co.kirikiri.domain.roadmap.Roadmap;
 import co.kirikiri.domain.roadmap.RoadmapCategory;
 import co.kirikiri.domain.roadmap.RoadmapContent;
+import co.kirikiri.domain.roadmap.RoadmapReview;
 import co.kirikiri.exception.NotFoundException;
 import co.kirikiri.persistence.dto.GoalRoomLastValueDto;
 import co.kirikiri.persistence.dto.RoadmapFilterType;
@@ -17,6 +18,7 @@ import co.kirikiri.persistence.member.MemberRepository;
 import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
 import co.kirikiri.persistence.roadmap.RoadmapContentRepository;
 import co.kirikiri.persistence.roadmap.RoadmapRepository;
+import co.kirikiri.persistence.roadmap.RoadmapReviewRepository;
 import co.kirikiri.service.dto.CustomScrollRequest;
 import co.kirikiri.service.dto.roadmap.RoadmapGoalRoomsFilterTypeDto;
 import co.kirikiri.service.dto.roadmap.request.RoadmapFilterTypeRequest;
@@ -42,6 +44,7 @@ public class RoadmapReadService {
     private final RoadmapRepository roadmapRepository;
     private final RoadmapCategoryRepository roadmapCategoryRepository;
     private final RoadmapContentRepository roadmapContentRepository;
+    private final RoadmapReviewRepository roadmapReviewRepository;
     private final GoalRoomRepository goalRoomRepository;
     private final MemberRepository memberRepository;
 
@@ -124,6 +127,8 @@ public class RoadmapReadService {
     }
 
     public List<RoadmapReviewResponse> findRoadmapReviews(final Long roadmapId) {
-        return null;
+        final Roadmap roadmap = findRoadmapById(roadmapId);
+        final List<RoadmapReview> roadmapReviews = roadmapReviewRepository.findByRoadmapOrderByUpdatedAtDesc(roadmap);
+        return GoalRoomMapper.convertToRoadmapReviewResponses(roadmapReviews);
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/response/RoadmapReviewResponse.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/response/RoadmapReviewResponse.java
@@ -1,0 +1,15 @@
+package co.kirikiri.service.dto.roadmap.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+
+public record RoadmapReviewResponse(
+        Long id,
+        String name,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime updatedAt,
+        String content,
+        Double rate
+) {
+
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/response/RoadmapReviewResponse.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/response/RoadmapReviewResponse.java
@@ -7,7 +7,7 @@ public record RoadmapReviewResponse(
         Long id,
         String name,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime updatedAt,
+        LocalDateTime createdAt,
         String content,
         Double rate
 ) {

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
@@ -13,7 +13,6 @@ import co.kirikiri.domain.goalroom.vo.GoalRoomTodoContent;
 import co.kirikiri.domain.goalroom.vo.LimitedMemberCount;
 import co.kirikiri.domain.goalroom.vo.Period;
 import co.kirikiri.domain.member.Member;
-import co.kirikiri.domain.roadmap.RoadmapReview;
 import co.kirikiri.persistence.goalroom.dto.RoadmapGoalRoomsFilterType;
 import co.kirikiri.service.dto.goalroom.GoalRoomCreateDto;
 import co.kirikiri.service.dto.goalroom.GoalRoomRoadmapNodeDto;
@@ -35,7 +34,6 @@ import co.kirikiri.service.dto.member.response.MemberGoalRoomResponse;
 import co.kirikiri.service.dto.member.response.MemberResponse;
 import co.kirikiri.service.dto.roadmap.RoadmapGoalRoomsFilterTypeDto;
 import co.kirikiri.service.dto.roadmap.response.RoadmapGoalRoomResponse;
-import co.kirikiri.service.dto.roadmap.response.RoadmapReviewResponse;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AccessLevel;
@@ -231,17 +229,5 @@ public class GoalRoomMapper {
                 goalRoom.getCurrentMemberCount(), goalRoom.getLimitedMemberCount().getValue(),
                 goalRoom.getCreatedAt(), goalRoom.getStartDate(), goalRoom.getEndDate(),
                 new MemberResponse(leader.getId(), leader.getNickname().getValue()));
-    }
-
-    public static List<RoadmapReviewResponse> convertToRoadmapReviewResponses(
-            final List<RoadmapReview> roadmapReviews) {
-        return roadmapReviews.stream()
-                .map(GoalRoomMapper::convertToRaodmapReviewResponse)
-                .toList();
-    }
-
-    private static RoadmapReviewResponse convertToRaodmapReviewResponse(final RoadmapReview roadmapReview) {
-        return new RoadmapReviewResponse(roadmapReview.getId(), roadmapReview.getMemberNickname(),
-                roadmapReview.getUpdatedAt(), roadmapReview.getContent(), roadmapReview.getRate());
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
@@ -13,6 +13,7 @@ import co.kirikiri.domain.goalroom.vo.GoalRoomTodoContent;
 import co.kirikiri.domain.goalroom.vo.LimitedMemberCount;
 import co.kirikiri.domain.goalroom.vo.Period;
 import co.kirikiri.domain.member.Member;
+import co.kirikiri.domain.roadmap.RoadmapReview;
 import co.kirikiri.persistence.goalroom.dto.RoadmapGoalRoomsFilterType;
 import co.kirikiri.service.dto.goalroom.GoalRoomCreateDto;
 import co.kirikiri.service.dto.goalroom.GoalRoomRoadmapNodeDto;
@@ -34,6 +35,7 @@ import co.kirikiri.service.dto.member.response.MemberGoalRoomResponse;
 import co.kirikiri.service.dto.member.response.MemberResponse;
 import co.kirikiri.service.dto.roadmap.RoadmapGoalRoomsFilterTypeDto;
 import co.kirikiri.service.dto.roadmap.response.RoadmapGoalRoomResponse;
+import co.kirikiri.service.dto.roadmap.response.RoadmapReviewResponse;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AccessLevel;
@@ -147,7 +149,7 @@ public class GoalRoomMapper {
     }
 
     private static GoalRoomTodoResponse convertGoalRoomTodoResponse(final List<Long> checkedTodoIds,
-                                                                final GoalRoomToDo goalRoomToDo) {
+                                                                    final GoalRoomToDo goalRoomToDo) {
         final GoalRoomToDoCheckResponse checkResponse = new GoalRoomToDoCheckResponse(
                 isCheckedTodo(goalRoomToDo.getId(), checkedTodoIds));
         return new GoalRoomTodoResponse(goalRoomToDo.getId(),
@@ -165,7 +167,8 @@ public class GoalRoomMapper {
                                                                          final List<Long> checkedTodoIds) {
         final GoalRoomRoadmapNodesResponse nodeResponses = convertToGoalRoomRoadmapNodesResponse(
                 goalRoom.getGoalRoomRoadmapNodes());
-        final List<GoalRoomTodoResponse> todoResponses = convertGoalRoomTodoResponsesLimit(goalRoom.getGoalRoomToDos(), checkedTodoIds);
+        final List<GoalRoomTodoResponse> todoResponses = convertGoalRoomTodoResponsesLimit(goalRoom.getGoalRoomToDos(),
+                checkedTodoIds);
         final List<CheckFeedResponse> checkFeedResponses = convertToCheckFeedResponses(checkFeeds);
 
         return new MemberGoalRoomResponse(goalRoom.getName().getValue(), goalRoom.getStatus().name(),
@@ -194,7 +197,7 @@ public class GoalRoomMapper {
     }
 
     private static List<GoalRoomTodoResponse> convertGoalRoomTodoResponsesLimit(final GoalRoomToDos goalRoomToDos,
-                                                                           final List<Long> checkedTodoIds) {
+                                                                                final List<Long> checkedTodoIds) {
         return goalRoomToDos.getValues()
                 .stream()
                 .map(goalRoomToDo -> convertGoalRoomTodoResponse(checkedTodoIds, goalRoomToDo))
@@ -228,5 +231,17 @@ public class GoalRoomMapper {
                 goalRoom.getCurrentMemberCount(), goalRoom.getLimitedMemberCount().getValue(),
                 goalRoom.getCreatedAt(), goalRoom.getStartDate(), goalRoom.getEndDate(),
                 new MemberResponse(leader.getId(), leader.getNickname().getValue()));
+    }
+
+    public static List<RoadmapReviewResponse> convertToRoadmapReviewResponses(
+            final List<RoadmapReview> roadmapReviews) {
+        return roadmapReviews.stream()
+                .map(GoalRoomMapper::convertToRaodmapReviewResponse)
+                .toList();
+    }
+
+    private static RoadmapReviewResponse convertToRaodmapReviewResponse(final RoadmapReview roadmapReview) {
+        return new RoadmapReviewResponse(roadmapReview.getId(), roadmapReview.getMemberNickname(),
+                roadmapReview.getUpdatedAt(), roadmapReview.getContent(), roadmapReview.getRate());
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/RoadmapMapper.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/RoadmapMapper.java
@@ -7,6 +7,7 @@ import co.kirikiri.domain.roadmap.RoadmapContent;
 import co.kirikiri.domain.roadmap.RoadmapNode;
 import co.kirikiri.domain.roadmap.RoadmapNodeImage;
 import co.kirikiri.domain.roadmap.RoadmapNodes;
+import co.kirikiri.domain.roadmap.RoadmapReview;
 import co.kirikiri.domain.roadmap.RoadmapTags;
 import co.kirikiri.persistence.dto.RoadmapFilterType;
 import co.kirikiri.service.dto.member.response.MemberResponse;
@@ -25,6 +26,7 @@ import co.kirikiri.service.dto.roadmap.response.RoadmapContentResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapForListResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapNodeResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
+import co.kirikiri.service.dto.roadmap.response.RoadmapReviewResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapTagResponse;
 import java.util.List;
 import lombok.AccessLevel;
@@ -154,5 +156,17 @@ public final class RoadmapMapper {
                             new RoadmapCategoryResponse(category.getId(), category.getName()));
                 })
                 .toList();
+    }
+
+    public static List<RoadmapReviewResponse> convertToRoadmapReviewResponses(
+            final List<RoadmapReview> roadmapReviews) {
+        return roadmapReviews.stream()
+                .map(RoadmapMapper::convertToRoadmapReviewResponse)
+                .toList();
+    }
+
+    private static RoadmapReviewResponse convertToRoadmapReviewResponse(final RoadmapReview roadmapReview) {
+        return new RoadmapReviewResponse(roadmapReview.getId(), roadmapReview.getMemberNickname(),
+                roadmapReview.getCreatedAt(), roadmapReview.getContent(), roadmapReview.getRate());
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapReviewRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapReviewRepositoryTest.java
@@ -82,7 +82,7 @@ class RoadmapReviewRepositoryTest {
     }
 
     @Test
-    void 로드맵에_대한_리뷰_정보를_조회한다() {
+    void 로드맵에_대한_리뷰_정보를_최신순으로_조회한다() {
         // given
         final Member member = 사용자를_저장한다("코끼리", "cokirikiri");
         final Member member2 = 사용자를_저장한다("끼리코", "kirikirico");

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapReviewRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapReviewRepositoryTest.java
@@ -81,6 +81,50 @@ class RoadmapReviewRepositoryTest {
                 .isEmpty();
     }
 
+    @Test
+    void 로드맵에_대한_리뷰_정보를_조회한다() {
+        // given
+        final Member member = 사용자를_저장한다("코끼리", "cokirikiri");
+        final Member member2 = 사용자를_저장한다("끼리코", "kirikirico");
+        final RoadmapCategory category = 카테고리를_저장한다("게임");
+        final Roadmap roadmap = 로드맵을_저장한다(member, category);
+
+        final RoadmapReview roadmapReview1 = new RoadmapReview("리뷰", 2.5, member);
+        final RoadmapReview roadmapReview2 = new RoadmapReview("리뷰", 4.0, member2);
+        roadmapReview1.updateRoadmap(roadmap);
+        roadmapReview2.updateRoadmap(roadmap);
+        roadmapReviewRepository.save(roadmapReview1);
+        roadmapReviewRepository.save(roadmapReview2);
+
+        // when
+        final List<RoadmapReview> findRoadmapReviews = roadmapReviewRepository.findByRoadmapOrderByUpdatedAtDesc(
+                roadmap);
+
+        // then
+        assertThat(findRoadmapReviews)
+                .isEqualTo(List.of(roadmapReview2, roadmapReview1));
+    }
+
+    @Test
+    void 로드맵에_대한_리뷰_정보가_없으면_빈_값을_반환한다() {
+        // given
+        final Member member = 사용자를_저장한다("코끼리", "cokirikiri");
+        final Member member2 = 사용자를_저장한다("끼리코", "kirikirico");
+        final RoadmapCategory category = 카테고리를_저장한다("게임");
+        final Roadmap roadmap1 = 로드맵을_저장한다(member, category);
+        final Roadmap roadmap2 = 로드맵을_저장한다(member2, category);
+
+        final RoadmapReview roadmapReview = new RoadmapReview("리뷰", 2.5, member);
+        roadmapReview.updateRoadmap(roadmap1);
+        roadmapReviewRepository.save(roadmapReview);
+
+        // when
+        final List<RoadmapReview> roadmapReviews = roadmapReviewRepository.findByRoadmapOrderByUpdatedAtDesc(roadmap2);
+
+        // then
+        assertThat(roadmapReviews).isEmpty();
+    }
+
     private Member 사용자를_저장한다(final String name, final String identifier) {
         final MemberProfile memberProfile = new MemberProfile(Gender.MALE, LocalDate.of(1990, 1, 1), "010-1234-5678");
         final Member creator = new Member(new Identifier(identifier), new EncryptedPassword(new Password("password1!")),

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapReviewRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapReviewRepositoryTest.java
@@ -1,6 +1,7 @@
 package co.kirikiri.persistence.roadmap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import co.kirikiri.domain.member.EncryptedPassword;
 import co.kirikiri.domain.member.Gender;
@@ -16,8 +17,10 @@ import co.kirikiri.domain.roadmap.RoadmapDifficulty;
 import co.kirikiri.domain.roadmap.RoadmapNode;
 import co.kirikiri.domain.roadmap.RoadmapNodes;
 import co.kirikiri.domain.roadmap.RoadmapReview;
+import co.kirikiri.persistence.dto.RoadmapLastValueDto;
 import co.kirikiri.persistence.helper.RepositoryTest;
 import co.kirikiri.persistence.member.MemberRepository;
+import co.kirikiri.service.dto.CustomScrollRequest;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -97,12 +100,23 @@ class RoadmapReviewRepositoryTest {
         roadmapReviewRepository.save(roadmapReview2);
 
         // when
-        final List<RoadmapReview> findRoadmapReviews = roadmapReviewRepository.findByRoadmapOrderByUpdatedAtDesc(
-                roadmap);
+        final RoadmapLastValueDto firstRoadmapLastValueDto = RoadmapLastValueDto.create(
+                new CustomScrollRequest(null, null, null, null, 2));
+        final List<RoadmapReview> roadmapReviewsFirstPage = roadmapReviewRepository.findRoadmapReviewWithMemberByRoadmapOrderByLatest(
+                roadmap, firstRoadmapLastValueDto, 2);
+
+        final RoadmapLastValueDto secondRoadmapLastValueDto = RoadmapLastValueDto.create(
+                new CustomScrollRequest(roadmapReviewsFirstPage.get(1).getCreatedAt(), null, null, null, 2));
+        final List<RoadmapReview> roadmapReviewsSecondPage = roadmapReviewRepository.findRoadmapReviewWithMemberByRoadmapOrderByLatest(
+                roadmap, secondRoadmapLastValueDto, 2);
 
         // then
-        assertThat(findRoadmapReviews)
-                .isEqualTo(List.of(roadmapReview2, roadmapReview1));
+        assertAll(
+                () -> assertThat(roadmapReviewsFirstPage)
+                        .isEqualTo(List.of(roadmapReview2, roadmapReview1)),
+                () -> assertThat(roadmapReviewsSecondPage)
+                        .isEmpty()
+        );
     }
 
     @Test
@@ -119,10 +133,13 @@ class RoadmapReviewRepositoryTest {
         roadmapReviewRepository.save(roadmapReview);
 
         // when
-        final List<RoadmapReview> roadmapReviews = roadmapReviewRepository.findByRoadmapOrderByUpdatedAtDesc(roadmap2);
+        final RoadmapLastValueDto firstRoadmapLastValueDto = RoadmapLastValueDto.create(
+                new CustomScrollRequest(null, null, null, null, 1));
+        final List<RoadmapReview> roadmapReviewsFirstPage = roadmapReviewRepository.findRoadmapReviewWithMemberByRoadmapOrderByLatest(
+                roadmap2, firstRoadmapLastValueDto, 1);
 
         // then
-        assertThat(roadmapReviews).isEmpty();
+        assertThat(roadmapReviewsFirstPage).isEmpty();
     }
 
     private Member 사용자를_저장한다(final String name, final String identifier) {

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/RoadmapReadServiceTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/RoadmapReadServiceTest.java
@@ -410,29 +410,34 @@ class RoadmapReadServiceTest {
         roadmapReview1.updateRoadmap(roadmap);
         roadmapReview2.updateRoadmap(roadmap);
 
+        final CustomScrollRequest scrollRequest = new CustomScrollRequest(null, null, null, null, 50);
+
         when(roadmapRepository.findRoadmapById(anyLong())).thenReturn(Optional.of(roadmap));
-        when(roadmapReviewRepository.findByRoadmapOrderByUpdatedAtDesc(any())).thenReturn(
-                List.of(roadmapReview2, roadmapReview1));
+        when(roadmapReviewRepository.findRoadmapReviewWithMemberByRoadmapOrderByLatest(any(), any(), anyInt()))
+                .thenReturn(List.of(roadmapReview2, roadmapReview1));
 
         // when
-        final List<RoadmapReviewResponse> response = roadmapService.findRoadmapReviews(1L);
+        final List<RoadmapReviewResponse> response = roadmapService.findRoadmapReviews(1L, scrollRequest);
 
         final List<RoadmapReviewResponse> expect = List.of(
                 new RoadmapReviewResponse(2L, "리뷰어2", LocalDateTime.now(), "리뷰 내용", 4.5),
                 new RoadmapReviewResponse(1L, "리뷰어1", LocalDateTime.now(), "리뷰 내용", 5.0));
 
         // then
-        assertThat(response).usingRecursiveComparison().ignoringFields("id", "updatedAt").isEqualTo(expect);
+        assertThat(response).usingRecursiveComparison().ignoringFields("id", "createdAt").isEqualTo(expect);
     }
 
     @Test
     void 로드맵_리뷰_조회_시_유효하지_않은_로드맵_아이디라면_예외를_반환한다() {
         // given
+        final CustomScrollRequest scrollRequest = new CustomScrollRequest(null, null, null, null, 2);
+
         when(roadmapRepository.findRoadmapById(anyLong()))
                 .thenThrow(new NotFoundException("존재하지 않는 로드맵입니다. roadmapId = 1"));
 
         // when, then
-        assertThatThrownBy(() -> roadmapService.findRoadmapReviews(1L)).isInstanceOf(NotFoundException.class)
+        assertThatThrownBy(() -> roadmapService.findRoadmapReviews(1L, scrollRequest))
+                .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("존재하지 않는 로드맵입니다. roadmapId = 1");
     }
 


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-114](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-114)


## ✨ 작업 내용
- 로드맵의 리뷰들을 조회하는 기능을 무한 스크롤 방식으로 구현했습니다.
- 각 로드맵의 리뷰들은 최신순으로 정렬되어 전달됩니다.
- 리뷰 내용 및 별점, 작성자 닉네임, 작성 시간 등을 함께 전달합니다


## 💬 리뷰어에게 남길 멘트
- 크게 어려움은 없었고 구현할 내용도 별로 없어서 리뷰에 큰 시간이 걸리지 않을 것 같네요. 그런데 무한 스크롤 방식으로 구현했는데 테스트가 제대로 되지 않아서 제가 작동하는 방식을 제대로 이해를 못 하고 있는 거 같아요. RoadmapRepositoryTest를 참고해주시면 감사하겠습니다. 직접 물어보려고 하는데 잘 부탁드립니다😆


## 🚀 요구사항 분석
- [x] 로드맵 리뷰 조회 API
    - [x] 특정 로드맵에 대한 리뷰를 무한 스크롤 방식으로 조회한다
    - [x] 리뷰 목록은 최신순으로 조회한다

