### PR TITLE
[feat/CK-179] 로드맵 카테고리 생성을 구현한다

### DIFF
--- a/backend/kirikiri/src/docs/asciidoc/roadmap.adoc
+++ b/backend/kirikiri/src/docs/asciidoc/roadmap.adoc
@@ -219,3 +219,22 @@ operation::roadmap-create-api-test/로드맵_삭제시_존재하지_않는_로�
 === *10-3* 실패 - 자신이 생성한 로드맵이 아닌 경우
 
 operation::roadmap-create-api-test/로드맵_삭제시_자신이_생성한_로드맵이_아닌_경우_예외가_발생한다[snippets='http-request,http-response,response-fields']
+
+[[로드맵카테고리생성-API]]
+== *11. 로드맵 카테고리 생성 API*
+
+=== *11-1* 성공
+
+operation::roadmap-create-api-test/정상적으로_로드맵_카테고리를_생성한다[snippets='http-request,request-fields,http-response']
+
+=== *11-2* 로드맵 카테고리 생성 시 카테고리 이름이 빈값일 경우
+
+operation::roadmap-create-api-test/로드맵_카테고리_생성_시_카테고리_이름이_빈값일_경우[snippets='http-request,request-fields,http-response']
+
+=== *11-3* 로드맵 카테고리 생성 시 카테고리 이름이 10자 초과일 경우
+
+operation::roadmap-create-api-test/로드맵_카테고리_생성_시_카테고리_이름이_10자_초과일_경우[snippets='http-request,request-fields,http-response']
+
+=== *11-4* 로드맵 카테고리 생성 시 카테고리 이름이 중복될 경우
+
+operation::roadmap-create-api-test/로드맵_카테고리_생성_시_카테고리_이름이_중복될_경우[snippets='http-request,request-fields,http-response']

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
@@ -6,6 +6,7 @@ import co.kirikiri.service.RoadmapCreateService;
 import co.kirikiri.service.RoadmapReadService;
 import co.kirikiri.service.dto.CustomScrollRequest;
 import co.kirikiri.service.dto.roadmap.RoadmapGoalRoomsOrderTypeDto;
+import co.kirikiri.service.dto.roadmap.request.RoadmapCategorySaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapOrderTypeRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapReviewSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
@@ -17,8 +18,6 @@ import co.kirikiri.service.dto.roadmap.response.RoadmapGoalRoomResponses;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapReviewResponse;
 import jakarta.validation.Valid;
