### PR TITLE
[feat/CK-180] 인증피드 신고기능을 구현한다

### DIFF
--- a/backend/kirikiri/src/docs/asciidoc/goalroom.adoc
+++ b/backend/kirikiri/src/docs/asciidoc/goalroom.adoc
@@ -298,3 +298,26 @@ operation::goal-room-create-api-test/골룸을_시작하는_사용자가_골룸�
 === *15-5* 실패 - 골룸의 시작 날짜가 미래인 경우
 
 operation::goal-room-create-api-test/골룸_시작시_골룸의_시작날짜가_미래라면_예외가_발생한다[snippets='http-request,http-response']
+
+[[인증피드신고-API]]
+== *16. 골룸 신고 AIP*
+
+=== *16-1* 성공
+
+operation::goal-room-create-api-test/인증_피드를_신고한다[snippets='http-request,request-headers,path-parameters,http-response']
+
+=== *16-2* 실패 - 존재하지 않는 사용자인 경우
+
+operation::goal-room-create-api-test/인증_피드_신고시_존재하지_않는_사용자면_예외가_발생한다[snippets='http-request,request-headers,path-parameters,http-response']
+
+=== *16-3* 실패 - 존재하지 않는 골룸인 경우
+
+operation::goal-room-create-api-test/인증_피드_신고시_존재하지_않는_골룸이면_예외가_발생한다[snippets='http-request,request-headers,path-parameters,http-response']
+
+=== *16-4* 실패 - 존재하지 않는 인증 피드인 경우
+
+operation::goal-room-create-api-test/인증_피드_신고시_존재하지_않는_인증피드면_예외가_발생한다[snippets='http-request,request-headers,path-parameters,http-response']
+
+=== *16-5* 실패 - 신고자가 참여하지 않은 골룸에 등록된 인증 피드에 대해 신고한 경우
+
+operation::goal-room-create-api-test/인증_피드_신고시_사용자가_참여하지_않은_골룸이면_예외가_발생한다[snippets='http-request,request-headers,path-parameters,http-response']

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/GoalRoomController.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/GoalRoomController.java
@@ -180,4 +180,14 @@ public class GoalRoomController {
                 goalRoomId);
         return ResponseEntity.ok(response);
     }
+
+    @Authenticated
+    @PostMapping("{goalRoomId}/checkFeeds/{checkFeedId}/report")
+    public ResponseEntity<Void> reportCheckFeed(
+            @MemberIdentifier final String identifier,
+            @PathVariable("goalRoomId") final Long goalRoomId,
+            @PathVariable("checkFeedId") final Long checkFeedId) {
+        goalRoomCreateService.reportCheckFeed(identifier, goalRoomId, checkFeedId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/goalroom/CheckFeed.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/goalroom/CheckFeed.java
@@ -13,8 +13,12 @@ import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
+@SQLDelete(sql = "UPDATE check_feed SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CheckFeed extends BaseCreatedTimeEntity {
 
@@ -29,6 +33,8 @@ public class CheckFeed extends BaseCreatedTimeEntity {
     private String originalFileName;
 
     private String description;
+
+    private boolean deleted = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "goal_room_roadmap_node_id", nullable = false)

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/goalroom/CheckFeedReport.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/goalroom/CheckFeedReport.java
@@ -1,0 +1,43 @@
+package co.kirikiri.domain.goalroom;
+
+import co.kirikiri.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "checkFeedAndGoalRoomMember",
+                        columnNames = {
+                                "check_feed_id",
+                                "goal_room_member_id"
+                        }
+                ),
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CheckFeedReport extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "check_feed_id", nullable = false)
+    private CheckFeed checkFeed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "goal_room_member_id", nullable = false)
+    private GoalRoomMember goalRoomMember;
+
+    public CheckFeedReport(final CheckFeed checkFeed, final GoalRoomMember goalRoomMember) {
+        this.checkFeed = checkFeed;
+        this.goalRoomMember = goalRoomMember;
+    }
+}
+
+
+

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedReportRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedReportRepository.java
@@ -2,9 +2,13 @@ package co.kirikiri.persistence.goalroom;
 
 import co.kirikiri.domain.goalroom.CheckFeed;
 import co.kirikiri.domain.goalroom.CheckFeedReport;
