### PR TITLE
[Fix/CK-165] 골룸 참여자 조회 시 골룸의 상태에 상관없이 조회 가능하도록 수정한다

### DIFF
--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberQueryRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberQueryRepository.java
@@ -1,0 +1,11 @@
+package co.kirikiri.persistence.goalroom;
+
+import co.kirikiri.domain.goalroom.GoalRoomPendingMember;
+import co.kirikiri.persistence.goalroom.dto.GoalRoomMemberSortType;
+import java.util.List;
+
+public interface GoalRoomPendingMemberQueryRepository {
+
+    List<GoalRoomPendingMember> findByGoalRoomIdOrderedBySortType(final Long goalRoomId,
+                                                                  final GoalRoomMemberSortType sortType);
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberQueryRepositoryImpl.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberQueryRepositoryImpl.java
@@ -1,0 +1,40 @@
+package co.kirikiri.persistence.goalroom;
+
+import static co.kirikiri.domain.goalroom.QGoalRoomPendingMember.goalRoomPendingMember;
+import static co.kirikiri.domain.member.QMember.member;
+import static co.kirikiri.domain.member.QMemberImage.memberImage;
+import static co.kirikiri.persistence.goalroom.dto.GoalRoomMemberSortType.JOINED_DESC;
+
+import co.kirikiri.domain.goalroom.GoalRoomPendingMember;
+import co.kirikiri.persistence.QuerydslRepositorySupporter;
+import co.kirikiri.persistence.goalroom.dto.GoalRoomMemberSortType;
+import com.querydsl.core.types.OrderSpecifier;
+import java.util.List;
+
+public class GoalRoomPendingMemberQueryRepositoryImpl extends QuerydslRepositorySupporter
+        implements GoalRoomPendingMemberQueryRepository {
+
+    public GoalRoomPendingMemberQueryRepositoryImpl() {
+        super(GoalRoomPendingMember.class);
+    }
+
+    @Override
+    public List<GoalRoomPendingMember> findByGoalRoomIdOrderedBySortType(final Long goalRoomId,
+                                                                         final GoalRoomMemberSortType sortType) {
+        return selectFrom(goalRoomPendingMember)
+                .innerJoin(goalRoomPendingMember.member, member)
+                .fetchJoin()
+                .innerJoin(member.image, memberImage)
+                .fetchJoin()
+                .where(goalRoomPendingMember.goalRoom.id.eq(goalRoomId))
+                .orderBy(sortCond(sortType))
+                .fetch();
+    }
+
+    private OrderSpecifier<?> sortCond(final GoalRoomMemberSortType sortType) {
+        if (sortType == JOINED_DESC) {
+            return goalRoomPendingMember.joinedAt.desc();
+        }
+        return goalRoomPendingMember.joinedAt.asc();
+    }
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface GoalRoomPendingMemberRepository extends JpaRepository<GoalRoomPendingMember, Long> {
+public interface GoalRoomPendingMemberRepository extends JpaRepository<GoalRoomPendingMember, Long>,
+        GoalRoomPendingMemberQueryRepository {
 
     @Query("select gp from GoalRoomPendingMember gp "
             + "inner join fetch gp.goalRoom g "

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomReadService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomReadService.java
@@ -3,6 +3,7 @@ package co.kirikiri.service;
 import co.kirikiri.domain.goalroom.CheckFeed;
 import co.kirikiri.domain.goalroom.GoalRoom;
 import co.kirikiri.domain.goalroom.GoalRoomMember;
+import co.kirikiri.domain.goalroom.GoalRoomPendingMember;
 import co.kirikiri.domain.goalroom.GoalRoomRoadmapNode;
 import co.kirikiri.domain.goalroom.GoalRoomRoadmapNodes;
 import co.kirikiri.domain.goalroom.GoalRoomStatus;
@@ -34,15 +35,15 @@ import co.kirikiri.service.dto.member.MemberDto;
 import co.kirikiri.service.dto.member.response.MemberGoalRoomForListResponse;
 import co.kirikiri.service.dto.member.response.MemberGoalRoomResponse;
 import co.kirikiri.service.mapper.GoalRoomMapper;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpMethod;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import java.net.URL;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -58,17 +59,17 @@ public class GoalRoomReadService {
     private final FileService fileService;
 
     public GoalRoomResponse findGoalRoom(final Long goalRoomId) {
-        final GoalRoom goalRoom = findGoalRoomById(goalRoomId);
+        final GoalRoom goalRoom = findGoalRoomWithRoadmapContentById(goalRoomId);
         return GoalRoomMapper.convertGoalRoomResponse(goalRoom);
     }
 
-    private GoalRoom findGoalRoomById(final Long goalRoomId) {
+    private GoalRoom findGoalRoomWithRoadmapContentById(final Long goalRoomId) {
         return goalRoomRepository.findByIdWithRoadmapContent(goalRoomId)
                 .orElseThrow(() -> new NotFoundException("골룸 정보가 존재하지 않습니다. goalRoomId = " + goalRoomId));
     }
 
     public GoalRoomCertifiedResponse findGoalRoom(final String identifier, final Long goalRoomId) {
-        final GoalRoom goalRoom = findGoalRoomById(goalRoomId);
+        final GoalRoom goalRoom = findGoalRoomWithRoadmapContentById(goalRoomId);
         final boolean isJoined = isMemberGoalRoomJoin(new Identifier(identifier), goalRoom);
         return GoalRoomMapper.convertGoalRoomCertifiedResponse(goalRoom, isJoined);
     }
@@ -82,17 +83,21 @@ public class GoalRoomReadService {
 
     public List<GoalRoomMemberResponse> findGoalRoomMembers(final Long goalRoomId,
                                                             final GoalRoomMemberSortTypeDto sortType) {
-
+        final GoalRoom goalRoom = findGoalRoomById(goalRoomId);
+        final GoalRoomMemberSortType goalRoomMemberSortType = GoalRoomMapper.convertGoalRoomMemberSortType(sortType);
+        if (goalRoom.isRecruiting()) {
+            final List<GoalRoomPendingMember> goalRoomPendingMembers = goalRoomPendingMemberRepository.findByGoalRoomIdOrderedBySortType(
+                    goalRoomId, goalRoomMemberSortType);
+            return GoalRoomMapper.convertToGoalRoomPendingMemberResponses(goalRoomPendingMembers);
+        }
         final List<GoalRoomMember> goalRoomMembers = goalRoomMemberRepository.findByGoalRoomIdOrderedBySortType(
-                goalRoomId, GoalRoomMemberSortType.valueOf(sortType.name()));
-        checkGoalRoomEmpty(goalRoomId, goalRoomMembers);
+                goalRoomId, goalRoomMemberSortType);
         return GoalRoomMapper.convertToGoalRoomMemberResponses(goalRoomMembers);
     }
 
-    private void checkGoalRoomEmpty(final Long goalRoomId, final List<GoalRoomMember> goalRoomMembers) {
-        if (goalRoomMembers.isEmpty()) {
-            throw new NotFoundException("존재하지 않는 골룸입니다. goalRoomId = " + goalRoomId);
-        }
+    private GoalRoom findGoalRoomById(final Long goalRoomId) {
+        return goalRoomRepository.findById(goalRoomId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 골룸입니다. goalRoomId = " + goalRoomId));
     }
 
     public List<GoalRoomTodoResponse> findAllGoalRoomTodo(final Long goalRoomId, final String identifier) {
@@ -218,7 +223,8 @@ public class GoalRoomReadService {
     }
 
     private void validateJoinedMemberInRunningGoalRoom(final GoalRoom goalRoom, final String identifier) {
-        if (goalRoomMemberRepository.findByGoalRoomAndMemberIdentifier(goalRoom, new Identifier(identifier)).isEmpty()) {
+        if (goalRoomMemberRepository.findByGoalRoomAndMemberIdentifier(goalRoom, new Identifier(identifier))
+                .isEmpty()) {
             throw new BadRequestException("골룸에 참여하지 않은 회원입니다.");
         }
     }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/GoalRoomMapper.java
@@ -3,6 +3,7 @@ package co.kirikiri.service.mapper;
 import co.kirikiri.domain.goalroom.CheckFeed;
 import co.kirikiri.domain.goalroom.GoalRoom;
 import co.kirikiri.domain.goalroom.GoalRoomMember;
+import co.kirikiri.domain.goalroom.GoalRoomPendingMember;
 import co.kirikiri.domain.goalroom.GoalRoomRoadmapNode;
 import co.kirikiri.domain.goalroom.GoalRoomRoadmapNodes;
 import co.kirikiri.domain.goalroom.GoalRoomStatus;
@@ -14,10 +15,12 @@ import co.kirikiri.domain.goalroom.vo.GoalRoomTodoContent;
 import co.kirikiri.domain.goalroom.vo.LimitedMemberCount;
 import co.kirikiri.domain.goalroom.vo.Period;
 import co.kirikiri.domain.member.Member;
+import co.kirikiri.persistence.goalroom.dto.GoalRoomMemberSortType;
 import co.kirikiri.persistence.goalroom.dto.RoadmapGoalRoomsFilterType;
 import co.kirikiri.service.dto.goalroom.CheckFeedDto;
 import co.kirikiri.service.dto.goalroom.GoalRoomCheckFeedDto;
 import co.kirikiri.service.dto.goalroom.GoalRoomCreateDto;
+import co.kirikiri.service.dto.goalroom.GoalRoomMemberSortTypeDto;
 import co.kirikiri.service.dto.goalroom.GoalRoomRoadmapNodeDto;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomCreateRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomRoadmapNodeRequest;
@@ -40,13 +43,13 @@ import co.kirikiri.service.dto.roadmap.RoadmapGoalRoomNumberDto;
 import co.kirikiri.service.dto.roadmap.RoadmapGoalRoomsFilterTypeDto;
 import co.kirikiri.service.dto.roadmap.response.RoadmapGoalRoomResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapGoalRoomResponses;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GoalRoomMapper {
@@ -141,6 +144,13 @@ public class GoalRoomMapper {
                 goalRoomLeader.getImage().getServerFilePath());
     }
 
+    public static GoalRoomMemberSortType convertGoalRoomMemberSortType(final GoalRoomMemberSortTypeDto sortType) {
+        if (sortType == null) {
+            return null;
+        }
+        return GoalRoomMemberSortType.valueOf(sortType.name());
+    }
+
     public static List<GoalRoomMemberResponse> convertToGoalRoomMemberResponses(
             final List<GoalRoomMember> goalRoomMembers) {
         return goalRoomMembers.stream()
@@ -152,6 +162,20 @@ public class GoalRoomMapper {
         final Member member = goalRoomMember.getMember();
         return new GoalRoomMemberResponse(member.getId(), member.getNickname().getValue(),
                 member.getImage().getServerFilePath(), goalRoomMember.getAccomplishmentRate());
+    }
+
+    public static List<GoalRoomMemberResponse> convertToGoalRoomPendingMemberResponses(
+            final List<GoalRoomPendingMember> goalRoomPendingMembers) {
+        return goalRoomPendingMembers.stream()
+                .map(GoalRoomMapper::convertToGoalRoomMemberResponse)
+                .toList();
+    }
+
+    private static GoalRoomMemberResponse convertToGoalRoomMemberResponse(
+            final GoalRoomPendingMember goalRoomPendingMember) {
+        final Member member = goalRoomPendingMember.getMember();
+        return new GoalRoomMemberResponse(member.getId(), member.getNickname().getValue(),
+                member.getImage().getServerFilePath(), 0D);
     }
 
     public static List<GoalRoomTodoResponse> convertGoalRoomTodoResponses(final GoalRoomToDos goalRoomToDos,
@@ -249,18 +273,22 @@ public class GoalRoomMapper {
                         leader.getImage().getServerFilePath()));
     }
 
-    public static List<GoalRoomCheckFeedResponse> convertToGoalRoomCheckFeedResponses(final List<GoalRoomCheckFeedDto> checkFeeds) {
+    public static List<GoalRoomCheckFeedResponse> convertToGoalRoomCheckFeedResponses(
+            final List<GoalRoomCheckFeedDto> checkFeeds) {
         return checkFeeds.stream()
                 .map(GoalRoomMapper::convertToGoalRoomCheckFeedResponse)
                 .toList();
     }
 
-    private static GoalRoomCheckFeedResponse convertToGoalRoomCheckFeedResponse(final GoalRoomCheckFeedDto goalRoomCheckFeedDto) {
+    private static GoalRoomCheckFeedResponse convertToGoalRoomCheckFeedResponse(
+            final GoalRoomCheckFeedDto goalRoomCheckFeedDto) {
         final MemberDto memberDto = goalRoomCheckFeedDto.memberDto();
-        final MemberResponse memberResponse = new MemberResponse(memberDto.id(), memberDto.name(), memberDto.imageUrl());
+        final MemberResponse memberResponse = new MemberResponse(memberDto.id(), memberDto.name(),
+                memberDto.imageUrl());
 
         final CheckFeedDto checkFeedDto = goalRoomCheckFeedDto.checkFeedDto();
-        final CheckFeedResponse checkFeedResponse = new CheckFeedResponse(checkFeedDto.id(), checkFeedDto.imageUrl(), checkFeedDto.description(), checkFeedDto.createdAt());
+        final CheckFeedResponse checkFeedResponse = new CheckFeedResponse(checkFeedDto.id(), checkFeedDto.imageUrl(),
+                checkFeedDto.description(), checkFeedDto.createdAt());
 
         return new GoalRoomCheckFeedResponse(memberResponse, checkFeedResponse);
     }

--- a/backend/kirikiri/src/test/java/co/kirikiri/controller/GoalRoomReadApiTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/controller/GoalRoomReadApiTest.java
@@ -40,13 +40,13 @@ import co.kirikiri.service.dto.member.response.MemberGoalRoomForListResponse;
 import co.kirikiri.service.dto.member.response.MemberGoalRoomResponse;
 import co.kirikiri.service.dto.member.response.MemberResponse;
 import com.fasterxml.jackson.core.type.TypeReference;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MvcResult;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 
 @WebMvcTest(GoalRoomController.class)
 class GoalRoomReadApiTest extends ControllerTestHelper {
@@ -366,10 +366,12 @@ class GoalRoomReadApiTest extends ControllerTestHelper {
                                 ),
                                 queryParameters(
                                         parameterWithName("sortCond")
-                                                .description("정렬 조건 (null일 경우 달성률순으로 기본 정렬) +" + "\n"
-                                                        + "ACCOMPLISHMENT_RATE : 달성률 순 +" + "\n"
-                                                        + "JOINED_ASC : 골룸 입장 순 (오래된순) +" + "\n"
-                                                        + "JOINED_DESC : 골룸 입장 순 (최신순) +" + "\n")
+                                                .description(
+                                                        "정렬 조건 (null일 경우: 골룸 모집중 -> 골룸 입장 순(오래된순)/ 골룸 진행중, 완료됨 -> 달성률 순으로 기본 정렬) +"
+                                                                + "\n"
+                                                                + "ACCOMPLISHMENT_RATE : 달성률 순 +" + "\n"
+                                                                + "JOINED_ASC : 골룸 입장 순 (오래된순) +" + "\n"
+                                                                + "JOINED_DESC : 골룸 입장 순 (최신순) +" + "\n")
                                                 .optional()
                                 ),
                                 responseFields(
@@ -407,10 +409,12 @@ class GoalRoomReadApiTest extends ControllerTestHelper {
                                 ),
                                 queryParameters(
                                         parameterWithName("sortCond")
-                                                .description("정렬 조건 (null일 경우 달성률순으로 기본 정렬) +" + "\n"
-                                                        + "ACCOMPLISHMENT_RATE : 달성률 순 +" + "\n"
-                                                        + "JOINED_ASC : 골룸 입장 순 (오래된순) +" + "\n"
-                                                        + "JOINED_DESC : 골룸 입장 순 (최신순) +" + "\n")
+                                                .description(
+                                                        "정렬 조건 (null일 경우: 골룸 모집중 -> 골룸 입장 순(오래된순)/ 골룸 진행중, 완료됨 -> 달성률 순으로 기본 정렬) +"
+                                                                + "\n"
+                                                                + "ACCOMPLISHMENT_RATE : 달성률 순 +" + "\n"
+                                                                + "JOINED_ASC : 골룸 입장 순 (오래된순) +" + "\n"
+                                                                + "JOINED_DESC : 골룸 입장 순 (최신순) +" + "\n")
                                                 .optional()
                                 ),
                                 responseFields(

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepositoryTest.java
@@ -14,6 +14,7 @@ import co.kirikiri.domain.goalroom.vo.Period;
 import co.kirikiri.domain.member.EncryptedPassword;
 import co.kirikiri.domain.member.Gender;
 import co.kirikiri.domain.member.Member;
+import co.kirikiri.domain.member.MemberImage;
 import co.kirikiri.domain.member.MemberProfile;
 import co.kirikiri.domain.member.vo.Identifier;
 import co.kirikiri.domain.member.vo.Nickname;
@@ -27,6 +28,7 @@ import co.kirikiri.domain.roadmap.RoadmapNode;
 import co.kirikiri.domain.roadmap.RoadmapNodeImage;
 import co.kirikiri.domain.roadmap.RoadmapNodeImages;
 import co.kirikiri.domain.roadmap.RoadmapNodes;
+import co.kirikiri.persistence.goalroom.dto.GoalRoomMemberSortType;
 import co.kirikiri.persistence.helper.RepositoryTest;
 import co.kirikiri.persistence.member.MemberRepository;
 import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
@@ -185,10 +187,133 @@ class GoalRoomPendingMemberRepositoryTest {
         );
     }
 
+    @Test
+    void 골룸_아이디로_골룸_사용자를_조회하고_들어온지_오래된_순서대로_정렬한다() {
+        // given
+        final Member creator = 크리에이터를_저장한다();
+        final RoadmapCategory category = 카테고리를_저장한다("게임");
+        final Roadmap roadmap = 로드맵을_저장한다(creator, category);
+
+        final RoadmapContents roadmapContents = roadmap.getContents();
+        final RoadmapContent targetRoadmapContent = roadmapContents.getValues().get(0);
+
+        final GoalRoom goalRoom = 골룸을_생성한다(targetRoadmapContent, creator);
+        final GoalRoom savedGoalRoom = goalRoomRepository.save(goalRoom);
+
+        final Member member1 = 사용자를_생성한다("identifier1", "password2!", "name1", "010-1111-1111");
+        final Member member2 = 사용자를_생성한다("identifier2", "password3!", "name2", "010-1111-1112");
+        final Member member3 = 사용자를_생성한다("identifier3", "password4!", "name3", "010-1111-1113");
+
+        final GoalRoomPendingMember goalRoomPendingMember0 = goalRoom.getGoalRoomPendingMembers().getValues().get(0);
+        final GoalRoomPendingMember goalRoomPendingMember1 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member1);
+        final GoalRoomPendingMember goalRoomPendingMember2 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member2);
+        final GoalRoomPendingMember goalRoomPendingMember3 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member3);
+        goalRoomPendingMemberRepository.saveAll(
+                List.of(goalRoomPendingMember1, goalRoomPendingMember2, goalRoomPendingMember3));
+        final List<GoalRoomPendingMember> expected = List.of(goalRoomPendingMember0, goalRoomPendingMember1,
+                goalRoomPendingMember2, goalRoomPendingMember3);
+
+        // when
+        final List<GoalRoomPendingMember> goalRoomPendingMembers = goalRoomPendingMemberRepository.findByGoalRoomIdOrderedBySortType(
+                savedGoalRoom.getId(), GoalRoomMemberSortType.JOINED_ASC);
+
+        // then
+        assertThat(goalRoomPendingMembers)
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 골룸_아이디로_골룸_사용자를_조회하고_마지막으로_들어온_순서대로_정렬한다() {
+        // given
+        final Member creator = 크리에이터를_저장한다();
+        final RoadmapCategory category = 카테고리를_저장한다("게임");
+        final Roadmap roadmap = 로드맵을_저장한다(creator, category);
+
+        final RoadmapContents roadmapContents = roadmap.getContents();
+        final RoadmapContent targetRoadmapContent = roadmapContents.getValues().get(0);
+
+        final GoalRoom goalRoom = 골룸을_생성한다(targetRoadmapContent, creator);
+        final GoalRoom savedGoalRoom = goalRoomRepository.save(goalRoom);
+
+        final Member member1 = 사용자를_생성한다("identifier1", "password2!", "name1", "010-1111-1111");
+        final Member member2 = 사용자를_생성한다("identifier2", "password3!", "name2", "010-1111-1112");
+        final Member member3 = 사용자를_생성한다("identifier3", "password4!", "name3", "010-1111-1113");
+
+        final GoalRoomPendingMember goalRoomPendingMember0 = goalRoom.getGoalRoomPendingMembers().getValues().get(0);
+        final GoalRoomPendingMember goalRoomPendingMember1 = new GoalRoomPendingMember(GoalRoomRole.LEADER,
+                LocalDateTime.now(), savedGoalRoom, member1);
+        final GoalRoomPendingMember goalRoomPendingMember2 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member2);
+        final GoalRoomPendingMember goalRoomPendingMember3 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member3);
+        final GoalRoomPendingMember savedGoalRoomPendingMember1 = goalRoomPendingMemberRepository.save(
+                goalRoomPendingMember1);
+        final GoalRoomPendingMember savedGoalRoomPendingMember2 = goalRoomPendingMemberRepository.save(
+                goalRoomPendingMember2);
+        final GoalRoomPendingMember savedGoalRoomPendingMember3 = goalRoomPendingMemberRepository.save(
+                goalRoomPendingMember3);
+        final List<GoalRoomPendingMember> expected = List.of(savedGoalRoomPendingMember3, savedGoalRoomPendingMember2,
+                savedGoalRoomPendingMember1, goalRoomPendingMember0);
+
+        // when
+        final List<GoalRoomPendingMember> goalRoomPendingMembers = goalRoomPendingMemberRepository.findByGoalRoomIdOrderedBySortType(
+                savedGoalRoom.getId(), GoalRoomMemberSortType.JOINED_DESC);
+
+        // then
+        assertThat(goalRoomPendingMembers)
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 골룸_아이디로_골룸_사용자를_조회하고_정렬조건을_달성률순_또는_입력하지_않은경우_참여한순으로_정렬한다() {
+        // given
+        final Member creator = 크리에이터를_저장한다();
+        final RoadmapCategory category = 카테고리를_저장한다("게임");
+        final Roadmap roadmap = 로드맵을_저장한다(creator, category);
+
+        final RoadmapContents roadmapContents = roadmap.getContents();
+        final RoadmapContent targetRoadmapContent = roadmapContents.getValues().get(0);
+
+        final GoalRoom goalRoom = 골룸을_생성한다(targetRoadmapContent, creator);
+        final GoalRoom savedGoalRoom = goalRoomRepository.save(goalRoom);
+
+        final Member member1 = 사용자를_생성한다("identifier1", "password2!", "name1", "010-1111-1111");
+        final Member member2 = 사용자를_생성한다("identifier2", "password3!", "name2", "010-1111-1112");
+        final Member member3 = 사용자를_생성한다("identifier3", "password4!", "name3", "010-1111-1113");
+
+        final GoalRoomPendingMember goalRoomPendingMember0 = goalRoom.getGoalRoomPendingMembers().getValues().get(0);
+        final GoalRoomPendingMember goalRoomPendingMember1 = new GoalRoomPendingMember(GoalRoomRole.LEADER,
+                LocalDateTime.now(), savedGoalRoom, member1);
+        final GoalRoomPendingMember goalRoomPendingMember2 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member2);
+        final GoalRoomPendingMember goalRoomPendingMember3 = new GoalRoomPendingMember(GoalRoomRole.FOLLOWER,
+                LocalDateTime.now(), savedGoalRoom, member3);
+        goalRoomPendingMemberRepository.saveAll(
+                List.of(goalRoomPendingMember1, goalRoomPendingMember2, goalRoomPendingMember3));
+        final List<GoalRoomPendingMember> expected = List.of(goalRoomPendingMember0, goalRoomPendingMember1,
+                goalRoomPendingMember2, goalRoomPendingMember3);
+
+        // when
+        final List<GoalRoomPendingMember> goalRoomPendingMembers1 = goalRoomPendingMemberRepository.findByGoalRoomIdOrderedBySortType(
+                savedGoalRoom.getId(), GoalRoomMemberSortType.ACCOMPLISHMENT_RATE);
+        final List<GoalRoomPendingMember> goalRoomPendingMembers2 = goalRoomPendingMemberRepository.findByGoalRoomIdOrderedBySortType(
+                savedGoalRoom.getId(), null);
+
+        // then
+        assertThat(goalRoomPendingMembers1)
+                .isEqualTo(expected);
+        assertThat(goalRoomPendingMembers2)
+                .isEqualTo(expected);
+    }
+
     private Member 크리에이터를_저장한다() {
         final MemberProfile memberProfile = new MemberProfile(Gender.MALE, LocalDate.of(1990, 1, 1), "010-1234-5678");
         final Member creator = new Member(new Identifier("cokirikiri"),
-                new EncryptedPassword(new Password("password1!")), new Nickname("코끼리"), null, memberProfile);
+                new EncryptedPassword(new Password("password1!")), new Nickname("코끼리"),
+                new MemberImage("originalFileName", "serverFilePath", ImageContentType.PNG), memberProfile);
         return memberRepository.save(creator);
     }
 
@@ -196,7 +321,8 @@ class GoalRoomPendingMemberRepositoryTest {
                              final String phoneNumber) {
         final MemberProfile memberProfile = new MemberProfile(Gender.MALE, LocalDate.of(1990, 1, 1), phoneNumber);
         final Member member = new Member(new Identifier(identifier), new EncryptedPassword(new Password(password)),
-                new Nickname(nickname), null, memberProfile);
+                new Nickname(nickname), new MemberImage("originalFileName", "serverFilePath", ImageContentType.PNG),
+                memberProfile);
         return memberRepository.save(member);
     }
 


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-165](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1/backlog?selectedIssue=CK-165)


## ✨ 작업 내용
- 골룸 참여자 조회 시 골룸이 진행중이거나 완료됐을 때만 조회가 가능한 로직을 모집중일 때도 조회가능하도록 수정했습니다.


## 💬 리뷰어에게 남길 멘트
- 제가 머지하면서 브랜치가 이상하게 꼬여서 브랜치 삭제하고 다시 추가했어요ㅠㅠ!


## 🚀 요구사항 분석


