### PR TITLE
[feat/CK-151] 골룸리스트의 오류를 해결한다

### DIFF
--- a/client/src/apis/goalRoom.ts
+++ b/client/src/apis/goalRoom.ts
@@ -16,8 +16,8 @@ export const getGoalRoomList = async ({
   filterCond = 'LATEST',
   lastCreatedAt = '',
   size = 10,
-}: GoalRoomListRequest): Promise<GoalRoomDetailResponse[]> => {
-  const { data } = await client.get<GoalRoomDetailResponse[]>(
+}: GoalRoomListRequest): Promise<GoalRoomDetailResponse> => {
+  const { data } = await client.get<GoalRoomDetailResponse>(
     `/roadmaps/${roadmapId}/goal-rooms?filterCond=${filterCond}&lastCreatedAt=${lastCreatedAt}&size=${size}`
   );
   return data;

--- a/client/src/components/goalRoomListPage/goalRoomList/GoalRoomFilter.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomList/GoalRoomFilter.tsx
@@ -1,0 +1,34 @@
+import { Select } from '@/components/roadmapCreatePage/selector/SelectBox';
+import { goalRoomFilter } from '@/constants/goalRoom/goalRoomFilter';
+import React, { useState } from 'react';
+import * as S from './goalRoomList.styles';
+
+const GoalRoomFilter = ({
+  children,
+}: {
+  children: (
+    selectedOption: (typeof goalRoomFilter)[keyof typeof goalRoomFilter]
+  ) => React.ReactNode;
+}) => {
+  const [selectedOption, setSelectedOption] =
+    useState<(typeof goalRoomFilter)[keyof typeof goalRoomFilter]>('마감 임박 순');
+
+  const selectFilterOption = (id: number) => {
+    if (Object.hasOwn(goalRoomFilter, id)) {
+      setSelectedOption(goalRoomFilter[id as keyof typeof goalRoomFilter]);
+    }
+  };
+
+  return (
+    <S.FilterWrapper>
+      <Select externalSelectState={selectFilterOption}>
+        <Select.Trigger asChild>
+          <S.FilterTrigger>{selectedOption}</S.FilterTrigger>
+        </Select.Trigger>
+        {children(selectedOption)}
+      </Select>
+    </S.FilterWrapper>
+  );
+};
+
+export default GoalRoomFilter;

--- a/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
@@ -3,21 +3,46 @@ import GoalRoomItem from './GoalRoomItem';
 import { useGoalRoomList } from '@/hooks/queries/goalRoom';
 import useValidParams from '@/hooks/_common/useValidParams';
 import { useNavigate } from 'react-router-dom';
+import GoalRoomFilter from './GoalRoomFilter';
+import { Select } from '@/components/roadmapCreatePage/selector/SelectBox';
+import { useState } from 'react';
+import { goalRoomFilter } from '@/constants/goalRoom/goalRoomFilter';
 
 const GoalRoomList = () => {
   const { id } = useValidParams<{ id: string }>();
-  const { goalRoomList } = useGoalRoomList({ roadmapId: Number(id) });
-
+  const [sortedOption, setSortedOption] =
+    useState<(typeof goalRoomFilter)[keyof typeof goalRoomFilter]>('마감 임박 순');
+  const { goalRoomList } = useGoalRoomList({
+    roadmapId: Number(id),
+    filterCond: sortedOption === '참여 인원 순' ? 'PARTICIPATION_RATE' : 'LATEST',
+  });
   const navigate = useNavigate();
 
   const moveCreateGoalRoomPage = () => {
     navigate(`/roadmap/${Number(id)}/goalroom-create`);
   };
+
   return (
     <S.ListContainer role='main' aria-label='골룸 리스트'>
       <S.FilterBar>
         <p aria-live='polite'>모집중인 골룸 {goalRoomList.length}개</p>
-        <p aria-live='polite'>마감 임박순</p>
+        <GoalRoomFilter>
+          {(selectedOption) => {
+            setSortedOption(selectedOption);
+            return (
+              <Select.OptionGroup asChild>
+                <S.FilterOptionWrapper>
+                  <Select.Option id={1} asChild>
+                    <S.FilterOption>마감 임박순</S.FilterOption>
+                  </Select.Option>
+                  <Select.Option id={2} asChild>
+                    <S.FilterOption>참여인원 순</S.FilterOption>
+                  </Select.Option>
+                </S.FilterOptionWrapper>
+              </Select.OptionGroup>
+            );
+          }}
+        </GoalRoomFilter>
       </S.FilterBar>
       <S.ListWrapper role='list' aria-label='골룸 리스트'>
         {goalRoomList.map((goalRoomInfo) => {

--- a/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
+++ b/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
@@ -101,3 +101,36 @@ export const CreateGoalRoomButton = styled.button`
   background-color: ${({ theme }) => theme.colors.main_middle};
   border-radius: 20px;
 `;
+
+export const FilterWrapper = styled.div`
+  ${({ theme }) => theme.fonts.description4};
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  color: ${({ theme }) => theme.colors.gray200};
+`;
+
+export const FilterTrigger = styled.button`
+  ${({ theme }) => theme.fonts.description4};
+  width: 9rem;
+  height: 1.5rem;
+  color: ${({ theme }) => theme.colors.gray200};
+`;
+
+export const FilterOptionWrapper = styled.ul`
+  position: absolute;
+  top: 2rem;
+
+  width: 9rem;
+  /* height: 3rem; */
+
+  border: 0.2rem solid ${({ theme }) => theme.colors.main_middle};
+  border-radius: 4px;
+`;
+
+export const FilterOption = styled.li`
+  cursor: pointer;
+  width: 100%;
+  height: 50%;
+  padding: 1rem 1rem;
+`;

--- a/client/src/constants/goalRoom/goalRoomFilter.ts
+++ b/client/src/constants/goalRoom/goalRoomFilter.ts
@@ -1,0 +1,4 @@
+export const goalRoomFilter = {
+  1: '마감 임박 순',
+  2: '참여 인원 순',
+} as const;

--- a/client/src/hooks/queries/goalRoom.ts
+++ b/client/src/hooks/queries/goalRoom.ts
@@ -27,7 +27,7 @@ export const useGoalRoomList = (params: GoalRoomListRequest) => {
   const { data } = useSuspendedQuery(['goalRoomList', params.roadmapId], () =>
     getGoalRoomList(params)
   );
-  return { goalRoomList: data };
+  return { goalRoomList: data.responses };
 };
 
 export const useMyPageGoalRoomList = (statusCond: GoalRoomRecruitmentStatus) => {

--- a/client/src/myTypes/_common/global.d.ts
+++ b/client/src/myTypes/_common/global.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  export interface ObjectConstructor {
+    hasOwn<T extends object>(o: T, p: PropertyKey): p is keyof typeof o;
+  }
+}
+
+export {};

--- a/client/src/myTypes/goalRoom/remote.ts
+++ b/client/src/myTypes/goalRoom/remote.ts
@@ -7,7 +7,7 @@ import {
   GoalRoomTodo,
 } from '@myTypes/goalRoom/internal';
 
-type FilterCondType = 'LATEST';
+type FilterCondType = 'LATEST' | 'PARTICIPATION_RATE';
 
 export type GoalRoomListRequest = {
   roadmapId: number;
@@ -45,7 +45,10 @@ export type CreateGoalRoomRequest = {
   goalRoomRoadmapNodeRequests: GoalRoomRoadmapNodeRequestsType[];
 };
 
-export type GoalRoomDetailResponse = GoalRoomDetailType;
+export type GoalRoomDetailResponse = {
+  responses: GoalRoomDetailType[];
+  hasNext: boolean;
+};
 
 export type GoalRoomInfoResponse = GoalRoomInfoType;
 


### PR DESCRIPTION
## 📌 작업 이슈 번호
CK-156


## ✨ 작업 내용
골룸 리스트에 있는 버그들 & 부족한 부분들을 해결했습니다.
- 골룸 리스트 필터링 기능 구현
- 무한스크롤이 적용된 api명세 반영


## 💬 리뷰어에게 남길 멘트
selectBox컴포넌트를 활용해서 골룸 리스트의 필터 컴포넌트를 만든 뒤 render-props를 이용해서 그 안에 상태를 꺼내는 방식으로
골룸리스트를 필터링해줬습니다.
```ts
const GoalRoomFilter = ({
  children,
}: {
  children: (
    selectedOption: (typeof goalRoomFilter)[keyof typeof goalRoomFilter]
  ) => React.ReactNode;
}) => {
// logic
return (
    <S.FilterWrapper>
      <Select externalSelectState={selectFilterOption}>
        <Select.Trigger asChild>
          <S.FilterTrigger>{selectedOption}</S.FilterTrigger>
        </Select.Trigger>
        {children(selectedOption)}
      </Select>
    </S.FilterWrapper>
  );
};
```
이런 식으로 GoalRoomFilter컴포넌트는 `children함수`를 반환해요.

```ts
<GoalRoomFilter>
          {(selectedOption) => {
            setSortedOption(selectedOption);
            return (
              <Select.OptionGroup asChild>
                <S.FilterOptionWrapper>
                  <Select.Option id={1} asChild>
                    <S.FilterOption>마감 임박순</S.FilterOption>
                  </Select.Option>
                  <Select.Option id={2} asChild>
                    <S.FilterOption>참여인원 순</S.FilterOption>
                  </Select.Option>
                </S.FilterOptionWrapper>
              </Select.OptionGroup>
            );
          }}
        </GoalRoomFilter>
```
이런식으로 GoalRoomFilter를 사용하는 곳에서 children으로 GoalRoomFilter 안의 상태를 꺼내서 쓸 수 있어요.

## 🚀 요구사항 분석