+import co.kirikiri.domain.goalroom.GoalRoomMember;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CheckFeedReportRepository extends JpaRepository<CheckFeedReport, Long> {
+
+    public Optional<CheckFeedReport> findByGoalRoomMemberAndCheckFeed(final GoalRoomMember goalRoomMember, final CheckFeed checkFeed);
 
     public int countAllByCheckFeed(final CheckFeed checkFeed);
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedReportRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedReportRepository.java
@@ -1,0 +1,10 @@
+package co.kirikiri.persistence.goalroom;
+
+import co.kirikiri.domain.goalroom.CheckFeed;
+import co.kirikiri.domain.goalroom.CheckFeedReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CheckFeedReportRepository extends JpaRepository<CheckFeedReport, Long> {
+
+    public int countAllByCheckFeed(final CheckFeed checkFeed);
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/CheckFeedRepository.java
@@ -12,12 +12,13 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface CheckFeedRepository extends JpaRepository<CheckFeed, Long>, CheckFeedQueryRepository {
 
-    @Query("SELECT cf"
-            + " FROM CheckFeed cf"
-            + " WHERE cf.goalRoomMember = :goalRoomMember"
-            + " AND cf.createdAt >= :start"
-            + " AND cf.createdAt < :end")
-    Optional<CheckFeed> findByGoalRoomMemberAndDateTime(final GoalRoomMember goalRoomMember, final LocalDateTime start,
+    @Query(value = "SELECT *"
+            + " FROM check_feed"
+            + " WHERE goal_room_member_id = :goalRoomMemberId"
+            + " AND created_at >= :start"
+            + " AND created_at < :end",
+            nativeQuery = true)
+    Optional<CheckFeed> findByGoalRoomMemberAndDateTime(final Long goalRoomMemberId, final LocalDateTime start,
                                                         final LocalDateTime end);
 
     @Query("SELECT COUNT(cf)"
@@ -25,12 +26,13 @@ public interface CheckFeedRepository extends JpaRepository<CheckFeed, Long>, Che
             + " WHERE cf.goalRoomMember = :goalRoomMember")
     int countByGoalRoomMember(final GoalRoomMember goalRoomMember);
 
-    @Query("SELECT COUNT(cf)"
-            + " FROM CheckFeed cf"
-            + " WHERE cf.goalRoomMember = :goalRoomMember"
-            + " AND cf.goalRoomRoadmapNode = :goalRoomRoadmapNode")
-    int countByGoalRoomMemberAndGoalRoomRoadmapNode(final GoalRoomMember goalRoomMember,
-                                                    final GoalRoomRoadmapNode goalRoomRoadmapNode);
+    @Query(value = "SELECT COUNT(*)"
+            + " FROM check_feed"
+            + " WHERE goal_room_member_id = :goalRoomMemberId"
+            + " AND goal_room_roadmap_node_id = :goalRoomRoadmapNodeId",
+            nativeQuery = true)
+    int countByGoalRoomMemberAndGoalRoomRoadmapNode(final Long goalRoomMemberId,
+                                                    final Long goalRoomRoadmapNodeId);
 
     @Query("SELECT cf"
             + " FROM CheckFeed cf"

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomCreateService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/GoalRoomCreateService.java
@@ -194,7 +194,7 @@ public class GoalRoomCreateService {
         final GoalRoomMember goalRoomMember = findGoalRoomMemberByGoalRoomAndIdentifier(goalRoom, identifier);
         final GoalRoomRoadmapNode currentNode = getNodeByDate(goalRoom);
         final int currentMemberCheckCount = checkFeedRepository.countByGoalRoomMemberAndGoalRoomRoadmapNode(
-                goalRoomMember, currentNode);
+                goalRoomMember.getId(), currentNode.getId());
         validateCheckCount(currentMemberCheckCount, goalRoomMember, currentNode);
         updateAccomplishmentRate(goalRoom, goalRoomMember, currentMemberCheckCount);
 
@@ -243,7 +243,7 @@ public class GoalRoomCreateService {
         final LocalDate today = LocalDate.now();
         final LocalDateTime todayStart = today.atStartOfDay();
         final LocalDateTime todayEnd = today.plusDays(1).atStartOfDay();
-        if (checkFeedRepository.findByGoalRoomMemberAndDateTime(member, todayStart, todayEnd).isPresent()) {
+        if (checkFeedRepository.findByGoalRoomMemberAndDateTime(member.getId(), todayStart, todayEnd).isPresent()) {
             throw new BadRequestException("이미 오늘 인증 피드를 등록하였습니다.");
         }
     }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomCreateIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomCreateIntegrationTest.java
@@ -11,6 +11,7 @@ import static co.kirikiri.integration.fixture.GoalRoomAPIFixture.골룸_투두�
 import static co.kirikiri.integration.fixture.GoalRoomAPIFixture.골룸_투두리스트를_체크한다;
 import static co.kirikiri.integration.fixture.GoalRoomAPIFixture.골룸을_생성하고_아이디를_반환한다;
 import static co.kirikiri.integration.fixture.GoalRoomAPIFixture.골룸을_시작한다;
+import static co.kirikiri.integration.fixture.GoalRoomAPIFixture.골룸의_사용자_정보를_전체_조회;
 import static co.kirikiri.integration.fixture.GoalRoomAPIFixture.골룸의_사용자_정보를_정렬_기준없이_조회;
 import static co.kirikiri.integration.fixture.GoalRoomAPIFixture.사용자의_특정_골룸_정보를_조회한다;
 import static co.kirikiri.integration.fixture.GoalRoomAPIFixture.십일_후;
@@ -36,6 +37,7 @@ import co.kirikiri.integration.helper.InitIntegrationTest;
 import co.kirikiri.service.dto.ErrorResponse;
 import co.kirikiri.service.dto.auth.request.LoginRequest;
 import co.kirikiri.service.dto.goalroom.GoalRoomFilterTypeDto;
+import co.kirikiri.service.dto.goalroom.GoalRoomMemberSortTypeDto;
 import co.kirikiri.service.dto.goalroom.request.CheckFeedRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomCreateRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomRoadmapNodeRequest;
@@ -1424,6 +1426,82 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
                 .isEqualTo(HttpStatus.NOT_FOUND.value());
         assertThat(errorResponse.message())
                 .isEqualTo("존재하지 않는 인증 피드입니다.");
+    }
+
+    @Test
+    void 인증_피드_신고로_인증피드가_삭제되어도_인증_피드_등록여부_계산에_영향을_미친다() throws IOException {
+        //given
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
+
+        final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
+        final List<GoalRoomRoadmapNodeRequest> 골룸_노드_별_기간_요청 = List.of(
+                new GoalRoomRoadmapNodeRequest(로드맵_응답.content().nodes().get(0).id(), 정상적인_골룸_노드_인증_횟수, 오늘, 십일_후));
+        final GoalRoomCreateRequest 골룸_생성_요청 = new GoalRoomCreateRequest(기본_로드맵_아이디, 정상적인_골룸_이름, 정상적인_골룸_제한_인원,
+                골룸_투두_요청, 골룸_노드_별_기간_요청);
+        final Long 골룸_아이디 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 기본_로그인_토큰);
+        멤버를_생성하고_골룸에_가입한_뒤_액세스_토큰을_반환한다("identifier2", "follow1", "010-1234-1234", 골룸_아이디);
+        골룸을_시작한다(기본_로그인_토큰, 골룸_아이디);
+
+        final MockMultipartFile 가짜_이미지_객체 = new MockMultipartFile("image", "originalFileName.jpeg",
+                "image/jpeg", "tempImage".getBytes());
+        final CheckFeedRequest 인증_피드_등록_요청 = new CheckFeedRequest(가짜_이미지_객체, "image description");
+        인증_피드_등록(골룸_아이디, 가짜_이미지_객체, 인증_피드_등록_요청, 기본_로그인_토큰);
+
+        final List<GoalRoomCheckFeedResponse> 인증_피드_전체_조회_응답 = 인증_피드_전체_조회_요청(기본_로그인_토큰, 골룸_아이디)
+                .as(new TypeRef<>() {
+                });
+        final Long 인증_피드_아이디 = 인증_피드_전체_조회_응답.get(0).checkFeed().id();
+
+        인증_피드_신고(골룸_아이디, 인증_피드_아이디, 기본_로그인_토큰);
+
+        // when
+        final ExtractableResponse<Response> 인증_피드_등록_응답 = 인증_피드_등록(골룸_아이디, 가짜_이미지_객체, 인증_피드_등록_요청,기본_로그인_토큰);
+        final ErrorResponse 예외_메세지 = 인증_피드_등록_응답.as(ErrorResponse.class);
+
+        // then
+        assertThat(인증_피드_등록_응답.statusCode())
+                .isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(예외_메세지.message())
+                .isEqualTo("이미 오늘 인증 피드를 등록하였습니다.");
+    }
+
+    @Test
+    void 인증_피드_신고로_삭제된_인증피드는_달성률_계산에서_제외된다() throws IOException {
+        //given
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
+
+        final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
+        final List<GoalRoomRoadmapNodeRequest> 골룸_노드_별_기간_요청 = List.of(
+                new GoalRoomRoadmapNodeRequest(로드맵_응답.content().nodes().get(0).id(), 정상적인_골룸_노드_인증_횟수, 오늘, 십일_후));
+        final GoalRoomCreateRequest 골룸_생성_요청 = new GoalRoomCreateRequest(기본_로드맵_아이디, 정상적인_골룸_이름, 정상적인_골룸_제한_인원,
+                골룸_투두_요청, 골룸_노드_별_기간_요청);
+        final Long 골룸_아이디 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 기본_로그인_토큰);
+        final String 팔로워_액세스_토큰 = 멤버를_생성하고_골룸에_가입한_뒤_액세스_토큰을_반환한다("identifier2", "follow1", "010-1234-1234", 골룸_아이디);
+        골룸을_시작한다(기본_로그인_토큰, 골룸_아이디);
+
+        final MockMultipartFile 가짜_이미지_객체 = new MockMultipartFile("image", "originalFileName.jpeg",
+                "image/jpeg", "tempImage".getBytes());
+        final CheckFeedRequest 인증_피드_등록_요청 = new CheckFeedRequest(가짜_이미지_객체, "image description");
+        인증_피드_등록(골룸_아이디, 가짜_이미지_객체, 인증_피드_등록_요청, 기본_로그인_토큰);
+        인증_피드_등록(골룸_아이디, 가짜_이미지_객체, 인증_피드_등록_요청, 팔로워_액세스_토큰);
+
+        final List<GoalRoomCheckFeedResponse> 인증_피드_전체_조회_응답 = 인증_피드_전체_조회_요청(기본_로그인_토큰, 골룸_아이디)
+                .as(new TypeRef<>() {
+                });
+        final Long 인증_피드_아이디 = 인증_피드_전체_조회_응답.get(0).checkFeed().id();
+        // 가장 최신에 등록된 인증피드(팔로워의) 인증피드 신고 및 삭제
+        인증_피드_신고(골룸_아이디, 인증_피드_아이디, 기본_로그인_토큰);
+
+        // when
+        final List<GoalRoomMemberResponse> 골룸_사용자_응답 = 골룸의_사용자_정보를_전체_조회(골룸_아이디, 기본_로그인_토큰,
+                GoalRoomMemberSortTypeDto.ACCOMPLISHMENT_RATE.name()).as(new TypeRef<>() {
+        });
+
+        // then
+        assertThat(골룸_사용자_응답.get(0).memberId()).isEqualTo(기본_회원_아이디);
+        assertThat(골룸_사용자_응답.get(1).memberId()).isEqualTo(2L);
     }
 
     private String 멤버를_생성하고_골룸에_가입한_뒤_액세스_토큰을_반환한다(final String 아이디, final String 닉네임, final String 전화번호, final Long 골룸_아이디) {

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/GoalRoomAPIFixture.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/GoalRoomAPIFixture.java
@@ -300,4 +300,14 @@ public class GoalRoomAPIFixture {
                 .log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 인증_피드_신고(final Long 골룸_아이디, final Long 인증피드_아이디, final String 로그인_토큰) {
+        return given().log().all()
+                .header(AUTHORIZATION, 로그인_토큰)
+                .when()
+                .post(API_PREFIX + "/goal-rooms/{goalRoomId}/checkFeeds/{checkFeedId}/report", 골룸_아이디, 인증피드_아이디)
+                .then()
+                .log().all()
+                .extract();
+    }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/CheckFeedReportRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/CheckFeedReportRepositoryTest.java
@@ -1,0 +1,210 @@
+package co.kirikiri.persistence.goalroom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import co.kirikiri.domain.ImageContentType;
+import co.kirikiri.domain.goalroom.CheckFeed;
+import co.kirikiri.domain.goalroom.CheckFeedReport;
+import co.kirikiri.domain.goalroom.GoalRoom;
+import co.kirikiri.domain.goalroom.GoalRoomMember;
+import co.kirikiri.domain.goalroom.GoalRoomRoadmapNode;
+import co.kirikiri.domain.goalroom.GoalRoomRoadmapNodes;
+import co.kirikiri.domain.goalroom.GoalRoomRole;
+import co.kirikiri.domain.goalroom.vo.GoalRoomName;
+import co.kirikiri.domain.goalroom.vo.LimitedMemberCount;
+import co.kirikiri.domain.goalroom.vo.Period;
+import co.kirikiri.domain.member.EncryptedPassword;
+import co.kirikiri.domain.member.Gender;
+import co.kirikiri.domain.member.Member;
+import co.kirikiri.domain.member.MemberImage;
+import co.kirikiri.domain.member.MemberProfile;
+import co.kirikiri.domain.member.vo.Identifier;
+import co.kirikiri.domain.member.vo.Nickname;
+import co.kirikiri.domain.member.vo.Password;
+import co.kirikiri.domain.roadmap.Roadmap;
+import co.kirikiri.domain.roadmap.RoadmapCategory;
+import co.kirikiri.domain.roadmap.RoadmapContent;
+import co.kirikiri.domain.roadmap.RoadmapContents;
+import co.kirikiri.domain.roadmap.RoadmapDifficulty;
+import co.kirikiri.domain.roadmap.RoadmapNode;
+import co.kirikiri.domain.roadmap.RoadmapNodeImage;
+import co.kirikiri.domain.roadmap.RoadmapNodeImages;
+import co.kirikiri.domain.roadmap.RoadmapNodes;
+import co.kirikiri.persistence.helper.RepositoryTest;
+import co.kirikiri.persistence.member.MemberRepository;
+import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
+import co.kirikiri.persistence.roadmap.RoadmapRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@RepositoryTest
+class CheckFeedReportRepositoryTest {
+
+    private static final LocalDate TODAY = LocalDate.now();
+    private static final LocalDate TEN_DAY_LATER = TODAY.plusDays(10);
+    private static final LocalDate TWENTY_DAY_LAYER = TODAY.plusDays(20);
+    private static final LocalDate THIRTY_DAY_LATER = TODAY.plusDays(30);
+    private static final LocalDateTime TODAY_START = TODAY.atStartOfDay();
+    private static final LocalDateTime TOMORROW_START = TODAY_START.plusDays(1);
+    private static final LocalDateTime DAY_AFTER_TOMORROW_START = TODAY_START.plusDays(2);
+
+    private final MemberRepository memberRepository;
+    private final RoadmapCategoryRepository roadmapCategoryRepository;
+    private final RoadmapRepository roadmapRepository;
+    private final GoalRoomRepository goalRoomRepository;
+    private final GoalRoomMemberRepository goalRoomMemberRepository;
+    private final CheckFeedRepository checkFeedRepository;
+    private final CheckFeedReportRepository checkFeedReportRepository;
+
+    public CheckFeedReportRepositoryTest(final MemberRepository memberRepository,
+                                         final RoadmapCategoryRepository roadmapCategoryRepository,
+                                         final RoadmapRepository roadmapRepository,
+                                         final GoalRoomRepository goalRoomRepository,
+                                         final GoalRoomMemberRepository goalRoomMemberRepository,
+                                         final CheckFeedRepository checkFeedRepository,
+                                         final CheckFeedReportRepository checkFeedReportRepository) {
+        this.memberRepository = memberRepository;
+        this.roadmapCategoryRepository = roadmapCategoryRepository;
+        this.roadmapRepository = roadmapRepository;
+        this.goalRoomRepository = goalRoomRepository;
+        this.goalRoomMemberRepository = goalRoomMemberRepository;
+        this.checkFeedRepository = checkFeedRepository;
+        this.checkFeedReportRepository = checkFeedReportRepository;
+    }
+
+    @Test
+    void 사용자가_인증피드를_신고한다() {
+        // given
+        final Member creator = 사용자를_저장한다("cokiri", "코끼리");
+        final RoadmapCategory category = 카테고리를_저장한다("여가");
+        final Roadmap roadmap = 로드맵을_저장한다(creator, category);
+
+        final RoadmapContents roadmapContents = roadmap.getContents();
+        final RoadmapContent targetRoadmapContent = roadmapContents.getValues().get(0);
+        final Member member = 사용자를_저장한다("participant", "참여자");
+        final GoalRoom goalRoom = 골룸을_저장한다(targetRoadmapContent, member);
+
+        final GoalRoomMember leader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom, creator);
+        final GoalRoomMember joinedMember = new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), goalRoom,
+                member);
+        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+
+        final GoalRoomRoadmapNode goalRoomRoadmapNode = goalRoom.getGoalRoomRoadmapNodes().getValues().get(0);
+        final CheckFeed checkFeed = 인증_피드를_저장한다(goalRoomRoadmapNode, joinedMember);
+
+        final CheckFeedReport checkFeedReport1 = new CheckFeedReport(checkFeed, leader);
+        final CheckFeedReport checkFeedReport2 = new CheckFeedReport(checkFeed, joinedMember);
+        checkFeedReportRepository.save(checkFeedReport1);
+        checkFeedReportRepository.save(checkFeedReport2);
+
+        // when
+        final int checkFeedReportCount = checkFeedReportRepository.countAllByCheckFeed(checkFeed);
+
+        // then
+        assertThat(checkFeedReportCount).isEqualTo(2);
+    }
+
+    @Test
+    void 동일한_사용자가_같은_인증피드를_신고하면_무시한다() {
+        // given
+        final Member creator = 사용자를_저장한다("cokiri", "코끼리");
+        final RoadmapCategory category = 카테고리를_저장한다("여가");
+        final Roadmap roadmap = 로드맵을_저장한다(creator, category);
+
+        final RoadmapContents roadmapContents = roadmap.getContents();
+        final RoadmapContent targetRoadmapContent = roadmapContents.getValues().get(0);
+        final Member member = 사용자를_저장한다("participant", "참여자");
+        final GoalRoom goalRoom = 골룸을_저장한다(targetRoadmapContent, member);
+
+        final GoalRoomMember leader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom, creator);
+        final GoalRoomMember joinedMember = new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), goalRoom,
+                member);
+        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+
+        final GoalRoomRoadmapNode goalRoomRoadmapNode = goalRoom.getGoalRoomRoadmapNodes().getValues().get(0);
+        final CheckFeed checkFeed = 인증_피드를_저장한다(goalRoomRoadmapNode, joinedMember);
+
+        final CheckFeedReport checkFeedReport1 = new CheckFeedReport(checkFeed, leader);
+        final CheckFeedReport checkFeedReport2 = new CheckFeedReport(checkFeed, leader);
+        checkFeedReportRepository.save(checkFeedReport1);
+
+        // when, then
+        assertThatThrownBy(() -> checkFeedReportRepository.save(checkFeedReport2))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+
+
+    private Member 사용자를_저장한다(final String identifier, final String nickname) {
+        final MemberImage memberImage = new MemberImage("originalFileName", "serverFilePath", ImageContentType.PNG);
+        final MemberProfile memberProfile = new MemberProfile(Gender.MALE,
+                LocalDate.of(1990, 1, 1), "010-1234-5678");
+        final Member creator = new Member(new Identifier(identifier), new EncryptedPassword(new Password("password1!")),
+                new Nickname(nickname), memberImage, memberProfile);
+        return memberRepository.save(creator);
+    }
+
+    private RoadmapCategory 카테고리를_저장한다(final String name) {
+        final RoadmapCategory roadmapCategory = new RoadmapCategory(name);
+        return roadmapCategoryRepository.save(roadmapCategory);
+    }
+
+    private Roadmap 로드맵을_저장한다(final Member creator, final RoadmapCategory category) {
+        final List<RoadmapNode> roadmapNodes = 로드맵_노드들을_생성한다();
+        final RoadmapContent roadmapContent = 로드맵_본문을_생성한다(roadmapNodes);
+        final Roadmap roadmap = new Roadmap("로드맵 제목", "로드맵 소개글", 10, RoadmapDifficulty.NORMAL, creator, category);
+        roadmap.addContent(roadmapContent);
+        return roadmapRepository.save(roadmap);
+    }
+
+    private List<RoadmapNode> 로드맵_노드들을_생성한다() {
+        final RoadmapNode roadmapNode1 = new RoadmapNode("로드맵 1주차", "로드맵 1주차 내용");
+        roadmapNode1.addImages(new RoadmapNodeImages(노드_이미지들을_생성한다()));
+        final RoadmapNode roadmapNode2 = new RoadmapNode("로드맵 2주차", "로드맵 2주차 내용");
+        return List.of(roadmapNode1, roadmapNode2);
+    }
+
+    private RoadmapContent 로드맵_본문을_생성한다(final List<RoadmapNode> roadmapNodes) {
+        final RoadmapContent roadmapContent = new RoadmapContent("로드맵 본문");
+        roadmapContent.addNodes(new RoadmapNodes(roadmapNodes));
+        return roadmapContent;
+    }
+
+    private List<RoadmapNodeImage> 노드_이미지들을_생성한다() {
+        return List.of(
+                new RoadmapNodeImage("node-image1.png", "node-image1-save-path", ImageContentType.PNG),
+                new RoadmapNodeImage("node-image2.png", "node-image2-save-path", ImageContentType.PNG)
+        );
+    }
+
+    private GoalRoom 골룸을_저장한다(final RoadmapContent roadmapContent, final Member member) {
+        final GoalRoom goalRoom = new GoalRoom(new GoalRoomName("골룸"), new LimitedMemberCount(10),
+                roadmapContent, member);
+        final List<RoadmapNode> roadmapNodes = roadmapContent.getNodes().getValues();
+
+        final RoadmapNode firstRoadmapNode = roadmapNodes.get(0);
+        final GoalRoomRoadmapNode firstGoalRoomRoadmapNode = new GoalRoomRoadmapNode(
+                new Period(TODAY, TEN_DAY_LATER),
+                10, firstRoadmapNode);
+
+        final RoadmapNode secondRoadmapNode = roadmapNodes.get(1);
+        final GoalRoomRoadmapNode secondGoalRoomRoadmapNode = new GoalRoomRoadmapNode(
+                new Period(TWENTY_DAY_LAYER, THIRTY_DAY_LATER),
+                10, secondRoadmapNode);
+
+        final GoalRoomRoadmapNodes goalRoomRoadmapNodes = new GoalRoomRoadmapNodes(
+                List.of(firstGoalRoomRoadmapNode, secondGoalRoomRoadmapNode));
+        goalRoom.addAllGoalRoomRoadmapNodes(goalRoomRoadmapNodes);
+        return goalRoomRepository.save(goalRoom);
+    }
+
+    private CheckFeed 인증_피드를_저장한다(final GoalRoomRoadmapNode goalRoomRoadmapNode, final GoalRoomMember joinedMember) {
+        return checkFeedRepository.save(
+                new CheckFeed("src/test/resources/testImage", ImageContentType.JPEG,
+                        "originalFileName", "인증 피드 본문", goalRoomRoadmapNode, joinedMember));
+    }
+}

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/CheckFeedRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/CheckFeedRepositoryTest.java
@@ -37,7 +37,7 @@ import co.kirikiri.persistence.roadmap.RoadmapRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @RepositoryTest
@@ -128,13 +128,17 @@ class CheckFeedRepositoryTest {
         인증_피드를_삭제한다(checkFeed);
 
         //when
+        final boolean isDeletedToday = checkFeedRepository.findById(checkFeed.getId()).isEmpty();
         final boolean isUpdateToday = checkFeedRepository.findByGoalRoomMemberAndDateTime(joinedMember.getId(),
                 TODAY_START, TOMORROW_START).isPresent();
         final int checkFeedNumber = checkFeedRepository.countByGoalRoomMember(joinedMember);
 
         //then
-        assertThat(isUpdateToday).isTrue();
-        assertThat(checkFeedNumber).isZero();
+        Assertions.assertAll(
+                () -> assertThat(isDeletedToday).isTrue(),
+                () -> assertThat(isUpdateToday).isTrue(),
+                () -> assertThat(checkFeedNumber).isZero()
+        );
     }
 
     @Test

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomCreateServiceTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomCreateServiceTest.java
@@ -603,12 +603,14 @@ class GoalRoomCreateServiceTest {
                 .thenReturn(Optional.of(goalRoom));
         when(goalRoomMemberRepository.findByGoalRoomAndMemberIdentifier(any(), any()))
                 .thenReturn(Optional.of(goalRoomLeader));
-        when(checkFeedRepository.findByGoalRoomMemberAndDateTime(any(), any(), any()))
-                .thenReturn(Optional.empty());
         when(checkFeedRepository.countByGoalRoomMemberAndGoalRoomRoadmapNode(any(), any()))
                 .thenReturn(0);
+        when(checkFeedRepository.findByGoalRoomMemberAndDateTime(any(), any(), any()))
+                .thenReturn(Optional.empty());
         when(checkFeedRepository.save(any()))
                 .thenReturn(checkFeed);
+        when(checkFeedRepository.countByGoalRoomMember(any()))
+                .thenReturn(1);
         when(filePathGenerator.makeFilePath(any(), any()))
                 .thenReturn("originalFileName.jpeg");
         when(fileService.generateUrl(anyString(), any()))


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-180](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-180)


