### PR TITLE
[feat/CK-172] 골룸 목록 정렬 구현 및 스타일 고도화를 진행한다

### DIFF
--- a/client/src/apis/goalRoom.ts
+++ b/client/src/apis/goalRoom.ts
@@ -1,3 +1,4 @@
+import { FILTER_COND } from '@constants/goalRoom/goalRoomFilter';
 import {
   GoalRoomListRequest,
   GoalRoomBrowseResponse,
@@ -16,7 +17,7 @@ import { GoalRoomRecruitmentStatus, MyPageGoalRoom } from '@myTypes/goalRoom/int
 
 export const getGoalRoomList = async ({
   roadmapId,
-  filterCond = 'LATEST',
+  filterCond = FILTER_COND.latest,
   lastCreatedAt = '',
   size = 6,
   lastId,

--- a/client/src/apis/goalRoom.ts
+++ b/client/src/apis/goalRoom.ts
@@ -19,7 +19,7 @@ export const getGoalRoomList = async ({
   roadmapId,
   filterCond = FILTER_COND.latest,
   lastCreatedAt = '',
-  size = 6,
+  size = 8,
   lastId,
 }: GoalRoomListRequest): Promise<GoalRoomDetailResponse> => {
   const { data } = await client.get<GoalRoomDetailResponse>(

--- a/client/src/components/goalRoomListPage/goalRoomDetail/goalRoomDetailDialog.styles.ts
+++ b/client/src/components/goalRoomListPage/goalRoomDetail/goalRoomDetailDialog.styles.ts
@@ -127,5 +127,5 @@ export const DetailButton = styled.button`
   color: ${({ theme }) => theme.colors.white};
 
   background-color: ${({ theme }) => theme.colors.main_dark};
-  border-radius: 85px;
+  border-radius: 8px;
 `;

--- a/client/src/components/goalRoomListPage/goalRoomList/GoalRoomFilter.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomList/GoalRoomFilter.tsx
@@ -10,8 +10,9 @@ const GoalRoomFilter = ({
     selectedOption: (typeof goalRoomFilter)[keyof typeof goalRoomFilter]
   ) => React.ReactNode;
 }) => {
-  const [selectedOption, setSelectedOption] =
-    useState<(typeof goalRoomFilter)[keyof typeof goalRoomFilter]>('마감 임박 순');
+  const [selectedOption, setSelectedOption] = useState<
+    (typeof goalRoomFilter)[keyof typeof goalRoomFilter]
+  >(goalRoomFilter['1']);
 
   const selectFilterOption = (id: number) => {
     if (Object.hasOwn(goalRoomFilter, id)) {

--- a/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
@@ -38,10 +38,10 @@ const GoalRoomList = () => {
               <Select.OptionGroup asChild>
                 <S.FilterOptionWrapper>
                   <Select.Option id={1} asChild>
-                    <S.FilterOption>마감 임박순</S.FilterOption>
+                    <S.FilterOption>마감 임박 순</S.FilterOption>
                   </Select.Option>
                   <Select.Option id={2} asChild>
-                    <S.FilterOption>참여인원 순</S.FilterOption>
+                    <S.FilterOption>참여 인원 순</S.FilterOption>
                   </Select.Option>
                 </S.FilterOptionWrapper>
               </Select.OptionGroup>

--- a/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
@@ -5,21 +5,23 @@ import useValidParams from '@/hooks/_common/useValidParams';
 import GoalRoomFilter from './GoalRoomFilter';
 import { Select } from '@/components/roadmapCreatePage/selector/SelectBox';
 import { useState } from 'react';
-import { goalRoomFilter } from '@/constants/goalRoom/goalRoomFilter';
+import { FILTER_COND, goalRoomFilter } from '@/constants/goalRoom/goalRoomFilter';
 import { useInfiniteScroll } from '@hooks/_common/useInfiniteScroll';
 import WavyLoading from '@components/_common/wavyLoading/WavyLoading';
 import { Link } from 'react-router-dom';
 
 const GoalRoomList = () => {
   const { id } = useValidParams<{ id: string }>();
-  const [sortedOption, setSortedOption] =
-    useState<(typeof goalRoomFilter)[keyof typeof goalRoomFilter]>('마감 임박 순');
+  const [sortedOption, setSortedOption] = useState<
+    (typeof goalRoomFilter)[keyof typeof goalRoomFilter]
+  >(goalRoomFilter['1']);
   const {
     goalRoomListResponse: { responses: goalRoomList, hasNext },
     fetchNextPage,
   } = useGoalRoomList({
     roadmapId: Number(id),
-    filterCond: sortedOption === '참여 인원 순' ? 'PARTICIPATION_RATE' : 'LATEST',
+    filterCond:
+      sortedOption === goalRoomFilter['1'] ? FILTER_COND.latest : FILTER_COND.deadline,
   });
 
   const loadMoreRef = useInfiniteScroll({
@@ -38,10 +40,10 @@ const GoalRoomList = () => {
               <Select.OptionGroup asChild>
                 <S.FilterOptionWrapper>
                   <Select.Option id={1} asChild>
-                    <S.FilterOption>마감 임박 순</S.FilterOption>
+                    <S.FilterOption>{goalRoomFilter['1']}</S.FilterOption>
                   </Select.Option>
                   <Select.Option id={2} asChild>
-                    <S.FilterOption>참여 인원 순</S.FilterOption>
+                    <S.FilterOption>{goalRoomFilter['2']}</S.FilterOption>
                   </Select.Option>
                 </S.FilterOptionWrapper>
               </Select.OptionGroup>

--- a/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
+++ b/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
@@ -11,7 +11,7 @@ export const ItemContainer = styled.article`
   padding: 1.7rem 4rem 3rem;
 
   background-color: ${({ theme }) => theme.colors.white};
-  border-radius: 34px;
+  border-radius: 16px;
   box-shadow: -1.5653846263885498px 7.826924800872803px 46.961544036865234px 0px
     rgba(0, 0, 0, 0.13);
 `;
@@ -23,8 +23,8 @@ export const FilterBar = styled.div`
   margin-bottom: 4rem;
 
   & > p {
-    ${({ theme }) => theme.fonts.description4};
-    color: ${({ theme }) => theme.colors.gray200};
+    ${({ theme }) => theme.fonts.button1};
+    color: ${({ theme }) => theme.colors.gray300};
   }
 `;
 
@@ -42,8 +42,7 @@ export const ListWrapper = styled.div`
 
 export const Recruiting = styled.div`
   ${({ theme }) => theme.fonts.description4}
-  color: ${({ theme }) => theme.colors.gray200};
-  float: right;
+  color: ${({ theme }) => theme.colors.gray300};
 `;
 
 export const Name = styled.h1`
@@ -108,14 +107,14 @@ export const FilterWrapper = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  color: ${({ theme }) => theme.colors.gray200};
+  color: ${({ theme }) => theme.colors.gray300};
 `;
 
 export const FilterTrigger = styled.button`
-  ${({ theme }) => theme.fonts.description4};
+  ${({ theme }) => theme.fonts.button1};
   width: 9rem;
   height: 1.5rem;
-  color: ${({ theme }) => theme.colors.gray200};
+  color: ${({ theme }) => theme.colors.gray300};
 `;
 
 export const FilterOptionWrapper = styled.ul`

--- a/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
+++ b/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
@@ -2,7 +2,8 @@ import media from '@/styles/media';
 import styled from 'styled-components';
 
 export const ListContainer = styled.section`
-  margin-top: 6rem;
+  min-height: 100vh;
+  margin-top: 4rem;
 `;
 
 export const ItemContainer = styled.article`
@@ -20,7 +21,7 @@ export const FilterBar = styled.div`
   display: flex;
   justify-content: space-between;
   margin-right: 9rem;
-  margin-bottom: 4rem;
+  margin-bottom: 6rem;
 
   & > p {
     ${({ theme }) => theme.fonts.button1};
@@ -32,7 +33,6 @@ export const ListWrapper = styled.div`
   display: grid;
   grid-row-gap: 6rem;
   grid-template-columns: repeat(2, 1fr);
-  min-height: 100vh;
 
   ${media.mobile`
   grid-template-columns: repeat(1, 1fr);
@@ -93,8 +93,8 @@ export const CreateGoalRoomButton = styled.button`
   left: 50%;
   transform: translate(-50%);
 
-  width: 50%;
   height: 5rem;
+  padding: 0 10rem;
 
   color: ${({ theme }) => theme.colors.white};
 
@@ -103,10 +103,13 @@ export const CreateGoalRoomButton = styled.button`
 `;
 
 export const FilterWrapper = styled.div`
+  position: relation;
   ${({ theme }) => theme.fonts.description4};
   position: relative;
+
   display: flex;
   flex-direction: column;
+
   color: ${({ theme }) => theme.colors.gray300};
 `;
 
@@ -119,10 +122,9 @@ export const FilterTrigger = styled.button`
 
 export const FilterOptionWrapper = styled.ul`
   position: absolute;
-  top: 2rem;
+  top: -1rem;
 
   width: 9rem;
-  /* height: 3rem; */
 
   border: 0.2rem solid ${({ theme }) => theme.colors.main_middle};
   border-radius: 4px;
@@ -130,7 +132,13 @@ export const FilterOptionWrapper = styled.ul`
 
 export const FilterOption = styled.li`
   cursor: pointer;
+
   width: 100%;
   height: 50%;
   padding: 1rem 1rem;
+
+  color: ${({ theme }) => theme.colors.white};
+  text-align: center;
+
+  background-color: ${({ theme }) => theme.colors.main_dark};
 `;

--- a/client/src/components/roadmapCreatePage/selector/SelectBox.tsx
+++ b/client/src/components/roadmapCreatePage/selector/SelectBox.tsx
@@ -120,7 +120,8 @@ export const Indicator = (props: PropsWithChildren<IndicatorProps>) => {
 // select의 각 Option
 export const Option = (props: PropsWithChildren<OptionProps>) => {
   const { asChild = false, children, ...restProps } = props;
-  const { selectOption, selectedId } = useContextScope<SelectContextType>(SelectContext);
+  const { selectOption, selectedId, toggleBoxOpen } =
+    useContextScope<SelectContextType>(SelectContext);
   const isSelected = restProps.id === selectedId;
 
   if (asChild) {
@@ -130,6 +131,7 @@ export const Option = (props: PropsWithChildren<OptionProps>) => {
       onClick: (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
         selectOption(restProps.id);
+        toggleBoxOpen();
       },
     });
   }

--- a/client/src/constants/goalRoom/goalRoomFilter.ts
+++ b/client/src/constants/goalRoom/goalRoomFilter.ts
@@ -1,4 +1,9 @@
 export const goalRoomFilter = {
-  1: '마감 임박 순',
-  2: '참여 인원 순',
+  1: '최신 순',
+  2: '마감 임박 순',
+} as const;
+
+export const FILTER_COND = {
+  latest: 'LATEST',
+  deadline: 'CLOSE_TO_DEADLINE',
 } as const;

--- a/client/src/myTypes/goalRoom/remote.ts
+++ b/client/src/myTypes/goalRoom/remote.ts
@@ -1,3 +1,4 @@
+import { FILTER_COND } from '@constants/goalRoom/goalRoomFilter';
 import {
   CheckFeed,
   GoalRoomDetailType,
@@ -7,7 +8,7 @@ import {
   GoalRoomTodo,
 } from '@myTypes/goalRoom/internal';
 
-type FilterCondType = 'LATEST' | 'PARTICIPATION_RATE';
+type FilterCondType = (typeof FILTER_COND)[keyof typeof FILTER_COND];
 
 export type GoalRoomListRequest = {
   roadmapId: number;


### PR DESCRIPTION
## 📌 작업 이슈 번호
CK-172


## ✨ 작업 내용
- [x] 골룸 목록 정렬 API 명세 반영
- [x] 골룸 아이템 컴포넌트 스타일 변경 (너무 둥글둥글하지 않도록)
- [x] select box의 옵션을 클릭하면 option 창이 닫히도록 변경
- [x] 아이템이 적을 때, 아이템 사이의 row 간격이 늘어나는 버그 수정
- [x] 정렬 조건이 아이템을 가리는 버그 수정


## 💬 리뷰어에게 남길 멘트
잘 부탁드립니다~!


## 🚀 요구사항 분석
- 골룸 목록 정렬 API 변경사항 반영
- 골룸 목록 스타일 고도화

https://github.com/woowacourse-teams/2023-co-kirikiri/assets/88191233/57d80665-ec38-4709-acad-b7475a834eef



