### PR TITLE
[feat/CK-163] 로그인 라우팅 처리 로직 수정 및 뒤로가기 버튼 위치를 조정한다

### DIFF
--- a/client/src/components/loginPage/loginContent/LoginContent.styles.ts
+++ b/client/src/components/loginPage/loginContent/LoginContent.styles.ts
@@ -1,1 +1,10 @@
+import { SingleCardWrapper } from '@components/_common/SingleCard/SingleCard.styles';
+import styled from 'styled-components';
+
 export { InfoText, FormList } from '@components/signUpPage/SignUpForm.styles';
+
+export const LoginContentWrapper = styled(SingleCardWrapper)`
+  & img {
+    margin-left: 4rem;
+  }
+`;

--- a/client/src/components/loginPage/loginContent/LoginContent.tsx
+++ b/client/src/components/loginPage/loginContent/LoginContent.tsx
@@ -3,14 +3,15 @@ import { Link } from 'react-router-dom';
 import BackButton from '@components/_common/backButton/BackButton';
 import LoginOptions from '@components/loginPage/loginOptions/LoginOptions';
 import LoginForm from '@components/loginPage/loginForm/LoginForm';
-import { SingleCardWrapper } from '@components/_common/SingleCard/SingleCard.styles';
 import { useSwitch } from '@hooks/_common/useSwitch';
+
+import * as S from './LoginContent.styles';
 
 const LoginContent = () => {
   const { isSwitchOn: isLoginFormVisible, toggleSwitch: toggleLoginForm } = useSwitch();
 
   return (
-    <SingleCardWrapper>
+    <S.LoginContentWrapper>
       <Link to='/'>
         <img src={logo} alt='코끼리 로고' />
       </Link>
@@ -20,7 +21,7 @@ const LoginContent = () => {
         <LoginOptions toggleLoginForm={toggleLoginForm} />
       )}
       {isLoginFormVisible && <BackButton action={toggleLoginForm} />}
-    </SingleCardWrapper>
+    </S.LoginContentWrapper>
   );
 };
 

--- a/client/src/components/loginPage/loginForm/LoginForm.tsx
+++ b/client/src/components/loginPage/loginForm/LoginForm.tsx
@@ -3,22 +3,18 @@ import { UserLoginRequest } from '@myTypes/user/remote';
 import { useLogin } from '@hooks/queries/user';
 import useFormInput from '@hooks/_common/useFormInput';
 import * as S from './LoginForm.styles';
-import { useNavigate } from 'react-router-dom';
 
 const LoginForm = () => {
   const { formState: loginData, handleInputChange } = useFormInput<UserLoginRequest>({
     identifier: '',
     password: '',
   });
-  const navigate = useNavigate();
 
   const { login } = useLogin();
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     login(loginData);
-
-    navigate('/');
   };
 
   return (

--- a/client/src/hooks/queries/user.ts
+++ b/client/src/hooks/queries/user.ts
@@ -31,6 +31,7 @@ export const useSignUp = () => {
 };
 
 export const useLogin = () => {
+  const navigate = useNavigate();
   const { triggerToast } = useToast();
   const { setUserInfo } = useUserInfoContext();
 
@@ -46,9 +47,8 @@ export const useLogin = () => {
         getUserInfo().then((response: AxiosResponse<UserInfoResponse>) => {
           setUserInfo(response.data);
         });
-      },
-      onError() {
-        // TODO: 로그인 실패 시 로직
+
+        navigate('/');
       },
     }
   );


### PR DESCRIPTION
## 📌 작업 이슈 번호

CK-163

## ✨ 작업 내용

https://github.com/woowacourse-teams/2023-co-kirikiri/assets/81363031/65d33721-ec0c-43a8-a771-b49da03920e7

- 기존 로그인 폼과 비교해 사이즈 크게 잡았습니다.
- 기존 버튼과 로고가 겹치는 상황 해결
- 기존 그냥 로그인 버튼 누르면 홈으로 가던 로직에서 `성공해야` 홈으로 가게끔 라우팅 처리


## 💬 리뷰어에게 남길 멘트

자아아알~ 부탁드립니다!

## 🚀 요구사항 분석

- 로그인 폼 스타일링 고도화
- 로그인 폼 네비게이팅 로직 개선 