## ✨ 작업 내용
- 인증 피드 신고 기능을 구현했습니다.
- soft delete를 위해 인증 피드 Entity에 deleted 필드를 추가하였고 신고 내역을 저장하기 위해 checkFeedReport 테이블을 추가했습니다.
- 인증 피드에 대해 일정 기준 이상의 신고가 접수되면 해당 인증 피드는 삭제됩니다.
- 인증 피드는 삭제되어도 달성률 계산이나 인증 피드 등록 가능 여부 등에서 필요하기 때문에 조회합니다. (soft delete를 한 이유)

## 💬 리뷰어에게 남길 멘트
- 새로운 Entity를 추가했는데 너무 오랜만이기도 하고 아직 자신이 없어서 잘 만들어졌는지 봐주시면 감사하겠습니다.
- 동일한 사용자가 동일한 인증피드에 대해 중복으로 신고를 하더라도 사용자들은 어떤 예외라도 인지하지 못하지만 (해당 인증피드가 짧은 사이에 삭제된 경우를 제외하면) 내부적으로는 중복된 신고 요청은 무효화되도록 구현했습니다. 이를 위해 Entity 레벨에서 제약 조건을 추가해주고 중복 된 예외를 try ~ catch로 잡아서 아무런 행동도 하지 않도록 구현했는데 rollback되는 문제가 있어서 그냥 repository에 접근해서 중복된 Entity가 있는지 찾아보는 식으로 구현했습니다.
- GoalRoomCreateIntegration 통합 테스트 가장 아래부분에 `멤버_생성_후_골룸에_가입하는` 메서드를 하나 추가했습니다. 다른 통합 테스트들에서도 자주 사용되는 거 같아서 추가했는데 기존대로 풀어서 작성할지 아니면 저런 식으로 메서드를 만드는 게 좋은지 다른 분들의 의견이 궁금합니다. 동의하시면 Fixture에 추가하고 다른 테스트 메서드들에서 중복된 부분들을 대체하도록 할게요😊

## 🚀 요구사항 분석
- [x] 인증피드 신고 기능을 구현한다
    - [x] 골룸 내에서 3명 이상의 신고를 받은 인증 피드는 삭제한다
      - [x] 골룸 전체 인원이 3명 이하인 경우 (n-1)명만큼의 신고를 받았을 때 피드를 삭제한다.
    - [x] 같은 골룸 참가자에게 중복해서 신고가 들어올 경우 추가적인 신고는 무시한다.
    - [x] 인증 피드를 삭제할 때는 soft delete한다.
    - [x] 골룸 내에서 달성률을 계산할 때 삭제된 인증 피드는 인증 피드를 등록하지 않은 것으로 처리한다.
    - [x] 인증 피드가 삭제되었더라도 진행 중인 노드 동안 등록할 수 있는 인증 피드 개수 계산에 포함한다.

- [x] 인증 피드 테이블에 deleted 필드 추가하기
- [x] 인증 피드 신고 테이블 생성하기