-import java.net.URI;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -32,6 +31,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/roadmaps")
@@ -89,6 +90,12 @@ public class RoadmapController {
     public ResponseEntity<List<RoadmapCategoryResponse>> findAllRoadmapCategories() {
         final List<RoadmapCategoryResponse> roadmapCategoryResponses = roadmapReadService.findAllRoadmapCategories();
         return ResponseEntity.ok(roadmapCategoryResponses);
+    }
+
+    @PostMapping("/categories")
+    public ResponseEntity<Void> createRoadmapCategory(@RequestBody @Valid final RoadmapCategorySaveRequest roadmapCategorySaveRequest) {
+        roadmapCreateService.createRoadmapCategory(roadmapCategorySaveRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping("/me")

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapCategory.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapCategory.java
@@ -1,6 +1,7 @@
 package co.kirikiri.domain.roadmap;
 
 import co.kirikiri.domain.BaseEntity;
+import co.kirikiri.exception.BadRequestException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
@@ -12,6 +13,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class RoadmapCategory extends BaseEntity {
 
+    private static final int MAX_NAME_LENGTH = 10;
+
     @Column(length = 15, nullable = false)
     private String name;
 
@@ -21,7 +24,14 @@ public class RoadmapCategory extends BaseEntity {
 
     public RoadmapCategory(final Long id, final String name) {
         super.id = id;
+        validateNameLength(name);
         this.name = name;
+    }
+
+    private void validateNameLength(final String name) {
+        if (name.length() > MAX_NAME_LENGTH) {
+            throw new BadRequestException("카테고리 이름은 10자 이하입니다.");
+        }
     }
 
     public String getName() {

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapCategory.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapCategory.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class RoadmapCategory extends BaseEntity {
 
+    private static final int MIN_NAME_LENGTH = 1;
     private static final int MAX_NAME_LENGTH = 10;
 
     @Column(length = 15, nullable = false)
@@ -29,8 +30,8 @@ public class RoadmapCategory extends BaseEntity {
     }
 
     private void validateNameLength(final String name) {
-        if (name.length() > MAX_NAME_LENGTH) {
-            throw new BadRequestException("카테고리 이름은 10자 이하입니다.");
+        if (name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH) {
+            throw new BadRequestException("카테고리 이름은 1자 이상 10자 이하입니다.");
         }
     }
 

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapCategory.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapCategory.java
@@ -25,8 +25,9 @@ public class RoadmapCategory extends BaseEntity {
 
     public RoadmapCategory(final Long id, final String name) {
         super.id = id;
-        validateNameLength(name);
-        this.name = name;
+        final String trimmed = name.trim();
+        validateNameLength(trimmed);
+        this.name = trimmed;
     }
 
     private void validateNameLength(final String name) {

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapCategoryRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapCategoryRepository.java
@@ -2,7 +2,9 @@ package co.kirikiri.persistence.roadmap;
 
 import co.kirikiri.domain.roadmap.RoadmapCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface RoadmapCategoryRepository extends JpaRepository<RoadmapCategory, Long> {
 
+    Optional<RoadmapCategory> findByName(final String name);
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapCreateService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapCreateService.java
@@ -17,6 +17,7 @@ import co.kirikiri.domain.roadmap.RoadmapTags;
 import co.kirikiri.domain.roadmap.vo.RoadmapTagName;
 import co.kirikiri.exception.AuthenticationException;
 import co.kirikiri.exception.BadRequestException;
+import co.kirikiri.exception.ConflictException;
 import co.kirikiri.exception.ForbiddenException;
 import co.kirikiri.exception.NotFoundException;
 import co.kirikiri.persistence.goalroom.GoalRoomMemberRepository;
@@ -29,6 +30,7 @@ import co.kirikiri.service.dto.roadmap.RoadmapNodeSaveDto;
 import co.kirikiri.service.dto.roadmap.RoadmapReviewDto;
 import co.kirikiri.service.dto.roadmap.RoadmapSaveDto;
 import co.kirikiri.service.dto.roadmap.RoadmapTagSaveDto;
+import co.kirikiri.service.dto.roadmap.request.RoadmapCategorySaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapReviewSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
 import co.kirikiri.service.event.RoadmapCreateEvent;
@@ -166,5 +168,14 @@ public class RoadmapCreateService {
     private void validateRoadmapCreator(final Long roadmapId, final String identifier) {
         roadmapRepository.findByIdAndMemberIdentifier(roadmapId, identifier)
                 .orElseThrow(() -> new ForbiddenException("해당 로드맵을 생성한 사용자가 아닙니다."));
+    }
+
+    public void createRoadmapCategory(final RoadmapCategorySaveRequest roadmapCategorySaveRequest) {
+        final RoadmapCategory roadmapCategory = RoadmapMapper.convertToRoadmapCategory(roadmapCategorySaveRequest);
+        roadmapCategoryRepository.findByName(roadmapCategory.getName())
+                .ifPresent(it -> {
+                    throw new ConflictException("이미 존재하는 이름의 카테고리입니다.");
+                });
+        roadmapCategoryRepository.save(roadmapCategory);
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/request/RoadmapCategorySaveRequest.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/request/RoadmapCategorySaveRequest.java
@@ -3,6 +3,7 @@ package co.kirikiri.service.dto.roadmap.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record RoadmapCategorySaveRequest(
+        
         @NotBlank(message = "카테고리 이름은 빈 값일 수 없습니다.")
         String name
 ) {

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/request/RoadmapCategorySaveRequest.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/dto/roadmap/request/RoadmapCategorySaveRequest.java
@@ -1,0 +1,10 @@
+package co.kirikiri.service.dto.roadmap.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RoadmapCategorySaveRequest(
+        @NotBlank(message = "카테고리 이름은 빈 값일 수 없습니다.")
+        String name
+) {
+
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/RoadmapMapper.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/RoadmapMapper.java
@@ -21,6 +21,7 @@ import co.kirikiri.service.dto.roadmap.RoadmapReviewReadDto;
 import co.kirikiri.service.dto.roadmap.RoadmapSaveDto;
 import co.kirikiri.service.dto.roadmap.RoadmapTagDto;
 import co.kirikiri.service.dto.roadmap.RoadmapTagSaveDto;
+import co.kirikiri.service.dto.roadmap.request.RoadmapCategorySaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapNodeSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapOrderTypeRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapReviewSaveRequest;
@@ -208,5 +209,9 @@ public final class RoadmapMapper {
         return new RoadmapReviewResponse(roadmapReviewReadDto.id(),
                 new MemberResponse(memberDto.id(), memberDto.name(), memberDto.imageUrl()),
                 roadmapReviewReadDto.createdAt(), roadmapReviewReadDto.content(), roadmapReviewReadDto.rate());
+    }
+
+    public static RoadmapCategory convertToRoadmapCategory(final RoadmapCategorySaveRequest request) {
+        return new RoadmapCategory(request.name());
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/controller/RoadmapCreateApiTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/controller/RoadmapCreateApiTest.java
@@ -801,7 +801,7 @@ class RoadmapCreateApiTest extends ControllerTestHelper {
     @Test
     void 로드맵_카테고리_생성_시_카테고리_이름이_중복될_경우() throws Exception {
         // given
-        final RoadmapCategorySaveRequest request = new RoadmapCategorySaveRequest("10자가 초과되는 카테고리 이름입니다.");
+        final RoadmapCategorySaveRequest request = new RoadmapCategorySaveRequest("여행");
         doThrow(new ConflictException("이미 존재하는 이름의 카테고리입니다.")).when(roadmapCreateService)
                 .createRoadmapCategory(request);
 

--- a/backend/kirikiri/src/test/java/co/kirikiri/controller/RoadmapCreateApiTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/controller/RoadmapCreateApiTest.java
@@ -725,7 +725,7 @@ class RoadmapCreateApiTest extends ControllerTestHelper {
     }
 
     @Test
-    void 로드맵_카테고리를_생성한다() throws Exception {
+    void 정상적으로_로드맵_카테고리를_생성한다() throws Exception {
         // given
         final RoadmapCategorySaveRequest request = new RoadmapCategorySaveRequest("카테고리 이름");
         doNothing().when(roadmapCreateService)

--- a/backend/kirikiri/src/test/java/co/kirikiri/domain/roadmap/RoadmapCategoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/domain/roadmap/RoadmapCategoryTest.java
@@ -1,0 +1,43 @@
+package co.kirikiri.domain.roadmap;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import co.kirikiri.exception.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class RoadmapCategoryTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"글", "여행", "1234567890", "       1234567890        "})
+    void 정상적으로_로드맵_카테고리를_생성한다(final String name) {
+        //given
+        //when
+        //then
+        assertDoesNotThrow(() -> new RoadmapCategory(name));
+    }
+
+    @Test
+    void 카테고리_생성시_공백이_들어올_경우_예외를_던진다() {
+        //given
+        final String space = "";
+
+        //when
+        //then
+        assertThatThrownBy(() -> new RoadmapCategory(space))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    void 카테고리_생성시_10글자_초과일_경우_예외를_던진다() {
+        //given
+        final String space = "12345678901";
+
+        //when
+        //then
+        assertThatThrownBy(() -> new RoadmapCategory(space))
+                .isInstanceOf(BadRequestException.class);
+    }
+}

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapCreateIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapCreateIntegrationTest.java
@@ -383,26 +383,10 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
         응답_상태_코드_검증(로드맵_카테고리_생성_응답, HttpStatus.CREATED);
     }
 
-
-    @Test
-    void 카테고리_생성_시_빈_이름이_들어올_경우() {
-        //given
-        final RoadmapCategorySaveRequest 로드맵_카테고리_생성_요청 = new RoadmapCategorySaveRequest("운동");
-
-        //when
-        final ExtractableResponse<Response> 로드맵_카테고리_생성_응답 = 로드맵_카테고리를_생성한다(기본_로그인_토큰, 로드맵_카테고리_생성_요청);
-
-        //then
-        final ErrorResponse 에러_메세지 = 로드맵_카테고리_생성_응답.as(ErrorResponse.class);
-
-        응답_상태_코드_검증(로드맵_카테고리_생성_응답, HttpStatus.BAD_REQUEST);
-        assertThat(에러_메세지.message()).isEqualTo("카테고리 이름은 빈 값일 수 없습니다.");
-    }
-
     @Test
     void 카테고리_생성_시_10글자_초과_이름이_들어올_경우() {
         //given
-        final RoadmapCategorySaveRequest 로드맵_카테고리_생성_요청 = new RoadmapCategorySaveRequest("운동");
+        final RoadmapCategorySaveRequest 로드맵_카테고리_생성_요청 = new RoadmapCategorySaveRequest("10자 초과되는 카테고리 이름");
 
         //when
         final ExtractableResponse<Response> 로드맵_카테고리_생성_응답 = 로드맵_카테고리를_생성한다(기본_로그인_토큰, 로드맵_카테고리_생성_요청);
@@ -411,7 +395,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
         final ErrorResponse 에러_메세지 = 로드맵_카테고리_생성_응답.as(ErrorResponse.class);
 
         응답_상태_코드_검증(로드맵_카테고리_생성_응답, HttpStatus.BAD_REQUEST);
-        assertThat(에러_메세지.message()).isEqualTo("카테고리 이름은 10자 이하입니다.");
+        assertThat(에러_메세지.message()).isEqualTo("카테고리 이름은 1자 이상 10자 이하입니다.");
     }
 
     @Test

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapCreateIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapCreateIntegrationTest.java
@@ -246,7 +246,6 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
         final String 로드맵_노드_설명 = "a".repeat(2001);
         final List<RoadmapNodeSaveRequest> 로드맵_노드들 = List.of(
                 new RoadmapNodeSaveRequest("로드맵 노드 제목", 로드맵_노드_설명, Collections.emptyList()));
-        testTransactionService.로드맵_카테고리를_저장한다("여행");
 
         final RoadmapSaveRequest 로드맵_생성_요청값 = new RoadmapSaveRequest(기본_카테고리.getId(), "로드맵 제목", "로드맵 소개글",
                 "로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30, 로드맵_노드들, List.of(new RoadmapTagSaveRequest("태그1")));

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapCreateIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapCreateIntegrationTest.java
@@ -398,6 +398,21 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
     }
 
     @Test
+    void 카테고리_생성_시_공백이_들어올_경우() {
+        //given
+        final RoadmapCategorySaveRequest 로드맵_카테고리_생성_요청 = new RoadmapCategorySaveRequest("");
+
+        //when
+        final ExtractableResponse<Response> 로드맵_카테고리_생성_응답 = 로드맵_카테고리를_생성한다(기본_로그인_토큰, 로드맵_카테고리_생성_요청);
+
+        //then
+        final ErrorResponse[] 에러_메세지 = 로드맵_카테고리_생성_응답.as(ErrorResponse[].class);
+
+        응답_상태_코드_검증(로드맵_카테고리_생성_응답, HttpStatus.BAD_REQUEST);
+        assertThat(에러_메세지[0].message()).isEqualTo("카테고리 이름은 빈 값일 수 없습니다.");
+    }
+
+    @Test
     void 카테고리_생성_시_이미_있는_이름인_경우() {
         //given
         final RoadmapCategorySaveRequest 로드맵_카테고리_생성_요청 = new RoadmapCategorySaveRequest("운동");

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadIntegrationTest.java
@@ -8,6 +8,8 @@ import static co.kirikiri.integration.fixture.RoadmapAPIFixture.모든_카테고
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.사이즈_없이_로드맵을_조회한다;
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.사이즈별로_로드맵을_조회한다;
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.정렬된_카테고리별_로드맵_리스트_조회;
+import static co.kirikiri.integration.fixture.RoadmapAPIFixture.카테고리_생성;
+import static co.kirikiri.integration.fixture.RoadmapAPIFixture.카테고리들_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -26,10 +28,10 @@ import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.io.IOException;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import java.io.IOException;
+import java.util.List;
 
 class RoadmapReadIntegrationTest extends InitIntegrationTest {
 
@@ -84,7 +86,7 @@ class RoadmapReadIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
         final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
-        final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
+        final RoadmapCategory 다른_카테고리 = 카테고리_생성(기본_로그인_토큰, "여가");
         final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(다른_카테고리.getId(), "thrid roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
@@ -120,7 +122,7 @@ class RoadmapReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵_카테고리_리스트를_조회한다() {
         // given
-        final List<RoadmapCategory> 로드맵_카테고리_리스트 = testTransactionService.모든_로드맵_카테고리를_저장한다("IT", "여가", "운동", "시험",
+        final List<RoadmapCategory> 로드맵_카테고리_리스트 = 카테고리들_생성(기본_로그인_토큰, "IT", "여가", "운동", "시험",
                 "게임");
 
         // when
@@ -130,10 +132,8 @@ class RoadmapReadIntegrationTest extends InitIntegrationTest {
                 });
 
         // then
-        assertThat(로드맵_카테고리_응답_리스트.get(0).id()).isEqualTo(1L);
         assertThat(로드맵_카테고리_응답_리스트.get(0).name()).isEqualTo("여행");
         for (int index = 1; index < 로드맵_카테고리_응답_리스트.size(); index++) {
-            assertThat(로드맵_카테고리_응답_리스트.get(index).id()).isEqualTo(로드맵_카테고리_리스트.get(index - 1).getId());
             assertThat(로드맵_카테고리_응답_리스트.get(index).name()).isEqualTo(로드맵_카테고리_리스트.get(index - 1).getName());
         }
     }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadOrderIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadOrderIntegrationTest.java
@@ -16,6 +16,7 @@ import static co.kirikiri.integration.fixture.RoadmapAPIFixture.로드맵을_아
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.리뷰를_생성한다;
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.정렬된_로드맵_리스트_조회;
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.정렬된_카테고리별_로드맵_리스트_조회;
+import static co.kirikiri.integration.fixture.RoadmapAPIFixture.카테고리_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import co.kirikiri.domain.goalroom.GoalRoom;
@@ -34,9 +35,9 @@ import co.kirikiri.service.dto.roadmap.request.RoadmapTagSaveRequest;
 import co.kirikiri.service.dto.roadmap.response.RoadmapForListResponses;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import io.restassured.common.mapper.TypeRef;
+import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.List;
-import org.junit.jupiter.api.Test;
 
 class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
 
@@ -55,8 +56,8 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
 
         // 다른 카테고리의 세 번째 로드맵 생성
-        final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
-        final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(다른_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
+        final RoadmapCategory 다른_카테고리 = 카테고리_생성(기본_로그인_토큰, "여가");
+        final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(2L, "third roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
@@ -107,7 +108,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         리뷰를_생성한다(팔로워_액세스_토큰2, 두번째_로드맵_아이디, 두번째_로드맵_리뷰_생성_요청);
 
         // 다른 카테고리의 세 번째 로드맵 생성
-        final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
+        final RoadmapCategory 다른_카테고리 = 카테고리_생성(기본_로그인_토큰, "여가");
         final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(다른_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
@@ -146,7 +147,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         로드맵에_대한_골룸을_생성한다(두번째_로드맵_응답);
 
         // 다른 카테고리의 세 번째 로드맵 생성
-        final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
+        final RoadmapCategory 다른_카테고리 = 카테고리_생성(기본_로그인_토큰, "여가");
         final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(다른_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
@@ -188,7 +189,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         골룸을_시작한다(기본_로그인_토큰, 두번째_로드맵의_골룸_아이디);
 
         // 다른 카테고리의 세 번째 로드맵 생성
-        final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
+        final RoadmapCategory 다른_카테고리 = 카테고리_생성(기본_로그인_토큰, "여가");
         final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(다른_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
@@ -222,7 +223,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
 
         // 세 번째 로드맵 생성
-        final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
+        final RoadmapCategory 다른_카테고리 = 카테고리_생성(기본_로그인_토큰, "여가");
         final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(다른_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
@@ -275,7 +276,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         리뷰를_생성한다(팔로워_액세스_토큰2, 두번째_로드맵_아이디, 두번째_로드맵_리뷰_생성_요청);
 
         // 세 번째 로드맵 생성
-        final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
+        final RoadmapCategory 다른_카테고리 = 카테고리_생성(기본_로그인_토큰, "여가");
         final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(다른_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
@@ -323,7 +324,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         로드맵에_대한_골룸을_생성한다(두번째_로드맵_응답);
 
         // 세 번째 로드맵 생성
-        final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
+        final RoadmapCategory 다른_카테고리 = 카테고리_생성(기본_로그인_토큰, "여가");
         final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(다른_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
@@ -370,7 +371,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
 
         // 세 번째 로드맵 생성
-        final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
+        final RoadmapCategory 다른_카테고리 = 카테고리_생성(기본_로그인_토큰, "여가");
         final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(다른_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/RoadmapAPIFixture.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/RoadmapAPIFixture.java
@@ -4,6 +4,7 @@ import static co.kirikiri.integration.fixture.CommonFixture.API_PREFIX;
 import static co.kirikiri.integration.fixture.CommonFixture.AUTHORIZATION;
 import static io.restassured.RestAssured.given;
 
+import co.kirikiri.domain.roadmap.RoadmapCategory;
 import co.kirikiri.persistence.dto.RoadmapOrderType;
 import co.kirikiri.service.dto.CustomScrollRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapCategorySaveRequest;
@@ -20,6 +21,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class RoadmapAPIFixture {
 
@@ -212,15 +215,29 @@ public class RoadmapAPIFixture {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 로드맵_카테고리를_생성한다(final String 팔로워_토큰_정보, final RoadmapCategorySaveRequest 카테고리_생성_요청) {
+    public static ExtractableResponse<Response> 로드맵_카테고리를_생성한다(final String 로그인_토큰_정보, final RoadmapCategorySaveRequest 카테고리_생성_요청) {
         return given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .header(AUTHORIZATION, 팔로워_토큰_정보)
+                .header(AUTHORIZATION, 로그인_토큰_정보)
                 .body(카테고리_생성_요청)
                 .post("/api/roadmaps/categories")
                 .then()
                 .log().all()
                 .extract();
+    }
+
+    public static RoadmapCategory 카테고리_생성(final String 로그인_토큰_정보, final String 카테고리_이름) {
+        로드맵_카테고리를_생성한다(로그인_토큰_정보, new RoadmapCategorySaveRequest(카테고리_이름));
+        return new RoadmapCategory(1L, 카테고리_이름);
+    }
+
+    public static List<RoadmapCategory> 카테고리들_생성(final String 로그인_토큰_정보, final String... 카테고리_이름들) {
+        final List<RoadmapCategory> 카테고리들 = new ArrayList<>();
+        for (final String 카테고리_이름 : 카테고리_이름들) {
+            final RoadmapCategory 카테고리 = 카테고리_생성(로그인_토큰_정보, 카테고리_이름);
+            카테고리들.add(카테고리);
+        }
+        return 카테고리들;
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/RoadmapAPIFixture.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/RoadmapAPIFixture.java
@@ -6,6 +6,7 @@ import static io.restassured.RestAssured.given;
 
 import co.kirikiri.persistence.dto.RoadmapOrderType;
 import co.kirikiri.service.dto.CustomScrollRequest;
+import co.kirikiri.service.dto.roadmap.request.RoadmapCategorySaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapNodeSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapReviewSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
@@ -15,10 +16,10 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
-import java.io.IOException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import java.io.IOException;
 
 public class RoadmapAPIFixture {
 
@@ -208,6 +209,18 @@ public class RoadmapAPIFixture {
                 .when()
                 .get("/api/roadmaps/search?size=" + 페이지_사이즈 + "&roadmapTitle=" + 로드맵_제목)
                 .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 로드맵_카테고리를_생성한다(final String 팔로워_토큰_정보, final RoadmapCategorySaveRequest 카테고리_생성_요청) {
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .header(AUTHORIZATION, 팔로워_토큰_정보)
+                .body(카테고리_생성_요청)
+                .post("/api/roadmaps/categories")
+                .then()
+                .log().all()
                 .extract();
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/InitIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/InitIntegrationTest.java
@@ -3,14 +3,15 @@ package co.kirikiri.integration.helper;
 import static co.kirikiri.integration.fixture.AuthenticationAPIFixture.기본_로그인;
 import static co.kirikiri.integration.fixture.CommonFixture.BEARER_TOKEN_FORMAT;
 import static co.kirikiri.integration.fixture.MemberAPIFixture.기본_회원가입;
+import static co.kirikiri.integration.fixture.RoadmapAPIFixture.카테고리_생성;
 
 import co.kirikiri.domain.roadmap.RoadmapCategory;
 import co.kirikiri.service.dto.roadmap.request.RoadmapDifficultyType;
 import co.kirikiri.service.dto.roadmap.request.RoadmapNodeSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapTagSaveRequest;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import java.util.List;
 
 public class InitIntegrationTest extends IntegrationTest {
 
@@ -25,7 +26,7 @@ public class InitIntegrationTest extends IntegrationTest {
         기본_회원_아이디 = 기본_회원가입();
         기본_로그인_토큰 = String.format(BEARER_TOKEN_FORMAT, 기본_로그인().accessToken());
         기본_재발행_토큰 = 기본_로그인().refreshToken();
-        기본_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여행");
+        기본_카테고리 = 카테고리_생성(기본_로그인_토큰, "여행");
         기본_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "로드맵 제목", "로드맵 소개글",
                 "로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("roadmap 1st week", "로드맵 1주차 내용", null)),

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/TestConfig.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/TestConfig.java
@@ -2,7 +2,6 @@ package co.kirikiri.integration.helper;
 
 import co.kirikiri.persistence.goalroom.GoalRoomMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomRepository;
-import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
 import co.kirikiri.service.FileService;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -10,14 +9,11 @@ import org.springframework.context.annotation.Bean;
 @TestConfiguration
 public class TestConfig {
 
-    private final RoadmapCategoryRepository roadmapCategoryRepository;
     private final GoalRoomRepository goalRoomRepository;
     private final GoalRoomMemberRepository goalRoomMemberRepository;
 
-    public TestConfig(final RoadmapCategoryRepository roadmapCategoryRepository,
-                      final GoalRoomRepository goalRoomRepository,
+    public TestConfig(final GoalRoomRepository goalRoomRepository,
                       final GoalRoomMemberRepository goalRoomMemberRepository) {
-        this.roadmapCategoryRepository = roadmapCategoryRepository;
         this.goalRoomRepository = goalRoomRepository;
         this.goalRoomMemberRepository = goalRoomMemberRepository;
     }
@@ -29,6 +25,6 @@ public class TestConfig {
 
     @Bean
     public TestTransactionService testTransactionService() {
-        return new TestTransactionService(roadmapCategoryRepository, goalRoomRepository, goalRoomMemberRepository);
+        return new TestTransactionService(goalRoomRepository, goalRoomMemberRepository);
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/TestTransactionService.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/TestTransactionService.java
@@ -21,10 +21,8 @@ import co.kirikiri.domain.member.MemberProfile;
 import co.kirikiri.domain.member.vo.Identifier;
 import co.kirikiri.domain.member.vo.Nickname;
 import co.kirikiri.domain.member.vo.Password;
-import co.kirikiri.domain.roadmap.RoadmapCategory;
 import co.kirikiri.persistence.goalroom.GoalRoomMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomRepository;
-import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomCreateRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomRoadmapNodeRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomTodoRequest;
@@ -32,11 +30,11 @@ import co.kirikiri.service.dto.member.response.MemberInformationResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public class TestTransactionService {
@@ -44,31 +42,13 @@ public class TestTransactionService {
     @PersistenceContext
     private EntityManager em;
 
-    private final RoadmapCategoryRepository roadmapCategoryRepository;
     private final GoalRoomRepository goalRoomRepository;
     private final GoalRoomMemberRepository goalRoomMemberRepository;
 
-    public TestTransactionService(final RoadmapCategoryRepository roadmapCategoryRepository,
-                                  final GoalRoomRepository goalRoomRepository,
+    public TestTransactionService(final GoalRoomRepository goalRoomRepository,
                                   final GoalRoomMemberRepository goalRoomMemberRepository) {
-        this.roadmapCategoryRepository = roadmapCategoryRepository;
         this.goalRoomRepository = goalRoomRepository;
         this.goalRoomMemberRepository = goalRoomMemberRepository;
-    }
-
-    public List<RoadmapCategory> 모든_로드맵_카테고리를_저장한다(final String... 카테고리_이름_목록) {
-        final List<RoadmapCategory> roadmapCategories = new ArrayList<>();
-        for (final String 카테고리_이름 : 카테고리_이름_목록) {
-            final RoadmapCategory 로드맵_카테고리 = 로드맵_카테고리를_저장한다(카테고리_이름);
-            roadmapCategories.add(new RoadmapCategory(로드맵_카테고리.getId(), 카테고리_이름));
-        }
-        roadmapCategoryRepository.saveAll(roadmapCategories);
-        return roadmapCategories;
-    }
-
-    public RoadmapCategory 로드맵_카테고리를_저장한다(final String 카테고리_이름) {
-        final RoadmapCategory 로드맵_카테고리 = new RoadmapCategory(카테고리_이름);
-        return roadmapCategoryRepository.save(로드맵_카테고리);
     }
 
     public GoalRoom 골룸을_완료시킨다(final Long 골룸_아이디) {


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-179](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1/backlog?selectedIssue=CK-179)


## ✨ 작업 내용
로드맵 카테고리 생성 API를 구현 했습니다.
인수테스트에서 기존에 로드맵 카테고리 생성 부분을 API를 사용하도록 교체 했습니다.

## 💬 리뷰어에게 남길 멘트
밀리가 작업하시는 ADMIIN 추가 후에 controller에서 ADMIN 계정만 사용할 수 있게 수정해야합니다!


## 🚀 요구사항 분석
- [x] 카테고리를 생성한다.
- [x] 카테고리 이름은 중복될 수 없다.
- [x] 카테고리 이름은 10자 이하이다.
