### PR TITLE
[Fix/CK-165] 골룸 참여자 조회 시 골룸의 상태에 상관없이 조회 가능하도록 수정한다

### DIFF
--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberQueryRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberQueryRepository.java
@@ -1,0 +1,11 @@
+package co.kirikiri.persistence.goalroom;
+
+import co.kirikiri.domain.goalroom.GoalRoomPendingMember;
+import co.kirikiri.persistence.goalroom.dto.GoalRoomMemberSortType;
+import java.util.List;
+
+public interface GoalRoomPendingMemberQueryRepository {
+
+    List<GoalRoomPendingMember> findByGoalRoomIdOrderedBySortType(final Long goalRoomId,
+                                                                  final GoalRoomMemberSortType sortType);
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberQueryRepositoryImpl.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberQueryRepositoryImpl.java
@@ -1,0 +1,40 @@
+package co.kirikiri.persistence.goalroom;
+
+import static co.kirikiri.domain.goalroom.QGoalRoomPendingMember.goalRoomPendingMember;
+import static co.kirikiri.domain.member.QMember.member;
+import static co.kirikiri.domain.member.QMemberImage.memberImage;
+import static co.kirikiri.persistence.goalroom.dto.GoalRoomMemberSortType.JOINED_DESC;
+
+import co.kirikiri.domain.goalroom.GoalRoomPendingMember;
+import co.kirikiri.persistence.QuerydslRepositorySupporter;
+import co.kirikiri.persistence.goalroom.dto.GoalRoomMemberSortType;
+import com.querydsl.core.types.OrderSpecifier;
+import java.util.List;
+
+public class GoalRoomPendingMemberQueryRepositoryImpl extends QuerydslRepositorySupporter
+        implements GoalRoomPendingMemberQueryRepository {
+
+    public GoalRoomPendingMemberQueryRepositoryImpl() {
+        super(GoalRoomPendingMember.class);
+    }
+
+    @Override
+    public List<GoalRoomPendingMember> findByGoalRoomIdOrderedBySortType(final Long goalRoomId,
+                                                                         final GoalRoomMemberSortType sortType) {
+        return selectFrom(goalRoomPendingMember)
+                .innerJoin(goalRoomPendingMember.member, member)
+                .fetchJoin()
+                .innerJoin(member.image, memberImage)
+                .fetchJoin()
+                .where(goalRoomPendingMember.goalRoom.id.eq(goalRoomId))
+                .orderBy(sortCond(sortType))
+                .fetch();
+    }
+
+    private OrderSpecifier<?> sortCond(final GoalRoomMemberSortType sortType) {
+        if (sortType == JOINED_DESC) {
+            return goalRoomPendingMember.joinedAt.desc();
+        }
+        return goalRoomPendingMember.joinedAt.asc();
+    }
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface GoalRoomPendingMemberRepository extends JpaRepository<GoalRoomPendingMember, Long> {
+public interface GoalRoomPendingMemberRepository extends JpaRepository<GoalRoomPendingMember, Long>,
+        GoalRoomPendingMemberQueryRepository {
 
     @Query("select gp from GoalRoomPendingMember gp "
             + "inner join fetch gp.goalRoom g "

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomReadService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomReadService.java
@@ -77,13 +77,14 @@ public class GoalRoomReadService {
     public List<GoalRoomMemberResponse> findGoalRoomMembers(final Long goalRoomId,
                                                             final GoalRoomMemberSortTypeDto sortType) {
         final GoalRoom goalRoom = findGoalRoomById(goalRoomId);
+        final GoalRoomMemberSortType goalRoomMemberSortType = GoalRoomMapper.convertGoalRoomMemberSortType(sortType);
         if (goalRoom.isRecruiting()) {
             final List<GoalRoomPendingMember> goalRoomPendingMembers = goalRoomPendingMemberRepository.findByGoalRoomIdOrderedBySortType(
-                    goalRoomId, GoalRoomMemberSortType.valueOf(sortType.name()));
+                    goalRoomId, goalRoomMemberSortType);
             return GoalRoomMapper.convertToGoalRoomPendingMemberResponses(goalRoomPendingMembers);
         }
         final List<GoalRoomMember> goalRoomMembers = goalRoomMemberRepository.findByGoalRoomIdOrderedBySortType(
-                goalRoomId, GoalRoomMemberSortType.valueOf(sortType.name()));
+                goalRoomId, goalRoomMemberSortType);
         return GoalRoomMapper.convertToGoalRoomMemberResponses(goalRoomMembers);
     }
 

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
@@ -16,8 +16,10 @@ import co.kirikiri.domain.goalroom.vo.LimitedMemberCount;
 import co.kirikiri.domain.goalroom.vo.Period;
 import co.kirikiri.domain.member.Member;
 import co.kirikiri.domain.member.MemberImage;
+import co.kirikiri.persistence.goalroom.dto.GoalRoomMemberSortType;
 import co.kirikiri.persistence.goalroom.dto.RoadmapGoalRoomsFilterType;
 import co.kirikiri.service.dto.goalroom.GoalRoomCreateDto;
+import co.kirikiri.service.dto.goalroom.GoalRoomMemberSortTypeDto;
 import co.kirikiri.service.dto.goalroom.GoalRoomRoadmapNodeDto;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomCreateRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomRoadmapNodeRequest;
@@ -139,6 +141,13 @@ public class GoalRoomMapper {
         final Member goalRoomLeader = goalRoom.findGoalRoomLeader();
         return new MemberResponse(goalRoomLeader.getId(), goalRoomLeader.getNickname().getValue(),
                 goalRoomLeader.getImage().getServerFilePath());
+    }
+
+    public static GoalRoomMemberSortType convertGoalRoomMemberSortType(final GoalRoomMemberSortTypeDto sortType) {
+        if (sortType == null) {
+            return null;
+        }
+        return GoalRoomMemberSortType.valueOf(sortType.name());
     }
 
     public static List<GoalRoomMemberResponse> convertToGoalRoomMemberResponses(

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
@@ -3,6 +3,7 @@ package co.kirikiri.service.mapper;
 import co.kirikiri.domain.goalroom.CheckFeed;
 import co.kirikiri.domain.goalroom.GoalRoom;
 import co.kirikiri.domain.goalroom.GoalRoomMember;
+import co.kirikiri.domain.goalroom.GoalRoomPendingMember;
 import co.kirikiri.domain.goalroom.GoalRoomRoadmapNode;
 import co.kirikiri.domain.goalroom.GoalRoomRoadmapNodes;
 import co.kirikiri.domain.goalroom.GoalRoomStatus;
@@ -151,6 +152,20 @@ public class GoalRoomMapper {
         final Member member = goalRoomMember.getMember();
         return new GoalRoomMemberResponse(member.getId(), member.getNickname().getValue(),
                 member.getImage().getServerFilePath(), goalRoomMember.getAccomplishmentRate());
+    }
+
+    public static List<GoalRoomMemberResponse> convertToGoalRoomPendingMemberResponses(
+            final List<GoalRoomPendingMember> goalRoomPendingMembers) {
+        return goalRoomPendingMembers.stream()
+                .map(GoalRoomMapper::convertToGoalRoomMemberResponse)
+                .toList();
+    }
+
+    private static GoalRoomMemberResponse convertToGoalRoomMemberResponse(
+            final GoalRoomPendingMember goalRoomPendingMember) {
+        final Member member = goalRoomPendingMember.getMember();
+        return new GoalRoomMemberResponse(member.getId(), member.getNickname().getValue(),
+                member.getImage().getServerFilePath(), 0D);
     }
 
     public static List<GoalRoomTodoResponse> convertGoalRoomTodoResponses(final GoalRoomToDos goalRoomToDos,

--- a/backend/kirikiri/src/test/java/co/kirikiri/controller/GoalRoomReadApiTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/controller/GoalRoomReadApiTest.java
@@ -26,7 +26,6 @@ import co.kirikiri.exception.NotFoundException;
 import co.kirikiri.service.GoalRoomCreateService;
 import co.kirikiri.service.GoalRoomReadService;
 import co.kirikiri.service.dto.ErrorResponse;
-import co.kirikiri.service.dto.goalroom.GoalRoomMemberSortTypeDto;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomStatusTypeRequest;
 import co.kirikiri.service.dto.goalroom.response.CheckFeedResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomCertifiedResponse;
@@ -368,10 +367,12 @@ class GoalRoomReadApiTest extends ControllerTestHelper {
                                 ),
                                 queryParameters(
                                         parameterWithName("sortCond")
-                                                .description("정렬 조건 (null일 경우 달성률순으로 기본 정렬) +" + "\n"
-                                                        + "ACCOMPLISHMENT_RATE : 달성률 순 +" + "\n"
-                                                        + "JOINED_ASC : 골룸 입장 순 (오래된순) +" + "\n"
-                                                        + "JOINED_DESC : 골룸 입장 순 (최신순) +" + "\n")
+                                                .description(
+                                                        "정렬 조건 (null일 경우: 골룸 모집중 -> 골룸 입장 순(오래된순)/ 골룸 진행중, 완료됨 -> 달성률 순으로 기본 정렬) +"
+                                                                + "\n"
+                                                                + "ACCOMPLISHMENT_RATE : 달성률 순 +" + "\n"
+                                                                + "JOINED_ASC : 골룸 입장 순 (오래된순) +" + "\n"
+                                                                + "JOINED_DESC : 골룸 입장 순 (최신순) +" + "\n")
                                                 .optional()
                                 ),
                                 responseFields(
@@ -409,10 +410,12 @@ class GoalRoomReadApiTest extends ControllerTestHelper {
                                 ),
                                 queryParameters(
                                         parameterWithName("sortCond")
-                                                .description("정렬 조건 (null일 경우 달성률순으로 기본 정렬) +" + "\n"
-                                                        + "ACCOMPLISHMENT_RATE : 달성률 순 +" + "\n"
-                                                        + "JOINED_ASC : 골룸 입장 순 (오래된순) +" + "\n"
-                                                        + "JOINED_DESC : 골룸 입장 순 (최신순) +" + "\n")
+                                                .description(
+                                                        "정렬 조건 (null일 경우: 골룸 모집중 -> 골룸 입장 순(오래된순)/ 골룸 진행중, 완료됨 -> 달성률 순으로 기본 정렬) + "
+                                                                + "\n"
+                                                                + "ACCOMPLISHMENT_RATE : 달성률 순 +" + "\n"
+                                                                + "JOINED_ASC : 골룸 입장 순 (오래된순) +" + "\n"
+                                                                + "JOINED_DESC : 골룸 입장 순 (최신순) +" + "\n")
                                                 .optional()
                                 ),
                                 responseFields(

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomReadIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomReadIntegrationTest.java
@@ -31,14 +31,14 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import java.io.IOException;
-import java.time.LocalDate;
-import java.util.List;
 
 class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
 
@@ -222,7 +222,8 @@ class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
 
-        final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "두번째_로드맵 제목", "두번째_로드맵 소개글", "두번째_로드맵 본문",
+        final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "두번째_로드맵 제목", "두번째_로드맵 소개글",
+                "두번째_로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("두번째_로드맵 1주차", "두번째_로드맵 1주차 내용", null)), null);
         로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
@@ -486,6 +487,41 @@ class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
     }
 
     @Test
+    void 모집중인_골룸의_사용자_정보를_달성률순으로_전체_조회한다() throws IOException {
+        // given
+        final MemberJoinRequest 팔로워1_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
+                "follow1", "010-1234-1234", GenderType.FEMALE, LocalDate.of(1999, 9, 9));
+        final MemberJoinRequest 팔로워2_회원_가입_요청 = new MemberJoinRequest("identifier3", "paswword2@",
+                "follow2", "010-1234-1234", GenderType.FEMALE, LocalDate.of(1999, 9, 9));
+        final Long 팔로워1_아이디 = 회원가입(팔로워1_회원_가입_요청);
+        final Long 팔로워2_아이디 = 회원가입(팔로워2_회원_가입_요청);
+
+        final LoginRequest 팔로워1_로그인_요청 = new LoginRequest(팔로워1_회원_가입_요청.identifier(), 팔로워1_회원_가입_요청.password());
+        final LoginRequest 팔로워2_로그인_요청 = new LoginRequest(팔로워2_회원_가입_요청.identifier(), 팔로워2_회원_가입_요청.password());
+
+        final String 팔로워1_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(팔로워1_로그인_요청).accessToken());
+        final String 팔로워2_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(팔로워2_로그인_요청).accessToken());
+
+        final Long 기본_로드맵_아이디 = 기본_로드맵_생성(기본_로그인_토큰);
+        final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
+
+        final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
+
+        골룸_참가_요청(기본_골룸_아이디, 팔로워1_액세스_토큰);
+        골룸_참가_요청(기본_골룸_아이디, 팔로워2_액세스_토큰);
+
+        //when
+        final List<GoalRoomMemberResponse> 골룸_사용자_응답 = 골룸의_사용자_정보를_달성률순으로_전체_조회(기본_골룸_아이디, 기본_로그인_토큰)
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertThat(골룸_사용자_응답.get(0).memberId()).isEqualTo(기본_회원_아이디);
+        assertThat(골룸_사용자_응답.get(1).memberId()).isEqualTo(팔로워1_아이디);
+        assertThat(골룸_사용자_응답.get(2).memberId()).isEqualTo(팔로워2_아이디);
+    }
+
+    @Test
     void 골룸의_사용자_정보_조회시_존재하지_않는_골룸이면_예외가_발생한다() {
         // given
         // when
@@ -569,7 +605,8 @@ class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
                 .extract();
     }
 
-    private ExtractableResponse<Response> 사용자가_참여한_골룸_중_골룸_골룸_진행_상태에_따라_목록을_조회(final String 로그인_토큰, final String 골룸_진행_상태) {
+    private ExtractableResponse<Response> 사용자가_참여한_골룸_중_골룸_골룸_진행_상태에_따라_목록을_조회(final String 로그인_토큰,
+                                                                               final String 골룸_진행_상태) {
         return given().log().all()
                 .header(AUTHORIZATION, 로그인_토큰)
                 .queryParam("statusCond", 골룸_진행_상태)

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomReadIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomReadIntegrationTest.java
@@ -9,6 +9,7 @@ import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
 import co.kirikiri.service.GoalRoomCreateService;
 import co.kirikiri.service.dto.ErrorResponse;
 import co.kirikiri.service.dto.auth.request.LoginRequest;
+import co.kirikiri.service.dto.goalroom.GoalRoomMemberSortTypeDto;
 import co.kirikiri.service.dto.goalroom.request.CheckFeedRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomCreateRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomRoadmapNodeRequest;
@@ -265,7 +266,7 @@ class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
         골룸을_시작한다();
 
         // when
-        final List<MemberGoalRoomForListResponse> 요청_응답값 = 사용자가_참여한_골룸_중_골룸_골룸_진행_상태에_따라_목록을_조회(기본_로그인_토큰, "RECRUITING")
+        final List<MemberGoalRoomForListResponse> 요청_응답값 = 사용자가_참여한_골룸_중_골룸_진행_상태에_따라_목록을_조회(기본_로그인_토큰, "RECRUITING")
                 .as(new TypeRef<>() {
                 });
 
@@ -295,7 +296,7 @@ class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
         골룸을_시작한다();
 
         // when
-        final List<MemberGoalRoomForListResponse> 요청_응답값 = 사용자가_참여한_골룸_중_골룸_골룸_진행_상태에_따라_목록을_조회(기본_로그인_토큰, "RUNNING")
+        final List<MemberGoalRoomForListResponse> 요청_응답값 = 사용자가_참여한_골룸_중_골룸_진행_상태에_따라_목록을_조회(기본_로그인_토큰, "RUNNING")
                 .as(new TypeRef<>() {
                 });
 
@@ -476,9 +477,9 @@ class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
         인증_피드_등록(기본_골룸_아이디, 가짜_이미지_객체, 인증_피드_등록_요청1, 팔로워1_액세스_토큰);
 
         //when
-        final List<GoalRoomMemberResponse> 골룸_사용자_응답 = 골룸의_사용자_정보를_달성률순으로_전체_조회(기본_골룸_아이디, 기본_로그인_토큰)
-                .as(new TypeRef<>() {
-                });
+        final List<GoalRoomMemberResponse> 골룸_사용자_응답 = 골룸의_사용자_정보를_전체_조회(기본_골룸_아이디, 기본_로그인_토큰,
+                GoalRoomMemberSortTypeDto.ACCOMPLISHMENT_RATE.name()).as(new TypeRef<>() {
+        });
 
         // then
         assertThat(골룸_사용자_응답.get(0).memberId()).isEqualTo(팔로워1_아이디);
@@ -487,7 +488,7 @@ class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
     }
 
     @Test
-    void 모집중인_골룸의_사용자_정보를_달성률순으로_전체_조회한다() throws IOException {
+    void 모집중인_골룸의_사용자_정보를_참가한_최신순으로_전체_조회한다() throws IOException {
         // given
         final MemberJoinRequest 팔로워1_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
                 "follow1", "010-1234-1234", GenderType.FEMALE, LocalDate.of(1999, 9, 9));
@@ -511,14 +512,14 @@ class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
         골룸_참가_요청(기본_골룸_아이디, 팔로워2_액세스_토큰);
 
         //when
-        final List<GoalRoomMemberResponse> 골룸_사용자_응답 = 골룸의_사용자_정보를_달성률순으로_전체_조회(기본_골룸_아이디, 기본_로그인_토큰)
-                .as(new TypeRef<>() {
-                });
+        final List<GoalRoomMemberResponse> 골룸_사용자_응답 = 골룸의_사용자_정보를_전체_조회(기본_골룸_아이디, 기본_로그인_토큰,
+                GoalRoomMemberSortTypeDto.JOINED_DESC.name()).as(new TypeRef<>() {
+        });
 
         // then
-        assertThat(골룸_사용자_응답.get(0).memberId()).isEqualTo(기본_회원_아이디);
+        assertThat(골룸_사용자_응답.get(0).memberId()).isEqualTo(팔로워2_아이디);
         assertThat(골룸_사용자_응답.get(1).memberId()).isEqualTo(팔로워1_아이디);
-        assertThat(골룸_사용자_응답.get(2).memberId()).isEqualTo(팔로워2_아이디);
+        assertThat(골룸_사용자_응답.get(2).memberId()).isEqualTo(기본_회원_아이디);
     }
 
     @Test
@@ -560,9 +561,9 @@ class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
     void 골룸의_사용자_정보_조회시_존재하지_않는_골룸이면_예외가_발생한다() {
         // given
         // when
-        final ErrorResponse 예외_응답 = 골룸의_사용자_정보를_달성률순으로_전체_조회(1L, 기본_로그인_토큰)
-                .as(new TypeRef<>() {
-                });
+        final ErrorResponse 예외_응답 = 골룸의_사용자_정보를_전체_조회(1L, 기본_로그인_토큰,
+                GoalRoomMemberSortTypeDto.ACCOMPLISHMENT_RATE.name()).as(new TypeRef<>() {
+        });
 
         // then
         assertThat(예외_응답.message()).isEqualTo("존재하지 않는 골룸입니다. goalRoomId = 1");
@@ -640,8 +641,8 @@ class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
                 .extract();
     }
 
-    private ExtractableResponse<Response> 사용자가_참여한_골룸_중_골룸_골룸_진행_상태에_따라_목록을_조회(final String 로그인_토큰,
-                                                                               final String 골룸_진행_상태) {
+    private ExtractableResponse<Response> 사용자가_참여한_골룸_중_골룸_진행_상태에_따라_목록을_조회(final String 로그인_토큰,
+                                                                            final String 골룸_진행_상태) {
         return given().log().all()
                 .header(AUTHORIZATION, 로그인_토큰)
                 .queryParam("statusCond", 골룸_진행_상태)
@@ -664,12 +665,13 @@ class GoalRoomReadIntegrationTest extends GoalRoomCreateIntegrationTest {
                 .extract();
     }
 
-    private ExtractableResponse<Response> 골룸의_사용자_정보를_달성률순으로_전체_조회(final Long 기본_골룸_아이디, final String 로그인_토큰) {
+    private ExtractableResponse<Response> 골룸의_사용자_정보를_전체_조회(final Long 기본_골룸_아이디, final String 로그인_토큰,
+                                                            final String 정렬조건) {
         return given().log().all()
                 .header(AUTHORIZATION, 로그인_토큰)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .get(API_PREFIX + "/goal-rooms/{goalRoomId}/members?sortCond=ACCOMPLISHMENT_RATE", 기본_골룸_아이디)
+                .get(API_PREFIX + "/goal-rooms/{goalRoomId}/members?sortCond={sortType}", 기본_골룸_아이디, 정렬조건)
                 .then()
                 .log().all()
                 .extract();

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepositoryTest.java
@@ -268,7 +268,7 @@ class GoalRoomPendingMemberRepositoryTest {
     }
 
     @Test
-    void 골룸_아이디로_골룸_사용자를_조회하고_달성률이_높은_순대로_정렬한다() {
+    void 골룸_아이디로_골룸_사용자를_조회하고_정렬조건을_달성률순_또는_입력하지_않은경우_참여한순으로_정렬한다() {
         // given
         final Member creator = 크리에이터를_저장한다();
         final RoadmapCategory category = 카테고리를_저장한다("게임");

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepositoryTest.java
@@ -14,6 +14,7 @@ import co.kirikiri.domain.goalroom.vo.Period;
 import co.kirikiri.domain.member.EncryptedPassword;
 import co.kirikiri.domain.member.Gender;
 import co.kirikiri.domain.member.Member;
+import co.kirikiri.domain.member.MemberImage;
 import co.kirikiri.domain.member.MemberProfile;
 import co.kirikiri.domain.member.vo.Identifier;
 import co.kirikiri.domain.member.vo.Nickname;
@@ -27,6 +28,7 @@ import co.kirikiri.domain.roadmap.RoadmapNode;
 import co.kirikiri.domain.roadmap.RoadmapNodeImage;
 import co.kirikiri.domain.roadmap.RoadmapNodeImages;
 import co.kirikiri.domain.roadmap.RoadmapNodes;
+import co.kirikiri.persistence.goalroom.dto.GoalRoomMemberSortType;
 import co.kirikiri.persistence.helper.RepositoryTest;
 import co.kirikiri.persistence.member.MemberRepository;
 import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
@@ -185,10 +187,133 @@ class GoalRoomPendingMemberRepositoryTest {
         );
     }
 
+    @Test
+    void 골룸_아이디로_골룸_사용자를_조회하고_들어온지_오래된_순서대로_정렬한다() {
+        // given
+        final Member creator = 크리에이터를_저장한다();
+        final RoadmapCategory category = 카테고리를_저장한다("게임");
+        final Roadmap roadmap = 로드맵을_저장한다(creator, category);
+
+        final RoadmapContents roadmapContents = roadmap.getContents();
+        final RoadmapContent targetRoadmapContent = roadmapContents.getValues().get(0);
+
+        final GoalRoom goalRoom = 골룸을_생성한다(targetRoadmapContent, creator);
+        final GoalRoom savedGoalRoom = goalRoomRepository.save(goalRoom);
+
+        final Member member1 = 사용자를_생성한다("identifier1", "password2!", "name1", "010-1111-1111");
+        final Member member2 = 사용자를_생성한다("identifier2", "password3!", "name2", "010-1111-1112");
+        final Member member3 = 사용자를_생성한다("identifier3", "password4!", "name3", "010-1111-1113");
+
+        final GoalRoomPendingMember goalRoomPendingMember0 = goalRoom.getGoalRoomPendingMembers().getValues().get(0);
+        final GoalRoomPendingMember goalRoomPendingMember1 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member1);
+        final GoalRoomPendingMember goalRoomPendingMember2 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member2);
+        final GoalRoomPendingMember goalRoomPendingMember3 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member3);
+        goalRoomPendingMemberRepository.saveAll(
+                List.of(goalRoomPendingMember1, goalRoomPendingMember2, goalRoomPendingMember3));
+        final List<GoalRoomPendingMember> expected = List.of(goalRoomPendingMember0, goalRoomPendingMember1,
+                goalRoomPendingMember2, goalRoomPendingMember3);
+
+        // when
+        final List<GoalRoomPendingMember> goalRoomPendingMembers = goalRoomPendingMemberRepository.findByGoalRoomIdOrderedBySortType(
+                savedGoalRoom.getId(), GoalRoomMemberSortType.JOINED_ASC);
+
+        // then
+        assertThat(goalRoomPendingMembers)
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 골룸_아이디로_골룸_사용자를_조회하고_마지막으로_들어온_순서대로_정렬한다() {
+        // given
+        final Member creator = 크리에이터를_저장한다();
+        final RoadmapCategory category = 카테고리를_저장한다("게임");
+        final Roadmap roadmap = 로드맵을_저장한다(creator, category);
+
+        final RoadmapContents roadmapContents = roadmap.getContents();
+        final RoadmapContent targetRoadmapContent = roadmapContents.getValues().get(0);
+
+        final GoalRoom goalRoom = 골룸을_생성한다(targetRoadmapContent, creator);
+        final GoalRoom savedGoalRoom = goalRoomRepository.save(goalRoom);
+
+        final Member member1 = 사용자를_생성한다("identifier1", "password2!", "name1", "010-1111-1111");
+        final Member member2 = 사용자를_생성한다("identifier2", "password3!", "name2", "010-1111-1112");
+        final Member member3 = 사용자를_생성한다("identifier3", "password4!", "name3", "010-1111-1113");
+
+        final GoalRoomPendingMember goalRoomPendingMember0 = goalRoom.getGoalRoomPendingMembers().getValues().get(0);
+        final GoalRoomPendingMember goalRoomPendingMember1 = new GoalRoomPendingMember(GoalRoomRole.LEADER,
+                LocalDateTime.now(), savedGoalRoom, member1);
+        final GoalRoomPendingMember goalRoomPendingMember2 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member2);
+        final GoalRoomPendingMember goalRoomPendingMember3 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member3);
+        final GoalRoomPendingMember savedGoalRoomPendingMember1 = goalRoomPendingMemberRepository.save(
+                goalRoomPendingMember1);
+        final GoalRoomPendingMember savedGoalRoomPendingMember2 = goalRoomPendingMemberRepository.save(
+                goalRoomPendingMember2);
+        final GoalRoomPendingMember savedGoalRoomPendingMember3 = goalRoomPendingMemberRepository.save(
+                goalRoomPendingMember3);
+        final List<GoalRoomPendingMember> expected = List.of(savedGoalRoomPendingMember3, savedGoalRoomPendingMember2,
+                savedGoalRoomPendingMember1, goalRoomPendingMember0);
+
+        // when
+        final List<GoalRoomPendingMember> goalRoomPendingMembers = goalRoomPendingMemberRepository.findByGoalRoomIdOrderedBySortType(
+                savedGoalRoom.getId(), GoalRoomMemberSortType.JOINED_DESC);
+
+        // then
+        assertThat(goalRoomPendingMembers)
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 골룸_아이디로_골룸_사용자를_조회하고_달성률이_높은_순대로_정렬한다() {
+        // given
+        final Member creator = 크리에이터를_저장한다();
+        final RoadmapCategory category = 카테고리를_저장한다("게임");
+        final Roadmap roadmap = 로드맵을_저장한다(creator, category);
+
+        final RoadmapContents roadmapContents = roadmap.getContents();
+        final RoadmapContent targetRoadmapContent = roadmapContents.getValues().get(0);
+
+        final GoalRoom goalRoom = 골룸을_생성한다(targetRoadmapContent, creator);
+        final GoalRoom savedGoalRoom = goalRoomRepository.save(goalRoom);
+
+        final Member member1 = 사용자를_생성한다("identifier1", "password2!", "name1", "010-1111-1111");
+        final Member member2 = 사용자를_생성한다("identifier2", "password3!", "name2", "010-1111-1112");
+        final Member member3 = 사용자를_생성한다("identifier3", "password4!", "name3", "010-1111-1113");
+
+        final GoalRoomPendingMember goalRoomPendingMember0 = goalRoom.getGoalRoomPendingMembers().getValues().get(0);
+        final GoalRoomPendingMember goalRoomPendingMember1 = new GoalRoomPendingMember(GoalRoomRole.LEADER,
+                LocalDateTime.now(), savedGoalRoom, member1);
+        final GoalRoomPendingMember goalRoomPendingMember2 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member2);
+        final GoalRoomPendingMember goalRoomPendingMember3 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member3);
+        goalRoomPendingMemberRepository.saveAll(
+                List.of(goalRoomPendingMember1, goalRoomPendingMember2, goalRoomPendingMember3));
+        final List<GoalRoomPendingMember> expected = List.of(goalRoomPendingMember0, goalRoomPendingMember1,
+                goalRoomPendingMember2, goalRoomPendingMember3);
+
+        // when
+        final List<GoalRoomPendingMember> goalRoomPendingMembers1 = goalRoomPendingMemberRepository.findByGoalRoomIdOrderedBySortType(
+                savedGoalRoom.getId(), GoalRoomMemberSortType.ACCOMPLISHMENT_RATE);
+        final List<GoalRoomPendingMember> goalRoomPendingMembers2 = goalRoomPendingMemberRepository.findByGoalRoomIdOrderedBySortType(
+                savedGoalRoom.getId(), null);
+
+        // then
+        assertThat(goalRoomPendingMembers1)
+                .isEqualTo(expected);
+        assertThat(goalRoomPendingMembers2)
+                .isEqualTo(expected);
+    }
+
     private Member 크리에이터를_저장한다() {
         final MemberProfile memberProfile = new MemberProfile(Gender.MALE, LocalDate.of(1990, 1, 1), "010-1234-5678");
         final Member creator = new Member(new Identifier("cokirikiri"),
-                new EncryptedPassword(new Password("password1!")), new Nickname("코끼리"), null, memberProfile);
+                new EncryptedPassword(new Password("password1!")), new Nickname("코끼리"),
+                new MemberImage("originalFileName", "serverFilePath", ImageContentType.PNG), memberProfile);
         return memberRepository.save(creator);
     }
 
@@ -196,7 +321,8 @@ class GoalRoomPendingMemberRepositoryTest {
                              final String phoneNumber) {
         final MemberProfile memberProfile = new MemberProfile(Gender.MALE, LocalDate.of(1990, 1, 1), phoneNumber);
         final Member member = new Member(new Identifier(identifier), new EncryptedPassword(new Password(password)),
-                new Nickname(nickname), null, memberProfile);
+                new Nickname(nickname), new MemberImage("originalFileName", "serverFilePath", ImageContentType.PNG),
+                memberProfile);
         return memberRepository.save(member);
     }
 

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomReadServiceTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomReadServiceTest.java
@@ -283,11 +283,9 @@ class GoalRoomReadServiceTest {
         final GoalRoom goalRoom = 골룸을_생성한다(creator, roadmap.getContents().getValues().get(0));
 
         final GoalRoomPendingMember goalRoomMemberCreator = new GoalRoomPendingMember(GoalRoomRole.LEADER,
-                LocalDateTime.now(),
-                goalRoom, creator);
+                LocalDateTime.now(), goalRoom, creator);
         final GoalRoomPendingMember goalRoomMemberFollower = new GoalRoomPendingMember(GoalRoomRole.LEADER,
-                LocalDateTime.now(),
-                goalRoom, follower);
+                LocalDateTime.now(), goalRoom, follower);
 
         given(goalRoomRepository.findById(anyLong()))
                 .willReturn(Optional.of(goalRoom));

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomReadServiceTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomReadServiceTest.java
@@ -203,7 +203,7 @@ class GoalRoomReadServiceTest {
     }
 
     @Test
-    void 정상적으로_골룸에_참여자를_조회한다() {
+    void 정상적으로_진행중인_골룸의_참여자를_조회한다() {
         //given
         final Member creator = 사용자를_생성한다(1L);
         final Member follower = 사용자를_생성한다(2L);
@@ -211,12 +211,15 @@ class GoalRoomReadServiceTest {
         final Roadmap roadmap = 로드맵을_생성한다(creator);
 
         final GoalRoom goalRoom = 골룸을_생성한다(creator, roadmap.getContents().getValues().get(0));
+        goalRoom.start();
 
         final GoalRoomMember goalRoomMemberCreator = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(),
                 goalRoom, creator);
         final GoalRoomMember goalRoomMemberFollower = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(),
                 goalRoom, follower);
 
+        given(goalRoomRepository.findById(anyLong()))
+                .willReturn(Optional.of(goalRoom));
         given(goalRoomMemberRepository.findByGoalRoomIdOrderedBySortType(anyLong(), any()))
                 .willReturn(List.of(goalRoomMemberCreator, goalRoomMemberFollower));
 
@@ -229,15 +232,87 @@ class GoalRoomReadServiceTest {
                 "serverFilePath", 0.0);
         final GoalRoomMemberResponse expectedGoalRoomMemberResponse2 = new GoalRoomMemberResponse(2L, "name1",
                 "serverFilePath", 0.0);
-        assertThat(result).usingRecursiveComparison()
+        assertThat(result)
                 .isEqualTo(List.of(expectedGoalRoomMemberResponse1, expectedGoalRoomMemberResponse2));
+        verify(goalRoomPendingMemberRepository, never()).findByGoalRoomIdOrderedBySortType(anyLong(), any());
+    }
+
+    @Test
+    void 정상적으로_완료된_골룸의_참여자를_조회한다() {
+        //given
+        final Member creator = 사용자를_생성한다(1L);
+        final Member follower = 사용자를_생성한다(2L);
+
+        final Roadmap roadmap = 로드맵을_생성한다(creator);
+
+        final GoalRoom goalRoom = 골룸을_생성한다(creator, roadmap.getContents().getValues().get(0));
+        goalRoom.complete();
+
+        final GoalRoomMember goalRoomMemberCreator = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(),
+                goalRoom, creator);
+        final GoalRoomMember goalRoomMemberFollower = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(),
+                goalRoom, follower);
+
+        given(goalRoomRepository.findById(anyLong()))
+                .willReturn(Optional.of(goalRoom));
+        given(goalRoomMemberRepository.findByGoalRoomIdOrderedBySortType(anyLong(), any()))
+                .willReturn(List.of(goalRoomMemberCreator, goalRoomMemberFollower));
+
+        //when
+        final List<GoalRoomMemberResponse> result = goalRoomReadService.findGoalRoomMembers(1L,
+                GoalRoomMemberSortTypeDto.ACCOMPLISHMENT_RATE);
+
+        //then
+        final GoalRoomMemberResponse expectedGoalRoomMemberResponse1 = new GoalRoomMemberResponse(1L, "name1",
+                "serverFilePath", 0.0);
+        final GoalRoomMemberResponse expectedGoalRoomMemberResponse2 = new GoalRoomMemberResponse(2L, "name1",
+                "serverFilePath", 0.0);
+        assertThat(result)
+                .isEqualTo(List.of(expectedGoalRoomMemberResponse1, expectedGoalRoomMemberResponse2));
+        verify(goalRoomPendingMemberRepository, never()).findByGoalRoomIdOrderedBySortType(anyLong(), any());
+    }
+
+    @Test
+    void 정상적으로_모집중인_골룸의_참여자를_조회한다() {
+        //given
+        final Member creator = 사용자를_생성한다(1L);
+        final Member follower = 사용자를_생성한다(2L);
+
+        final Roadmap roadmap = 로드맵을_생성한다(creator);
+
+        final GoalRoom goalRoom = 골룸을_생성한다(creator, roadmap.getContents().getValues().get(0));
+
+        final GoalRoomPendingMember goalRoomMemberCreator = new GoalRoomPendingMember(GoalRoomRole.LEADER,
+                LocalDateTime.now(),
+                goalRoom, creator);
+        final GoalRoomPendingMember goalRoomMemberFollower = new GoalRoomPendingMember(GoalRoomRole.LEADER,
+                LocalDateTime.now(),
+                goalRoom, follower);
+
+        given(goalRoomRepository.findById(anyLong()))
+                .willReturn(Optional.of(goalRoom));
+        given(goalRoomPendingMemberRepository.findByGoalRoomIdOrderedBySortType(anyLong(), any()))
+                .willReturn(List.of(goalRoomMemberCreator, goalRoomMemberFollower));
+
+        //when
+        final List<GoalRoomMemberResponse> result = goalRoomReadService.findGoalRoomMembers(1L,
+                GoalRoomMemberSortTypeDto.ACCOMPLISHMENT_RATE);
+
+        //then
+        final GoalRoomMemberResponse expectedGoalRoomMemberResponse1 = new GoalRoomMemberResponse(1L, "name1",
+                "serverFilePath", 0.0);
+        final GoalRoomMemberResponse expectedGoalRoomMemberResponse2 = new GoalRoomMemberResponse(2L, "name1",
+                "serverFilePath", 0.0);
+        assertThat(result)
+                .isEqualTo(List.of(expectedGoalRoomMemberResponse1, expectedGoalRoomMemberResponse2));
+        verify(goalRoomMemberRepository, never()).findByGoalRoomIdOrderedBySortType(anyLong(), any());
     }
 
     @Test
     void 존재하지_않는_골룸일_경우_예외를_던진다() {
         //given
-        given(goalRoomMemberRepository.findByGoalRoomIdOrderedBySortType(anyLong(), any()))
-                .willReturn(Collections.emptyList());
+        given(goalRoomRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
 
         //when
         //then


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-165](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1/backlog?selectedIssue=CK-165)


## ✨ 작업 내용
- 골룸 참여자 조회 시 골룸이 진행중이거나 완료됐을 때만 조회가 가능한 로직을 모집중일 때도 조회가능하도록 수정했습니다.


## 💬 리뷰어에게 남길 멘트



## 🚀 요구사항 분석


