### PR TITLE
[feat/CK-183] 사용자 역할(어드민, 일반 사용자)을 추가한다

### DIFF
--- a/backend/kirikiri/src/docs/asciidoc/member.adoc
+++ b/backend/kirikiri/src/docs/asciidoc/member.adoc
@@ -85,3 +85,14 @@ operation::member-read-api-test/특정_사용자의_정보를_조회한다[snipp
 === *3-2* 실패 - 조회할 사용자가 존재하지 않은 회원일 때
 
 operation::member-read-api-test/특정_사용자_정보_조회시_조회할_사용자가_없는_회원이면_예외_발생[snippets='http-request,http-response']
+
+[[어드민회원가입-API]]
+== *4. 어드민 회원 가입*
+
+=== *4-1* 성공
+
+operation::member-create-api-test/정상적으로_어드민_역할로_회원가입에_성공한다[snippets='http-request,http-response,request-fields,response-headers']
+
+=== *4-2* 실패
+
+1-2 ~ 1-12의 경우와 동일

--- a/backend/kirikiri/src/main/java/co/kirikiri/common/interceptor/AdminPermission.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/common/interceptor/AdminPermission.java
@@ -1,0 +1,12 @@
+package co.kirikiri.common.interceptor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AdminPermission {
+
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/common/interceptor/AuthInterceptor.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/common/interceptor/AuthInterceptor.java
@@ -30,6 +30,13 @@ public class AuthInterceptor implements HandlerInterceptor {
             final String token = authorizationHeader.substring(BEARER.length());
             checkTokenCertify(token);
         }
+        if (handlerMethod.hasMethodAnnotation(AdminPermission.class)) {
+            final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+            checkHeader(authorizationHeader);
+            final String token = authorizationHeader.substring(BEARER.length());
+            checkTokenCertify(token);
+            checkAdminUser(token);
+        }
         return true;
     }
 
@@ -42,6 +49,12 @@ public class AuthInterceptor implements HandlerInterceptor {
     private void checkTokenCertify(final String token) {
         if (!authService.isCertified(token)) {
             throw new AuthenticationException("토큰이 유효하지 않습니다.");
+        }
+    }
+
+    private void checkAdminUser(final String token) {
+        if (!authService.isAdminUser(token)) {
+            throw new AuthenticationException("어드민 권한이 필요합니다.");
         }
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/AuthController.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/AuthController.java
@@ -30,5 +30,4 @@ public class AuthController {
         final AuthenticationResponse response = authService.reissueToken(request);
         return ResponseEntity.ok(response);
     }
-
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/MemberController.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/MemberController.java
@@ -26,7 +26,15 @@ public class MemberController {
 
     @PostMapping("/join")
     public ResponseEntity<Void> join(@RequestBody @Valid final MemberJoinRequest request) {
-        final Long memberId = memberService.join(request);
+        final boolean isAdmin = false;
+        final Long memberId = memberService.join(request, isAdmin);
+        return ResponseEntity.created(URI.create("/api/members/" + memberId)).build();
+    }
+
+    @PostMapping("/join/admin")
+    public ResponseEntity<Void> joinAdmin(@RequestBody @Valid final MemberJoinRequest request) {
+        final boolean isAdmin = true;
+        final Long memberId = memberService.join(request, isAdmin);
         return ResponseEntity.created(URI.create("/api/members/" + memberId)).build();
     }
 

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
@@ -1,5 +1,6 @@
 package co.kirikiri.controller;
 
+import co.kirikiri.common.interceptor.AdminPermission;
 import co.kirikiri.common.interceptor.Authenticated;
 import co.kirikiri.common.resolver.MemberIdentifier;
 import co.kirikiri.service.RoadmapCreateService;
@@ -41,7 +42,7 @@ public class RoadmapController {
     private final RoadmapCreateService roadmapCreateService;
     private final RoadmapReadService roadmapReadService;
 
-    @Authenticated
+    @AdminPermission
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> create(final RoadmapSaveRequest request, @MemberIdentifier final String identifier) {
         final Long roadmapId = roadmapCreateService.create(request, identifier);

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/member/Member.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/member/Member.java
@@ -5,8 +5,11 @@ import co.kirikiri.domain.member.vo.Identifier;
 import co.kirikiri.domain.member.vo.Nickname;
 import co.kirikiri.domain.member.vo.Password;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
@@ -26,6 +29,10 @@ public class Member extends BaseUpdatedTimeEntity {
     @Embedded
     private Nickname nickname;
 
+    @Enumerated(value = EnumType.STRING)
+    @Column(length = 10, nullable = false)
+    private MemberRole role = MemberRole.USER;
+
     @OneToOne(fetch = FetchType.LAZY,
             cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
             orphanRemoval = true)
@@ -40,15 +47,27 @@ public class Member extends BaseUpdatedTimeEntity {
 
     public Member(final Identifier identifier, final EncryptedPassword encryptedPassword, final Nickname nickname,
                   final MemberImage image, final MemberProfile memberProfile) {
-        this(null, identifier, encryptedPassword, nickname, image, memberProfile);
+        this(null, identifier, encryptedPassword, nickname, MemberRole.USER, image, memberProfile);
+    }
+
+    public Member(final Identifier identifier, final EncryptedPassword encryptedPassword, final Nickname nickname,
+                  final MemberRole role, final MemberImage image, final MemberProfile memberProfile) {
+        this(null, identifier, encryptedPassword, nickname, role, image, memberProfile);
     }
 
     public Member(final Long id, final Identifier identifier, final EncryptedPassword encryptedPassword,
                   final Nickname nickname, final MemberImage image, final MemberProfile memberProfile) {
+        this(id, identifier, encryptedPassword, nickname, MemberRole.USER, image, memberProfile);
+    }
+
+    public Member(final Long id, final Identifier identifier, final EncryptedPassword encryptedPassword,
+                  final Nickname nickname, final MemberRole role, final MemberImage image,
+                  final MemberProfile memberProfile) {
         this.id = id;
         this.identifier = identifier;
         this.encryptedPassword = encryptedPassword;
         this.nickname = nickname;
+        this.role = role;
         this.image = image;
         this.memberProfile = memberProfile;
     }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/member/Member.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/member/Member.java
@@ -84,6 +84,10 @@ public class Member extends BaseUpdatedTimeEntity {
         return nickname;
     }
 
+    public MemberRole getRole() {
+        return role;
+    }
+
     public MemberImage getImage() {
         return image;
     }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/member/Member.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/member/Member.java
@@ -30,7 +30,7 @@ public class Member extends BaseUpdatedTimeEntity {
     private Nickname nickname;
 
     @Enumerated(value = EnumType.STRING)
-    @Column(length = 10, nullable = false)
+    @Column(length = 10)
     private MemberRole role = MemberRole.USER;
 
     @OneToOne(fetch = FetchType.LAZY,

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/member/MemberRole.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/member/MemberRole.java
@@ -1,0 +1,6 @@
+package co.kirikiri.domain.member;
+
+public enum MemberRole {
+    ADMIN,
+    USER
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/AuthService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/AuthService.java
@@ -3,6 +3,7 @@ package co.kirikiri.service;
 import co.kirikiri.domain.auth.EncryptedToken;
 import co.kirikiri.domain.auth.RefreshToken;
 import co.kirikiri.domain.member.Member;
+import co.kirikiri.domain.member.MemberRole;
 import co.kirikiri.domain.member.vo.Password;
 import co.kirikiri.exception.AuthenticationException;
 import co.kirikiri.persistence.auth.RefreshTokenRepository;
@@ -64,6 +65,11 @@ public class AuthService {
 
     public boolean isCertified(final String token) {
         return tokenProvider.isValidToken(token);
+    }
+
+    public boolean isAdminUser(final String token) {
+        final String role = tokenProvider.findRole(token);
+        return MemberRole.ADMIN.equals(MemberRole.valueOf(role));
     }
 
     @Transactional

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/AuthService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/AuthService.java
@@ -47,9 +47,11 @@ public class AuthService {
     }
 
     private AuthenticationResponse makeAuthenticationResponse(final Member member) {
-        final String refreshToken = tokenProvider.createRefreshToken(member.getIdentifier().getValue(), Map.of());
+        final String identifier = member.getIdentifier().getValue();
+        final String role = member.getRole().name();
+        final String refreshToken = tokenProvider.createRefreshToken(identifier, role, Map.of());
         saveRefreshToken(member, refreshToken);
-        final String accessToken = tokenProvider.createAccessToken(member.getIdentifier().getValue(), Map.of());
+        final String accessToken = tokenProvider.createAccessToken(identifier, role, Map.of());
         return AuthMapper.convertToAuthenticationResponse(refreshToken, accessToken);
     }
 

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/AuthService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/AuthService.java
@@ -53,7 +53,7 @@ public class AuthService {
         final String refreshToken = tokenProvider.createRefreshToken(identifier, role, Map.of());
         saveRefreshToken(member, refreshToken);
         final String accessToken = tokenProvider.createAccessToken(identifier, role, Map.of());
-        return AuthMapper.convertToAuthenticationResponse(refreshToken, accessToken);
+        return AuthMapper.convertToAuthenticationResponse(refreshToken, accessToken, role);
     }
 
     private void saveRefreshToken(final Member member, final String rawRefreshToken) {

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/JwtTokenProvider.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/JwtTokenProvider.java
@@ -23,6 +23,7 @@ public class JwtTokenProvider implements TokenProvider {
 
     private static final String TYPE_CLAIM_KEY = "type";
     private static final String UUID_CLAIM_KEY = "UUID";
+    private static final String ROLE_CLAIM_KEY = "role";
 
     private final String secretKey;
     private final Long accessTokenValidityInSeconds;
@@ -37,18 +38,20 @@ public class JwtTokenProvider implements TokenProvider {
     }
 
     @Override
-    public String createAccessToken(final String subject, final Map<String, Object> claims) {
+    public String createAccessToken(final String subject, final String role, final Map<String, Object> claims) {
         final Map<String, Object> copiedClaims = new HashMap<>(claims);
         copiedClaims.put(TYPE_CLAIM_KEY, "Access");
         copiedClaims.put(UUID_CLAIM_KEY, generateUUID());
+        copiedClaims.put(ROLE_CLAIM_KEY, role);
         return createToken(accessTokenValidityInSeconds, subject, copiedClaims);
     }
 
     @Override
-    public String createRefreshToken(final String subject, final Map<String, Object> claims) {
+    public String createRefreshToken(final String subject, final String role, final Map<String, Object> claims) {
         final Map<String, Object> copiedClaims = new HashMap<>(claims);
         copiedClaims.put(TYPE_CLAIM_KEY, "Refresh");
         copiedClaims.put(UUID_CLAIM_KEY, generateUUID());
+        copiedClaims.put(ROLE_CLAIM_KEY, role);
         return createToken(refreshTokenValidityInSeconds, subject, copiedClaims);
     }
 
@@ -113,5 +116,12 @@ public class JwtTokenProvider implements TokenProvider {
         final Jws<Claims> claimsJws = parseToClaimsJws(token);
         return claimsJws.getBody()
                 .getSubject();
+    }
+
+    @Override
+    public String findRole(final String token) {
+        final Jws<Claims> claimsJws = parseToClaimsJws(token);
+        return claimsJws.getBody()
+                .get(ROLE_CLAIM_KEY, String.class);
     }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/TokenProvider.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/TokenProvider.java
@@ -5,13 +5,15 @@ import java.util.Map;
 
 public interface TokenProvider {
 
-    String createAccessToken(final String subject, final Map<String, Object> claims);
+    String createAccessToken(final String subject, final String role, final Map<String, Object> claims);
 
-    String createRefreshToken(final String subject, final Map<String, Object> claims);
+    String createRefreshToken(final String subject, final String role, final Map<String, Object> claims);
 
     boolean isValidToken(final String token);
 
     LocalDateTime findTokenExpiredAt(final String token);
 
     String findSubject(final String token);
+
+    String findRole(final String token);
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/dto/auth/response/AuthenticationResponse.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/dto/auth/response/AuthenticationResponse.java
@@ -2,7 +2,8 @@ package co.kirikiri.service.dto.auth.response;
 
 public record AuthenticationResponse(
         String refreshToken,
-        String accessToken
+        String accessToken,
+        boolean isAdmin
 ) {
 
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/AuthMapper.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/mapper/AuthMapper.java
@@ -1,6 +1,7 @@
 package co.kirikiri.service.mapper;
 
 import co.kirikiri.domain.auth.EncryptedToken;
+import co.kirikiri.domain.member.MemberRole;
 import co.kirikiri.domain.member.vo.Identifier;
 import co.kirikiri.domain.member.vo.Password;
 import co.kirikiri.service.dto.auth.LoginDto;
@@ -18,8 +19,11 @@ public class AuthMapper {
     }
 
     public static AuthenticationResponse convertToAuthenticationResponse(final String refreshToken,
-                                                                         final String accessToken) {
-        return new AuthenticationResponse(refreshToken, accessToken);
+                                                                         final String accessToken, final String role) {
+        if (role.equals(MemberRole.ADMIN.name())) {
+            return new AuthenticationResponse(refreshToken, accessToken, true);
+        }
+        return new AuthenticationResponse(refreshToken, accessToken, false);
     }
 
     public static EncryptedToken convertToEncryptedToken(final ReissueTokenRequest reissueTokenRequest) {

--- a/backend/kirikiri/src/main/resources/db/migration/V3_alter_role_column.sql
+++ b/backend/kirikiri/src/main/resources/db/migration/V3_alter_role_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member
+    ADD role varchar(10) default 'USER';

--- a/backend/kirikiri/src/test/java/co/kirikiri/controller/AuthCreateApiTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/controller/AuthCreateApiTest.java
@@ -41,7 +41,8 @@ class AuthCreateApiTest extends ControllerTestHelper {
     void 정상적으로_로그인에_성공한다() throws Exception {
         //given
         final LoginRequest request = new LoginRequest(IDENTIFIER, PASSWORD);
-        final AuthenticationResponse expectedResponse = new AuthenticationResponse("refreshToken", "accessToken");
+        final AuthenticationResponse expectedResponse = new AuthenticationResponse("refreshToken", "accessToken",
+                false);
         final String jsonRequest = objectMapper.writeValueAsString(request);
         given(authService.login(request))
                 .willReturn(expectedResponse);
@@ -172,7 +173,7 @@ class AuthCreateApiTest extends ControllerTestHelper {
         //given
         final ReissueTokenRequest request = new ReissueTokenRequest("refreshToken");
         final AuthenticationResponse expectedResponse = new AuthenticationResponse("reIssuedRefreshToken",
-                "reIssuedAccessToken");
+                "reIssuedAccessToken", false);
         final String jsonRequest = objectMapper.writeValueAsString(request);
         given(authService.reissueToken(request))
                 .willReturn(expectedResponse);
@@ -186,7 +187,8 @@ class AuthCreateApiTest extends ControllerTestHelper {
                                 ),
                                 responseFields(
                                         fieldWithPath("refreshToken").description("리프레시 토큰"),
-                                        fieldWithPath("accessToken").description("액세스 토큰")
+                                        fieldWithPath("accessToken").description("액세스 토큰"),
+                                        fieldWithPath("isAdmin").description("어드민 계정 여부")
                                 )
                         )
                 )
@@ -291,7 +293,8 @@ class AuthCreateApiTest extends ControllerTestHelper {
     private List<FieldDescription> makeSuccessResponseFieldDescription() {
         return List.of(
                 new FieldDescription("refreshToken", "리프레시 토큰"),
-                new FieldDescription("accessToken", "액세스 토큰")
+                new FieldDescription("accessToken", "액세스 토큰"),
+                new FieldDescription("isAdmin", "어드민 계정 여부")
         );
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/controller/MemberCreateApiTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/controller/MemberCreateApiTest.java
@@ -288,8 +288,34 @@ class MemberCreateApiTest extends ControllerTestHelper {
         회원가입(jsonRequest, status().isConflict());
     }
 
+    @Test
+    void 정상적으로_어드민_역할로_회원가입에_성공한다() throws Exception {
+        //given
+        final MemberJoinRequest memberJoinRequest = new MemberJoinRequest("identifier1", "password1!",
+                "nickname", "010-1234-5678", GenderType.MALE, LocalDate.now());
+        final String jsonRequest = objectMapper.writeValueAsString(memberJoinRequest);
+
+        //when
+        //then
+        final List<FieldDescription> requestFieldDescription = makeSuccessRequestFieldDescription();
+
+        어드민_회원가입(jsonRequest, status().isCreated())
+                .andDo(documentationResultHandler.document(
+                        requestFields(makeFieldDescriptor(requestFieldDescription)),
+                        responseHeaders(headerWithName(HttpHeaders.LOCATION).description("회원 단일 조회 api 경로"))));
+    }
+
     private ResultActions 회원가입(final String jsonRequest, final ResultMatcher result) throws Exception {
         return mockMvc.perform(post(API_PREFIX + "/members/join")
+                        .content(jsonRequest)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .contextPath(API_PREFIX))
+                .andExpect(result)
+                .andDo(print());
+    }
+
+    private ResultActions 어드민_회원가입(final String jsonRequest, final ResultMatcher result) throws Exception {
+        return mockMvc.perform(post(API_PREFIX + "/members/join/admin")
                         .content(jsonRequest)
                         .contentType(MediaType.APPLICATION_JSON)
                         .contextPath(API_PREFIX))

--- a/backend/kirikiri/src/test/java/co/kirikiri/controller/MemberCreateApiTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/controller/MemberCreateApiTest.java
@@ -2,6 +2,7 @@ package co.kirikiri.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
@@ -63,7 +64,7 @@ class MemberCreateApiTest extends ControllerTestHelper {
         //when
         doThrow(new BadRequestException("제약 조건에 맞지 않는 아이디입니다."))
                 .when(memberService)
-                .join(any());
+                .join(any(), anyBoolean());
 
         //then
         회원가입(jsonRequest, status().isBadRequest());
@@ -79,7 +80,7 @@ class MemberCreateApiTest extends ControllerTestHelper {
         //when
         doThrow(new BadRequestException("제약 조건에 맞지 않는 비밀번호입니다."))
                 .when(memberService)
-                .join(any());
+                .join(any(), anyBoolean());
 
         //then
         회원가입(jsonRequest, status().isBadRequest());
@@ -95,7 +96,7 @@ class MemberCreateApiTest extends ControllerTestHelper {
         //when
         doThrow(new BadRequestException("제약 조건에 맞지 않는 닉네임입니다."))
                 .when(memberService)
-                .join(any());
+                .join(any(), anyBoolean());
 
         //then
         회원가입(jsonRequest, status().isBadRequest());
@@ -265,7 +266,7 @@ class MemberCreateApiTest extends ControllerTestHelper {
         //when
         doThrow(new ConflictException("이미 존재하는 아이디입니다."))
                 .when(memberService)
-                .join(any());
+                .join(any(), anyBoolean());
 
         //then
         회원가입(jsonRequest, status().isConflict());
@@ -281,7 +282,7 @@ class MemberCreateApiTest extends ControllerTestHelper {
         //when
         doThrow(new ConflictException("이미 존재하는 닉네임입니다."))
                 .when(memberService)
-                .join(any());
+                .join(any(), anyBoolean());
 
         //then
         회원가입(jsonRequest, status().isConflict());

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/AuthenticationIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/AuthenticationIntegrationTest.java
@@ -2,6 +2,8 @@ package co.kirikiri.integration;
 
 import static co.kirikiri.integration.fixture.AuthenticationAPIFixture.응답을_반환하는_로그인;
 import static co.kirikiri.integration.fixture.AuthenticationAPIFixture.토큰_재발행;
+import static co.kirikiri.integration.fixture.MemberAPIFixture.DEFAULT_ADMIN_IDENTIFIER;
+import static co.kirikiri.integration.fixture.MemberAPIFixture.DEFAULT_ADMIN_PASSWORD;
 import static co.kirikiri.integration.fixture.MemberAPIFixture.DEFAULT_IDENTIFIER;
 import static co.kirikiri.integration.fixture.MemberAPIFixture.DEFAULT_PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +37,24 @@ class AuthenticationIntegrationTest extends InitIntegrationTest {
         final AuthenticationResponse 로그인_응답_바디 = 로그인_응답.as(AuthenticationResponse.class);
         assertThat(로그인_응답_바디.accessToken()).isNotEmpty();
         assertThat(로그인_응답_바디.refreshToken()).isNotEmpty();
+        assertThat(로그인_응답_바디.isAdmin()).isFalse();
+    }
+
+    @Test
+    void 어드민_계정으로_정상적으로_로그인에_성공한다() {
+        //given
+        final LoginRequest 로그인_요청 = new LoginRequest(DEFAULT_ADMIN_IDENTIFIER, DEFAULT_ADMIN_PASSWORD);
+
+        //when
+        final ExtractableResponse<Response> 로그인_응답 = 응답을_반환하는_로그인(로그인_요청);
+
+        //then
+        assertThat(로그인_응답.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        final AuthenticationResponse 로그인_응답_바디 = 로그인_응답.as(AuthenticationResponse.class);
+        assertThat(로그인_응답_바디.accessToken()).isNotEmpty();
+        assertThat(로그인_응답_바디.refreshToken()).isNotEmpty();
+        assertThat(로그인_응답_바디.isAdmin()).isTrue();
     }
 
     @Test

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomCreateIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomCreateIntegrationTest.java
@@ -65,7 +65,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 정상적으로_골룸을_생성한다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -85,7 +85,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_생성_시_컨텐츠_id가_빈값일_경우() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -110,7 +110,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_생성_시_골룸_이름이_빈값일_경우() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -135,7 +135,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_생성_시_골룸_제한_인원이_빈값일_경우() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -160,7 +160,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_생성_시_골룸_이름이_40자_초과인_경우() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final String 적절하지_않은_길이의_골룸_이름 = "a".repeat(41);
@@ -183,7 +183,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_생성_시_노드_별_기간_수와_로드맵_노드의_수가_맞지_않을때() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -204,7 +204,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_생성_시_제한_인원이_20명_초과일때() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -228,7 +228,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸에_참가_요청을_보낸다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -272,7 +272,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 인원이_가득_찬_골룸에_참가_요청을_보내면_예외가_발생한다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -303,7 +303,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 모집_중이지_않은_골룸에_참가_요청을_보내면_예외가_발생한다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -335,7 +335,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 인증_피드_등록을_요청한다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -363,7 +363,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
 
     @Test
     void 인증용_사진이_없는_경우_인증_피드_등록이_실패한다() throws IOException {
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -392,7 +392,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
 
     @Test
     void 인증용_사진의_확장자가_허용되지_않는_경우_인증_피드_등록이_실패한다() throws IOException {
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -422,7 +422,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
 
     @Test
     void 하루에_두_번_이상_인증_피드_등록을_요청하는_경우_실패한다() throws IOException {
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -457,7 +457,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
 
     @Test
     void 진행_중인_노드의_허용된_인증_횟수_이상_요청할_경우_실패한다() throws IOException {
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -488,7 +488,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 이미_참여한_골룸에_참가_요청을_보내면_예외가_발생한다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -514,7 +514,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 정상적으로_골룸에_투두리스트를_추가한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
         final Long 골룸_아이디 = 정상적인_골룸_생성(기본_로그인_토큰, 기본_로드맵_아이디, 로드맵_응답.content().nodes().get(0).id());
 
@@ -533,7 +533,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸에_팔로워가_투두_리스트를_추가할때_예외를_던진다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final MemberJoinRequest 팔로워_회원가입_요청 = new MemberJoinRequest("identifier2", "password12!@#$%", "follower",
@@ -560,7 +560,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 종료된_골룸에_투두_리스트를_추가할때_예외를_던진다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 골룸_아이디 = 정상적인_골룸_생성(기본_로그인_토큰, 기본_로드맵_아이디, 로드맵_응답.content().nodes().get(0).id());
@@ -582,7 +582,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_투두_리스트를_체크한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 골룸_아이디 = 정상적인_골룸_생성(기본_로그인_토큰, 기본_로드맵_아이디, 로드맵_응답.content().nodes().get(0).id());
@@ -603,7 +603,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_투두리스트_체크를_해제한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 골룸_아이디 = 정상적인_골룸_생성(기본_로그인_토큰, 기본_로드맵_아이디, 로드맵_응답.content().nodes().get(0).id());
@@ -639,7 +639,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_투두리스트_체크시_사용자가_없으면_예외가_발생한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 골룸_아이디 = 정상적인_골룸_생성(기본_로그인_토큰, 기본_로드맵_아이디, 로드맵_응답.content().nodes().get(0).id());
@@ -666,7 +666,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 정상적으로_모집중인_골룸을_나간다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -695,7 +695,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 정상적으로_완료된_골룸을_나간다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -754,7 +754,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 모집중인_골룸을_나갈때_참여하지_않은_골룸일_경우_예외가_발생한다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -786,7 +786,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 완료된_골룸을_나갈때_참여하지_않은_골룸일_경우_예외가_발생한다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -822,7 +822,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸을_나갈때_골룸이_진행중이면_예외가_발생한다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -848,7 +848,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 모집중인_골룸을_나갈때_리더가_나가면_다음으로_들어온_사용자가_리더가_된다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -891,7 +891,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 완료된_골룸을_나갈때_리더가_나가면_다음으로_들어온_사용자가_리더가_된다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -935,7 +935,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 모집중인_골룸을_나갈때_팔로워가_나가면_리더는_변하지_않는다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -966,7 +966,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 완료된_골룸을_나갈때_팔로워가_나가면_리더는_변하지_않는다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -1000,7 +1000,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 모집중인_골룸을_나갈때_남은_사용자가_없으면_골룸은_삭제된다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -1027,7 +1027,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 완료된_골룸을_나갈때_남은_사용자가_없으면_골룸은_삭제된다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -1057,7 +1057,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸을_정상적으로_시작한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -1088,7 +1088,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸을_시작하는_사용자가_골룸의_리더가_아니면_예외가_발생한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -1119,7 +1119,7 @@ class GoalRoomCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_시작시_골룸의_시작날짜가_미래라면_예외가_발생한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 십일_후, 이십일_후);

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomReadIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomReadIntegrationTest.java
@@ -74,7 +74,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_아이디로_골룸_정보를_조회한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -91,7 +91,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_아이디와_사용자_아이디로_골룸_정보를_조회한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -108,7 +108,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_투두리스트를_조회한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -146,7 +146,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_투두리스트_조회시_참여하지_않은_사용자일_경우() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -176,7 +176,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 진행중인_사용자_단일_골룸을_조회한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -219,7 +219,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_시작_전에_사용자_단일_골룸_조회_시_인증_피드가_빈_응답을_반환한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -234,7 +234,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 사용자의_모든_골룸_목록을_조회한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -243,7 +243,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
                 "두번째_로드맵 본문",
                 RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("두번째_로드맵 1주차", "두번째_로드맵 1주차 내용", null)), null);
-        로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 두번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 두번째_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 두번째_로드맵_응답);
@@ -264,12 +264,12 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 사용자가_참여한_골룸_중_모집_중인_골룸_목록을_조회한다() throws IOException {
         // given
-        final Long 첫번쨰_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 첫번쨰_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 첫번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(첫번쨰_로드맵_아이디);
 
         final Long 첫번째_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 첫번째_로드맵_응답);
 
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 두번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(두번째_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest("Content", 십일_후, 이십일_후);
@@ -295,12 +295,12 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 사용자가_참여한_골룸_중_진행_중인_골룸_목록을_조회한다() throws IOException {
         // given
-        final Long 첫번쨰_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 첫번쨰_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 첫번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(첫번쨰_로드맵_아이디);
 
         final Long 첫번째_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 첫번째_로드맵_응답);
 
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 두번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(두번째_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest("Content", 십일_후, 이십일_후);
@@ -326,7 +326,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_노드를_조회한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -359,7 +359,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_노드_조회시_참여하지_않은_사용자일_경우_예외가_발생한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -391,7 +391,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
         회원가입(팔로워_회원_가입_요청);
         final String 팔로워_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(팔로워_로그인_요청).accessToken());
 
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -440,7 +440,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
         회원가입(다른_회원_회원_가입_요청);
         final String 다른_회원_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(다른_회원_로그인_요청).accessToken());
 
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -478,7 +478,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
         final String 팔로워1_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(팔로워1_로그인_요청).accessToken());
         final String 팔로워2_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(팔로워2_로그인_요청).accessToken());
 
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -520,7 +520,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
         final String 팔로워1_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(팔로워1_로그인_요청).accessToken());
         final String 팔로워2_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(팔로워2_로그인_요청).accessToken());
 
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -555,7 +555,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
         final String 팔로워1_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(팔로워1_로그인_요청).accessToken());
         final String 팔로워2_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(팔로워2_로그인_요청).accessToken());
 
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -589,7 +589,7 @@ class GoalRoomReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵의_골룸_목록을_마감임박순으로_조회한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomSchedulerIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomSchedulerIntegrationTest.java
@@ -57,7 +57,7 @@ class GoalRoomSchedulerIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸이_시작되면_골룸_대기_사용자에서_골룸_사용자로_이동하고_대기_사용자에서는_제거된다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -84,7 +84,7 @@ class GoalRoomSchedulerIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸의_시작날짜가_오늘보다_이후이면_아무일도_일어나지_않는다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -112,7 +112,7 @@ class GoalRoomSchedulerIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_종료시_종료_날짜가_어제인_골룸의_상태가_COMPLETED로_변경된다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -138,7 +138,7 @@ class GoalRoomSchedulerIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸_종료시_종료_날짜가_어제가_아니면_아무_일도_일어나지_않는다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -163,7 +163,7 @@ class GoalRoomSchedulerIntegrationTest extends InitIntegrationTest {
     @Test
     void 진행_중인_사용자_단일_골룸을_조회할_때_진행_중인_노드_기간이_아니면_빈_인증피드를_반환한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 십일_후에_시작하는_골룸_생성(기본_로그인_토큰, 로드맵_응답);
@@ -189,7 +189,7 @@ class GoalRoomSchedulerIntegrationTest extends InitIntegrationTest {
     @Test
     void 모집_중인_사용자_단일_골룸_조회_시_인증_피드가_빈_응답을_반환한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final Long 기본_골룸_아이디 = 기본_골룸_생성(기본_로그인_토큰, 로드맵_응답);

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/MemberCreateIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/MemberCreateIntegrationTest.java
@@ -1,5 +1,6 @@
 package co.kirikiri.integration;
 
+import static co.kirikiri.integration.fixture.MemberAPIFixture.요청을_받는_어드민_회원가입;
 import static co.kirikiri.integration.fixture.MemberAPIFixture.요청을_받는_회원가입;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,6 +28,19 @@ class MemberCreateIntegrationTest extends InitIntegrationTest {
 
         //when
         final ExtractableResponse<Response> 회원가입_응답 = 요청을_받는_회원가입(회원가입_요청);
+
+        //then
+        assertThat(회원가입_응답.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void 정상적으로_어드민_역할로_회원가입을_성공한다() {
+        //given
+        final MemberJoinRequest 회원가입_요청 = new MemberJoinRequest("ab12", "password12!@#$%", "hello", "010-1234-5678",
+                GenderType.MALE, LocalDate.of(2023, Month.JULY, 12));
+
+        //when
+        final ExtractableResponse<Response> 회원가입_응답 = 요청을_받는_어드민_회원가입(회원가입_요청);
 
         //then
         assertThat(회원가입_응답.statusCode()).isEqualTo(HttpStatus.CREATED.value());

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/MemberReadIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/MemberReadIntegrationTest.java
@@ -70,13 +70,13 @@ class MemberReadIntegrationTest extends InitIntegrationTest {
     void 특정_사용자의_정보를_조회시_존재하지_않는_회원이면_실패한다() throws JsonProcessingException {
         // given
         // when
-        final ExtractableResponse<Response> 특정_사용자의_정보_조회_응답 = 요청을_받는_특정_사용자의_정보_조회(기본_로그인_토큰, 2L);
+        final ExtractableResponse<Response> 특정_사용자의_정보_조회_응답 = 요청을_받는_특정_사용자의_정보_조회(기본_로그인_토큰, 100L);
 
         // then
         final ErrorResponse 에러_메세지 = jsonToClass(특정_사용자의_정보_조회_응답.asString(),
                 new TypeReference<>() {
                 });
         assertThat(특정_사용자의_정보_조회_응답.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
-        assertThat(에러_메세지.message()).isEqualTo("존재하지 않는 회원입니다. memberId = 2");
+        assertThat(에러_메세지.message()).isEqualTo("존재하지 않는 회원입니다. memberId = 100");
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapCreateIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapCreateIntegrationTest.java
@@ -36,12 +36,24 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 정상적으로_로드맵을_생성한다() throws IOException {
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // expect
         응답_상태_코드_검증(로드맵_생성_응답값, HttpStatus.CREATED);
         final Long 로드맵_아이디 = 아이디를_반환한다(로드맵_생성_응답값);
         assertThat(로드맵_아이디).isEqualTo(1L);
+    }
+
+    @Test
+    void 어드민_권한이_없는_사용자는_로드맵을_생성하면_예외가_발생한다() throws IOException {
+        // when
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+
+        // then
+        final ErrorResponse 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
+        });
+        응답_상태_코드_검증(로드맵_생성_응답값, HttpStatus.UNAUTHORIZED);
+        assertThat(에러_메세지.message()).isEqualTo("어드민 권한이 필요합니다.");
     }
 
     @Test
@@ -54,7 +66,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapTagSaveRequest("태그1")));
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         응답_상태_코드_검증(로드맵_생성_응답값, HttpStatus.CREATED);
@@ -79,7 +91,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapTagSaveRequest("태그1")));
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final List<ErrorResponse> 에러_메시지들 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -109,7 +121,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapTagSaveRequest("태그1")));
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final ErrorResponse 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -130,7 +142,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapTagSaveRequest("태그")));
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final ErrorResponse 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -150,7 +162,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapTagSaveRequest("태그1")));
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final ErrorResponse 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -170,7 +182,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapTagSaveRequest("태그1")));
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final ErrorResponse 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -191,7 +203,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapTagSaveRequest("태그1")));
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final ErrorResponse 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -209,7 +221,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 "로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30, 로드맵_노드들, List.of(new RoadmapTagSaveRequest("태그1")));
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final List<ErrorResponse> 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -229,7 +241,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 "로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30, 로드맵_노드들, List.of(new RoadmapTagSaveRequest("태그1")));
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final ErrorResponse 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -250,7 +262,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 "로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30, 로드맵_노드들, List.of(new RoadmapTagSaveRequest("태그1")));
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final ErrorResponse 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -270,7 +282,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapNodeSaveRequest("로드맵 노드 제목", "로드맵 노드 설명", Collections.emptyList())), 태그_저장_요청);
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final ErrorResponse 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -292,7 +304,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapNodeSaveRequest("로드맵 노드 제목", "로드맵 노드 설명", Collections.emptyList())), 태그_저장_요청);
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final ErrorResponse 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -313,7 +325,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapNodeSaveRequest("로드맵 노드 제목", "로드맵 노드 설명", Collections.emptyList())), 태그_저장_요청);
 
         // when
-        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_생성_응답값 = 요청을_받는_이미지가_포함된_로드맵_생성(로드맵_생성_요청값, 어드민_로그인_토큰);
 
         // then
         final ErrorResponse 에러_메세지 = 로드맵_생성_응답값.as(new TypeRef<>() {
@@ -325,10 +337,10 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 골룸이_생성된_적이_없는_로드맵을_정상적으로_삭제한다() throws IOException {
         // given
-        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
-        final ExtractableResponse<Response> 로드맵_삭제_응답 = 로드맵_삭제(로드맵_아이디, 기본_로그인_토큰);
+        final ExtractableResponse<Response> 로드맵_삭제_응답 = 로드맵_삭제(로드맵_아이디, 어드민_로그인_토큰);
 
         // then
         응답_상태_코드_검증(로드맵_삭제_응답, HttpStatus.NO_CONTENT);
@@ -352,7 +364,7 @@ class RoadmapCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵을_삭제할_때_자신이_생성한_로드맵이_아니면_예외가_발생한다() throws IOException {
         // given
-        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
 
         회원가입(new MemberJoinRequest("identifier2", "password2!", "name2", "010-1111-2222", GenderType.FEMALE,
                 LocalDate.now()));

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadIntegrationTest.java
@@ -36,12 +36,12 @@ class RoadmapReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 존재하는_로드맵_아이디로_요청했을_때_단일_로드맵_정보_조회를_성공한다() throws IOException {
         //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapSaveRequest 다른_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "다른 로드맵 제목", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        로드맵_생성(다른_로드맵_생성_요청, 기본_로그인_토큰);
+        로드맵_생성(다른_로드맵_생성_요청, 어드민_로그인_토큰);
 
         //when
         final ExtractableResponse<Response> 단일_로드맵_조회_요청에_대한_응답 = 로드맵을_아이디로_조회한다(기본_로드맵_아이디);
@@ -78,18 +78,18 @@ class RoadmapReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 사이즈_조건으로_로드맵_목록을_조회한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
         final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(다른_카테고리.getId(), "thrid roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
         final RoadmapForListResponses 로드맵_리스트_응답 = 사이즈별로_로드맵을_조회한다(10)
@@ -141,20 +141,20 @@ class RoadmapReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 사용자가_생성한_로드맵을_조회한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapSaveRequest 세번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번쨰_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
-        final MemberRoadmapResponses 사용자_로드맵_응답_리스트 = 로그인한_사용자가_생성한_로드맵을_조회한다(기본_로그인_토큰, 10)
+        final MemberRoadmapResponses 사용자_로드맵_응답_리스트 = 로그인한_사용자가_생성한_로드맵을_조회한다(어드민_로그인_토큰, 10)
                 .response()
                 .as(new TypeRef<>() {
                 });
@@ -169,12 +169,12 @@ class RoadmapReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵_목록_조회시_다음_요소가_존재하면_hasNext가_true로_반환된다() throws IOException {
         // given
-        로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_카테고리별_로드맵_리스트_조회(RoadmapOrderType.LATEST, 기본_카테고리.getId(), 1)
@@ -190,21 +190,21 @@ class RoadmapReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 사용자가_생성한_로드맵을_이전에_받아온_리스트_이후로_조회한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapSaveRequest 세번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번쨰_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
         final MemberRoadmapResponses 사용자_로드맵_응답_리스트 = 로그인한_사용자가_생성한_로드맵을_이전에_받은_로드맵의_제일마지막_아이디_이후의_조건으로_조회한다(
-                기본_로그인_토큰, 10, 두번째_로드맵_아이디
+                어드민_로그인_토큰, 10, 두번째_로드맵_아이디
         )
                 .response()
                 .as(new TypeRef<>() {

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadOrderIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadOrderIntegrationTest.java
@@ -45,14 +45,14 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         // given
         // 기본, 두 번째 로드맵 - 여행, 세 번째 로드맵 - 여가
         // 첫 번째 로드맵 생성
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // 두 번째 로드맵 생성
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // 다른 카테고리의 세 번째 로드맵 생성
         final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
@@ -60,7 +60,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
+        로드맵_생성(세번째_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_카테고리별_로드맵_리스트_조회(RoadmapOrderType.LATEST, 기본_카테고리.getId(), 10)
@@ -79,7 +79,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         // given
         // 기본, 두 번째 로드맵 - 여행, 세 번째 로드맵 - 여가
         // 첫 번째 로드맵 생성
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         // 사용자 추가
@@ -95,7 +95,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 두번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(두번째_로드맵_아이디);
 
         // 사용자 추가
@@ -112,7 +112,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
+        로드맵_생성(세번째_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_카테고리별_로드맵_리스트_조회(RoadmapOrderType.REVIEW_RATE, 기본_카테고리.getId(),
@@ -132,14 +132,14 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         // given
         // 기본, 두 번째 로드맵 - 여행, 세 번째 로드맵 - 여가
         // 첫 번째 로드맵 생성
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // 두 번째 로드맵 생성
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 두번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(두번째_로드맵_아이디);
 
         // 두 번째 로드맵에 대한 골룸 생성
@@ -151,7 +151,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
+        로드맵_생성(세번째_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_카테고리별_로드맵_리스트_조회(RoadmapOrderType.GOAL_ROOM_COUNT,
@@ -171,21 +171,21 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         // given
         // 기본, 두 번째 로드맵 - 여행, 세 번째 로드맵 - 여가
         // 첫 번째 로드맵 생성
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // 두 번째 로드맵 생성
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 두번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(두번째_로드맵_아이디);
 
         // 두 번째 로드맵에 대한 골룸 생성 및 참가 신청
         final Long 두번째_로드맵의_골룸_아이디 = 로드맵에_대한_골룸을_생성한다(두번째_로드맵_응답);
         final String 팔로워_액세스_토큰 = 사용자를_추가하고_토큰을_조회한다("identifier2", "닉네임2");
         골룸_참가_요청(두번째_로드맵의_골룸_아이디, 팔로워_액세스_토큰);
-        골룸을_시작한다(기본_로그인_토큰, 두번째_로드맵의_골룸_아이디);
+        골룸을_시작한다(어드민_로그인_토큰, 두번째_로드맵의_골룸_아이디);
 
         // 다른 카테고리의 세 번째 로드맵 생성
         final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
@@ -193,7 +193,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
+        로드맵_생성(세번째_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_카테고리별_로드맵_리스트_조회(RoadmapOrderType.PARTICIPANT_COUNT,
@@ -212,14 +212,14 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
     void 전체_로드맵_목록을_최신순으로_조회한다() throws IOException {
         // given
         // 첫 번째 로드맵 생성
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // 두 번째 로드맵 생성
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // 세 번째 로드맵 생성
         final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
@@ -227,7 +227,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_로드맵_리스트_조회(RoadmapOrderType.LATEST, 10)
@@ -247,7 +247,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         // given
         // 기본, 두 번째 로드맵 - 여행, 세 번째 로드맵 - 여가
         // 첫 번째 로드맵 생성
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         // 사용자 추가
@@ -263,7 +263,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 두번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(두번째_로드맵_아이디);
 
         // 사용자 추가
@@ -280,7 +280,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 세번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(세번째_로드맵_아이디);
 
         // 사용자 추가
@@ -309,14 +309,14 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         // given
         // 기본, 두 번째 로드맵 - 여행, 세 번째 로드맵 - 여가
         // 첫 번째 로드맵 생성
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // 두 번째 로드맵 생성
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 두번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(두번째_로드맵_아이디);
 
         // 두 번째 로드맵에 대한 골룸 생성
@@ -328,7 +328,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 세번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(세번째_로드맵_아이디);
 
         // 세 번째 로드맵에 대한 골룸 생성
@@ -353,21 +353,21 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         // given
         // 기본, 두 번째 로드맵 - 여행, 세 번째 로드맵 - 여가
         // 첫 번째 로드맵 생성
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 첫번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         // 첫 번째 로드맵에 대한 골룸 생성 및 참가 신청
         final Long 첫번째_로드맵의_골룸_아이디 = 로드맵에_대한_골룸을_생성한다(첫번째_로드맵_응답);
         final String 팔로워_액세스_토큰 = 사용자를_추가하고_토큰을_조회한다("identifier2", "닉네임2");
         골룸_참가_요청(첫번째_로드맵의_골룸_아이디, 팔로워_액세스_토큰);
-        골룸을_시작한다(기본_로그인_토큰, 첫번째_로드맵의_골룸_아이디);
+        골룸을_시작한다(어드민_로그인_토큰, 첫번째_로드맵의_골룸_아이디);
 
         // 두 번째 로드맵 생성
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // 세 번째 로드맵 생성
         final RoadmapCategory 다른_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여가");
@@ -375,14 +375,14 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 세번째_로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(세번째_로드맵_아이디);
 
         // 세 번째 로드맵에 대한 골룸 생성 및 참가 신청
         final Long 세번째_로드맵의_골룸_아이디 = 로드맵에_대한_골룸을_생성한다(세번째_로드맵_응답);
         final String 팔로워_액세스_토큰2 = 사용자를_추가하고_토큰을_조회한다("identifier3", "닉네임3");
         골룸_참가_요청(세번째_로드맵의_골룸_아이디, 팔로워_액세스_토큰2);
-        골룸을_시작한다(기본_로그인_토큰, 세번째_로드맵의_골룸_아이디);
+        골룸을_시작한다(어드민_로그인_토큰, 세번째_로드맵의_골룸_아이디);
 
         // when
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_로드맵_리스트_조회(RoadmapOrderType.PARTICIPANT_COUNT, 10)
@@ -403,14 +403,14 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
                 new GoalRoomRoadmapNodeRequest(로드맵_응답.content().nodes().get(0).id(), 정상적인_골룸_노드_인증_횟수, 오늘, 십일_후));
         final GoalRoomCreateRequest 골룸_생성_요청 = new GoalRoomCreateRequest(로드맵_응답.roadmapId(), 정상적인_골룸_이름, 정상적인_골룸_제한_인원,
                 골룸_투두_요청, 골룸_노드_별_기간_요청);
-        return 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 기본_로그인_토큰);
+        return 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 어드민_로그인_토큰);
     }
 
     private void 골룸을_생성하고_참여자에_사용자를_추가한다(final String 액세스_토큰, final RoadmapResponse 로드맵_응답) {
         final MemberInformationResponse 팔로워_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(액세스_토큰).as(new TypeRef<>() {
         });
 
-        final MemberInformationResponse 리더_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(기본_로그인_토큰).as(new TypeRef<>() {
+        final MemberInformationResponse 리더_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(어드민_로그인_토큰).as(new TypeRef<>() {
         });
         final GoalRoom 골룸 = testTransactionService.완료한_골룸을_생성한다(로드맵_응답);
         testTransactionService.골룸에_대한_참여자_리스트를_생성한다(리더_정보, 골룸, 팔로워_정보);

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReviewCreateIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReviewCreateIntegrationTest.java
@@ -42,7 +42,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵_리뷰를_생성한다() throws IOException {
         // given
-        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(로드맵_아이디);
 
         final MemberJoinRequest 팔로워_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
@@ -53,7 +53,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
         final MemberInformationResponse 팔로워_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(팔로워_액세스_토큰).as(new TypeRef<>() {
         });
 
-        final MemberInformationResponse 리더_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(기본_로그인_토큰).as(new TypeRef<>() {
+        final MemberInformationResponse 리더_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(어드민_로그인_토큰).as(new TypeRef<>() {
         });
         final GoalRoom 골룸 = testTransactionService.완료한_골룸을_생성한다(로드맵_응답);
         testTransactionService.골룸에_대한_참여자_리스트를_생성한다(리더_정보, 골룸, 팔로워_정보);
@@ -71,7 +71,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵_리뷰_생성시_별점이_null이면_예외가_발생한다() throws IOException {
         // given
-        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(로드맵_아이디);
 
         final MemberJoinRequest 팔로워_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
@@ -82,7 +82,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
         final MemberInformationResponse 팔로워_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(팔로워_액세스_토큰).as(new TypeRef<>() {
         });
 
-        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(기본_로그인_토큰).as(new TypeRef<>() {
+        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(어드민_로그인_토큰).as(new TypeRef<>() {
         });
         final GoalRoom 골룸 = testTransactionService.완료한_골룸을_생성한다(로드맵_응답);
         testTransactionService.골룸에_대한_참여자_리스트를_생성한다(사용자_정보, 골룸, 팔로워_정보);
@@ -102,7 +102,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵_리뷰_생성시_별점이_잘못된_값이면_예외가_발생한다() throws IOException {
         // given
-        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(로드맵_아이디);
 
         final MemberJoinRequest 팔로워_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
@@ -113,7 +113,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
         final MemberInformationResponse 팔로워_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(팔로워_액세스_토큰).as(new TypeRef<>() {
         });
 
-        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(기본_로그인_토큰).as(new TypeRef<>() {
+        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(어드민_로그인_토큰).as(new TypeRef<>() {
         });
         final GoalRoom 골룸 = testTransactionService.완료한_골룸을_생성한다(로드맵_응답);
         testTransactionService.골룸에_대한_참여자_리스트를_생성한다(사용자_정보, 골룸, 팔로워_정보);
@@ -132,7 +132,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵_리뷰_생성시_내용이_1000자가_넘으면_예외가_발생한다() throws IOException {
         // given
-        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(로드맵_아이디);
 
         final MemberJoinRequest 팔로워_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
@@ -143,7 +143,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
         final MemberInformationResponse 팔로워_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(팔로워_액세스_토큰).as(new TypeRef<>() {
         });
 
-        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(기본_로그인_토큰).as(new TypeRef<>() {
+        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(어드민_로그인_토큰).as(new TypeRef<>() {
         });
         final GoalRoom 골룸 = testTransactionService.완료한_골룸을_생성한다(로드맵_응답);
         testTransactionService.골룸에_대한_참여자_리스트를_생성한다(사용자_정보, 골룸, 팔로워_정보);
@@ -183,7 +183,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵_리뷰_생성시_완료한_골룸이_없다면_예외가_발생한다() throws IOException {
         // given
-        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(로드맵_아이디);
 
         final MemberJoinRequest 팔로워_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
@@ -197,7 +197,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
                 new GoalRoomRoadmapNodeRequest(로드맵_응답.content().nodes().get(0).id(), 정상적인_골룸_노드_인증_횟수, 오늘, 십일_후));
         final GoalRoomCreateRequest 골룸_생성_요청 = new GoalRoomCreateRequest(로드맵_응답.roadmapId(), 정상적인_골룸_이름, 정상적인_골룸_제한_인원,
                 골룸_투두_요청, 골룸_노드_별_기간_요청);
-        골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 기본_로그인_토큰);
+        골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 어드민_로그인_토큰);
         final RoadmapReviewSaveRequest 로드맵_리뷰_생성_요청 = new RoadmapReviewSaveRequest("리뷰 내용", 5.0);
 
         // when
@@ -213,7 +213,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵_리뷰_생성시_로드맵_생성자가_리뷰를_달려고_하면_예외가_발생한다() throws IOException {
         // given
-        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(로드맵_아이디);
 
         final MemberJoinRequest 팔로워_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
@@ -224,7 +224,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
         final MemberInformationResponse 팔로워_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(팔로워_액세스_토큰).as(new TypeRef<>() {
         });
 
-        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(기본_로그인_토큰).as(new TypeRef<>() {
+        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(어드민_로그인_토큰).as(new TypeRef<>() {
         });
         final GoalRoom 골룸 = testTransactionService.완료한_골룸을_생성한다(로드맵_응답);
         testTransactionService.골룸에_대한_참여자_리스트를_생성한다(사용자_정보, 골룸, 팔로워_정보);
@@ -232,19 +232,19 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
         final RoadmapReviewSaveRequest 로드맵_리뷰_생성_요청 = new RoadmapReviewSaveRequest("리뷰 내용", 5.0);
 
         // when
-        final ExtractableResponse<Response> 리뷰_생성_요청_결과 = 리뷰를_생성한다(기본_로그인_토큰, 로드맵_아이디, 로드맵_리뷰_생성_요청);
+        final ExtractableResponse<Response> 리뷰_생성_요청_결과 = 리뷰를_생성한다(어드민_로그인_토큰, 로드맵_아이디, 로드맵_리뷰_생성_요청);
 
         // then
         final ErrorResponse 예외_응답 = 리뷰_생성_요청_결과.as(ErrorResponse.class);
         assertThat(리뷰_생성_요청_결과.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         assertThat(예외_응답.message()).isEqualTo("로드맵 생성자는 리뷰를 달 수 없습니다. roadmapId = " + 로드맵_아이디 +
-                " memberId = " + 기본_회원_아이디);
+                " memberId = " + 어드민_회원_아이디);
     }
 
     @Test
     void 로드맵_리뷰_생성시_이미_리뷰를_단적이_있으면_예외가_발생한다() throws IOException {
         // given
-        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(로드맵_아이디);
 
         final MemberJoinRequest 팔로워_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
@@ -255,7 +255,7 @@ class RoadmapReviewCreateIntegrationTest extends InitIntegrationTest {
         final MemberInformationResponse 팔로워_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(팔로워_액세스_토큰).as(new TypeRef<>() {
         });
 
-        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(기본_로그인_토큰).as(new TypeRef<>() {
+        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(어드민_로그인_토큰).as(new TypeRef<>() {
         });
         final GoalRoom 골룸 = testTransactionService.완료한_골룸을_생성한다(로드맵_응답);
         testTransactionService.골룸에_대한_참여자_리스트를_생성한다(사용자_정보, 골룸, 팔로워_정보);

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReviewReadIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReviewReadIntegrationTest.java
@@ -40,7 +40,7 @@ class RoadmapReviewReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵에_대한_리뷰를_최신순으로_조회한다() throws IOException {
         // given
-        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(로드맵_아이디);
 
         final MemberJoinRequest 리더_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
@@ -104,11 +104,11 @@ class RoadmapReviewReadIntegrationTest extends InitIntegrationTest {
         assertAll(
                 () -> assertThat(첫번째_로드맵_리뷰_조회_응답값)
                         .usingRecursiveComparison()
-                        .ignoringFields("createdAt")
+                        .ignoringFields("member.id", "createdAt")
                         .isEqualTo(첫번째_로드맵_리뷰_조회_요청_예상값),
                 () -> assertThat(두번째_로드맵_리뷰_조회_응답값)
                         .usingRecursiveComparison()
-                        .ignoringFields("createdAt")
+                        .ignoringFields("member.id", "createdAt")
                         .isEqualTo(두번째_로드맵_리뷰_조회_요청_예상값)
         );
     }
@@ -116,7 +116,7 @@ class RoadmapReviewReadIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵_리뷰_조회_요청_시_작성된_리뷰가_없다면_빈_값을_반환한다() throws IOException {
         // given
-        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(로드맵_아이디);
 
         final MemberJoinRequest 리더_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapSchedulerIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapSchedulerIntegrationTest.java
@@ -41,7 +41,7 @@ public class RoadmapSchedulerIntegrationTest extends InitIntegrationTest {
     @Test
     void 삭제된_상태의_로드맵을_삭제시_모든_골룸이_종료된지_3개월이_지났으면_정상적으로_삭제한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -50,7 +50,7 @@ public class RoadmapSchedulerIntegrationTest extends InitIntegrationTest {
         final GoalRoomCreateRequest 골룸_생성_요청 = new GoalRoomCreateRequest(로드맵_응답.roadmapId(), 정상적인_골룸_이름, 정상적인_골룸_제한_인원,
                 골룸_투두_요청, 골룸_노드_별_기간_요청);
 
-        final Long 골룸_아이디1 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 기본_로그인_토큰);
+        final Long 골룸_아이디1 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 어드민_로그인_토큰);
 
         final GoalRoomTodoRequest 골룸_투두_요청2 = new GoalRoomTodoRequest("골룸 투두", 오늘, 십일_후);
         final List<GoalRoomRoadmapNodeRequest> 골룸_노드_별_기간_요청2 = List.of(
@@ -58,9 +58,9 @@ public class RoadmapSchedulerIntegrationTest extends InitIntegrationTest {
         final GoalRoomCreateRequest 골룸_생성_요청2 = new GoalRoomCreateRequest(로드맵_응답.roadmapId(), 정상적인_골룸_이름, 정상적인_골룸_제한_인원,
                 골룸_투두_요청2, 골룸_노드_별_기간_요청2);
 
-        final Long 골룸_아이디2 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청2, 기본_로그인_토큰);
+        final Long 골룸_아이디2 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청2, 어드민_로그인_토큰);
 
-        로드맵_삭제(기본_로드맵_아이디, 기본_로그인_토큰);
+        로드맵_삭제(기본_로드맵_아이디, 어드민_로그인_토큰);
 
         testTransactionService.골룸의_상태와_종료날짜를_변경한다(골룸_아이디1, GoalRoomStatus.COMPLETED, 현재부터_3개월_1일_전);
         testTransactionService.골룸의_상태와_종료날짜를_변경한다(골룸_아이디2, GoalRoomStatus.COMPLETED, 현재부터_3개월_1일_전);
@@ -75,7 +75,7 @@ public class RoadmapSchedulerIntegrationTest extends InitIntegrationTest {
     @Test
     void 삭제된_상태의_로드맵_삭제시_종료되지_않은_골룸이_있으면_삭제되지_않는다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -84,7 +84,7 @@ public class RoadmapSchedulerIntegrationTest extends InitIntegrationTest {
         final GoalRoomCreateRequest 골룸_생성_요청 = new GoalRoomCreateRequest(로드맵_응답.roadmapId(), 정상적인_골룸_이름, 정상적인_골룸_제한_인원,
                 골룸_투두_요청, 골룸_노드_별_기간_요청);
 
-        final Long 골룸_아이디1 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 기본_로그인_토큰);
+        final Long 골룸_아이디1 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 어드민_로그인_토큰);
 
         final GoalRoomTodoRequest 골룸_투두_요청2 = new GoalRoomTodoRequest("골룸 투두", 오늘, 십일_후);
         final List<GoalRoomRoadmapNodeRequest> 골룸_노드_별_기간_요청2 = List.of(
@@ -92,9 +92,9 @@ public class RoadmapSchedulerIntegrationTest extends InitIntegrationTest {
         final GoalRoomCreateRequest 골룸_생성_요청2 = new GoalRoomCreateRequest(로드맵_응답.roadmapId(), 정상적인_골룸_이름, 정상적인_골룸_제한_인원,
                 골룸_투두_요청2, 골룸_노드_별_기간_요청2);
 
-        final Long 골룸_아이디2 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청2, 기본_로그인_토큰);
+        final Long 골룸_아이디2 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청2, 어드민_로그인_토큰);
 
-        로드맵_삭제(기본_로드맵_아이디, 기본_로그인_토큰);
+        로드맵_삭제(기본_로드맵_아이디, 어드민_로그인_토큰);
 
         testTransactionService.골룸의_상태와_종료날짜를_변경한다(골룸_아이디1, GoalRoomStatus.COMPLETED, 현재부터_3개월_1일_전);
 
@@ -108,7 +108,7 @@ public class RoadmapSchedulerIntegrationTest extends InitIntegrationTest {
     @Test
     void 삭제된_상태의_로드맵_삭제시_종료된지_3개월이_지나지_않은_골룸이_있으면_삭제되지_않는다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapResponse 로드맵_응답 = 로드맵을_아이디로_조회하고_응답객체를_반환한다(기본_로드맵_아이디);
 
         final GoalRoomTodoRequest 골룸_투두_요청 = new GoalRoomTodoRequest(정상적인_골룸_투두_컨텐츠, 오늘, 십일_후);
@@ -117,7 +117,7 @@ public class RoadmapSchedulerIntegrationTest extends InitIntegrationTest {
         final GoalRoomCreateRequest 골룸_생성_요청 = new GoalRoomCreateRequest(로드맵_응답.roadmapId(), 정상적인_골룸_이름, 정상적인_골룸_제한_인원,
                 골룸_투두_요청, 골룸_노드_별_기간_요청);
 
-        final Long 골룸_아이디1 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 기본_로그인_토큰);
+        final Long 골룸_아이디1 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청, 어드민_로그인_토큰);
 
         final GoalRoomTodoRequest 골룸_투두_요청2 = new GoalRoomTodoRequest("골룸 투두", 오늘, 십일_후);
         final List<GoalRoomRoadmapNodeRequest> 골룸_노드_별_기간_요청2 = List.of(
@@ -125,9 +125,9 @@ public class RoadmapSchedulerIntegrationTest extends InitIntegrationTest {
         final GoalRoomCreateRequest 골룸_생성_요청2 = new GoalRoomCreateRequest(로드맵_응답.roadmapId(), 정상적인_골룸_이름, 정상적인_골룸_제한_인원,
                 골룸_투두_요청2, 골룸_노드_별_기간_요청2);
 
-        final Long 골룸_아이디2 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청2, 기본_로그인_토큰);
+        final Long 골룸_아이디2 = 골룸을_생성하고_아이디를_반환한다(골룸_생성_요청2, 어드민_로그인_토큰);
 
-        로드맵_삭제(기본_로드맵_아이디, 기본_로그인_토큰);
+        로드맵_삭제(기본_로드맵_아이디, 어드민_로그인_토큰);
 
         testTransactionService.골룸의_상태와_종료날짜를_변경한다(골룸_아이디1, GoalRoomStatus.COMPLETED, 현재부터_3개월_1일_전);
         testTransactionService.골룸의_상태와_종료날짜를_변경한다(골룸_아이디2, GoalRoomStatus.COMPLETED, 오늘);

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapSearchIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapSearchIntegrationTest.java
@@ -24,17 +24,17 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵을_제목을_기준으로_검색한다() throws IOException {
         // given
-        로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapSaveRequest 세번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번쨰_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
         final RoadmapForListResponses 로드맵_리스트_응답 = 제목으로_최신순_정렬된_로드맵을_검색한다(10, "roadmap")
@@ -51,14 +51,14 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
     @Test
     void 로드맵을_크리에이터_닉네임_기준으로_검색한다() throws IOException {
         // given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
-        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(기본_로그인_토큰).as(new TypeRef<>() {
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
+        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(어드민_로그인_토큰).as(new TypeRef<>() {
         });
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
         final RoadmapForListResponses 로드맵_리스트_응답 = 크리에이터_닉네임으로_정렬된_로드맵을_생성한다(10, 사용자_정보.nickname())
@@ -77,17 +77,17 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
         // given
         final String 태그_이름 = "tag name";
 
-        로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        로드맵_생성(기본_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest(태그_이름)));
-        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 어드민_로그인_토큰);
         final RoadmapSaveRequest 세번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest(태그_이름)));
-        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번쨰_로드맵_생성_요청, 어드민_로그인_토큰);
 
         // when
         final RoadmapForListResponses 로드맵_리스트_응답 = 태그_이름으로_최신순_정렬된_로드맵을_검색한다(10, 태그_이름)

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/AuthenticationAPIFixture.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/AuthenticationAPIFixture.java
@@ -1,6 +1,8 @@
 package co.kirikiri.integration.fixture;
 
 import static co.kirikiri.integration.fixture.CommonFixture.API_PREFIX;
+import static co.kirikiri.integration.fixture.MemberAPIFixture.DEFAULT_ADMIN_IDENTIFIER;
+import static co.kirikiri.integration.fixture.MemberAPIFixture.DEFAULT_ADMIN_PASSWORD;
 import static co.kirikiri.integration.fixture.MemberAPIFixture.DEFAULT_IDENTIFIER;
 import static co.kirikiri.integration.fixture.MemberAPIFixture.DEFAULT_PASSWORD;
 import static io.restassured.RestAssured.given;
@@ -31,6 +33,11 @@ public class AuthenticationAPIFixture {
 
     public static AuthenticationResponse 기본_로그인() {
         final LoginRequest request = new LoginRequest(DEFAULT_IDENTIFIER, DEFAULT_PASSWORD);
+        return 로그인(request);
+    }
+
+    public static AuthenticationResponse 기본_어드민_로그인() {
+        final LoginRequest request = new LoginRequest(DEFAULT_ADMIN_IDENTIFIER, DEFAULT_ADMIN_PASSWORD);
         return 로그인(request);
     }
 

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/MemberAPIFixture.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/MemberAPIFixture.java
@@ -47,6 +47,23 @@ public class MemberAPIFixture {
         return 회원가입(회원가입_요청);
     }
 
+    public static Long 어드민_회원가입(final MemberJoinRequest 회원가입_요청) {
+        final Response 회원가입_응답 = 요청을_받는_어드민_회원가입(회원가입_요청).response();
+        final String Location_헤더 = 회원가입_응답.header("Location");
+        return Long.parseLong(Location_헤더.substring(13));
+    }
+
+    public static ExtractableResponse<Response> 요청을_받는_어드민_회원가입(final MemberJoinRequest 회원가입_요청) {
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .body(회원가입_요청)
+                .post(API_PREFIX + "/members/join/admin")
+                .then()
+                .log().all()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> 요청을_받는_사용자_자신의_정보_조회_요청(final String 액세스_토큰) {
         return given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/MemberAPIFixture.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/MemberAPIFixture.java
@@ -23,6 +23,10 @@ public class MemberAPIFixture {
     public static final String DEFAULT_PHONE_NUMBER = "010-1234-5678";
     public static final LocalDate DEFAULT_BIRTHDAY = LocalDate.of(2023, Month.JULY, 12);
     public static final GenderType DEFAULT_GENDER_TYPE = GenderType.MALE;
+    public static final String DEFAULT_ADMIN_IDENTIFIER = "admin1";
+    public static final String DEFAULT_ADMIN_PASSWORD = "admin1234!";
+    public static final String DEFAULT_ADMIN_NICKNAME = "admin";
+    public static final String DEFAULT_ADMIN_PHONE_NUMBER = "010-9876-5432";
 
     public static ExtractableResponse<Response> 요청을_받는_회원가입(final MemberJoinRequest 회원가입_요청) {
         return given().log().all()
@@ -47,7 +51,9 @@ public class MemberAPIFixture {
         return 회원가입(회원가입_요청);
     }
 
-    public static Long 어드민_회원가입(final MemberJoinRequest 회원가입_요청) {
+    public static Long 어드민_회원가입() {
+        final MemberJoinRequest 회원가입_요청 = new MemberJoinRequest(DEFAULT_ADMIN_IDENTIFIER, DEFAULT_ADMIN_PASSWORD,
+                DEFAULT_ADMIN_NICKNAME, DEFAULT_ADMIN_PHONE_NUMBER, DEFAULT_GENDER_TYPE, DEFAULT_BIRTHDAY);
         final Response 회원가입_응답 = 요청을_받는_어드민_회원가입(회원가입_요청).response();
         final String Location_헤더 = 회원가입_응답.header("Location");
         return Long.parseLong(Location_헤더.substring(13));

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/InitIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/InitIntegrationTest.java
@@ -1,8 +1,10 @@
 package co.kirikiri.integration.helper;
 
 import static co.kirikiri.integration.fixture.AuthenticationAPIFixture.기본_로그인;
+import static co.kirikiri.integration.fixture.AuthenticationAPIFixture.기본_어드민_로그인;
 import static co.kirikiri.integration.fixture.CommonFixture.BEARER_TOKEN_FORMAT;
 import static co.kirikiri.integration.fixture.MemberAPIFixture.기본_회원가입;
+import static co.kirikiri.integration.fixture.MemberAPIFixture.어드민_회원가입;
 
 import co.kirikiri.domain.roadmap.RoadmapCategory;
 import co.kirikiri.service.dto.roadmap.request.RoadmapDifficultyType;
@@ -15,7 +17,9 @@ import org.junit.jupiter.api.BeforeEach;
 public class InitIntegrationTest extends IntegrationTest {
 
     protected static Long 기본_회원_아이디;
+    protected static Long 어드민_회원_아이디;
     protected static String 기본_로그인_토큰;
+    protected static String 어드민_로그인_토큰;
     protected static String 기본_재발행_토큰;
     protected static RoadmapCategory 기본_카테고리;
     protected static RoadmapSaveRequest 기본_로드맵_생성_요청;
@@ -25,6 +29,8 @@ public class InitIntegrationTest extends IntegrationTest {
         기본_회원_아이디 = 기본_회원가입();
         기본_로그인_토큰 = String.format(BEARER_TOKEN_FORMAT, 기본_로그인().accessToken());
         기본_재발행_토큰 = 기본_로그인().refreshToken();
+        어드민_회원_아이디 = 어드민_회원가입();
+        어드민_로그인_토큰 = String.format(BEARER_TOKEN_FORMAT, 기본_어드민_로그인().accessToken());
         기본_카테고리 = testTransactionService.로드맵_카테고리를_저장한다("여행");
         기본_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "로드맵 제목", "로드맵 소개글",
                 "로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/AuthServiceTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/AuthServiceTest.java
@@ -67,9 +67,9 @@ class AuthServiceTest {
         final String refreshToken = "refreshToken";
         given(memberRepository.findByIdentifier(any()))
                 .willReturn(Optional.of(member));
-        given(tokenProvider.createAccessToken(any(), any()))
+        given(tokenProvider.createAccessToken(any(), any(), any()))
                 .willReturn(accessToken);
-        given(tokenProvider.createRefreshToken(any(), any()))
+        given(tokenProvider.createRefreshToken(any(), any(), any()))
                 .willReturn(refreshToken);
         given(tokenProvider.findTokenExpiredAt(anyString()))
                 .willReturn(LocalDateTime.now());
@@ -119,9 +119,9 @@ class AuthServiceTest {
                 .willReturn(true);
         given(refreshTokenRepository.findByTokenAndIsRevokedFalse(any()))
                 .willReturn(Optional.of(refreshToken));
-        given(tokenProvider.createAccessToken(any(), any()))
+        given(tokenProvider.createAccessToken(any(), any(), any()))
                 .willReturn(rawAccessToken);
-        given(tokenProvider.createRefreshToken(any(), any()))
+        given(tokenProvider.createRefreshToken(any(), any(), any()))
                 .willReturn(rawRefreshToken);
         given(tokenProvider.findTokenExpiredAt(anyString()))
                 .willReturn(LocalDateTime.now());

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/AuthServiceTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/AuthServiceTest.java
@@ -79,7 +79,7 @@ class AuthServiceTest {
         final AuthenticationResponse authenticationResponse = authService.login(loginRequest);
 
         //then
-        assertThat(authenticationResponse).isEqualTo(new AuthenticationResponse(refreshToken, accessToken));
+        assertThat(authenticationResponse).isEqualTo(new AuthenticationResponse(refreshToken, accessToken, false));
     }
 
     @Test
@@ -131,7 +131,8 @@ class AuthServiceTest {
         final AuthenticationResponse authenticationResponse = authService.reissueToken(reissueTokenRequest);
 
         //then
-        assertThat(authenticationResponse).isEqualTo(new AuthenticationResponse(rawRefreshToken, rawAccessToken));
+        assertThat(authenticationResponse).isEqualTo(
+                new AuthenticationResponse(rawRefreshToken, rawAccessToken, false));
     }
 
     @Test

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/AuthServiceTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/AuthServiceTest.java
@@ -12,6 +12,7 @@ import co.kirikiri.domain.member.EncryptedPassword;
 import co.kirikiri.domain.member.Gender;
 import co.kirikiri.domain.member.Member;
 import co.kirikiri.domain.member.MemberProfile;
+import co.kirikiri.domain.member.MemberRole;
 import co.kirikiri.domain.member.vo.Identifier;
 import co.kirikiri.domain.member.vo.Nickname;
 import co.kirikiri.domain.member.vo.Password;
@@ -179,5 +180,19 @@ class AuthServiceTest {
         //then
         assertThatThrownBy(() -> authService.reissueToken(reissueTokenRequest))
                 .isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void 어드민_권한을_가진_사용자인지_확인한다() {
+        // given
+        given(tokenProvider.findRole(any()))
+                .willReturn(MemberRole.ADMIN.name());
+
+        // when
+        final String token = "token";
+        final boolean result = authService.isAdminUser(token);
+
+        // then
+        assertThat(result).isTrue();
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/JwtTokenProviderTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/JwtTokenProviderTest.java
@@ -21,10 +21,11 @@ class JwtTokenProviderTest {
     void 정상적으로_subject와_claims를_포함한_ACCESS_TOKEN을_생성한다() {
         //given
         final String subject = "subject";
+        final String role = "role";
         final Map<String, Object> claims = new HashMap<>(Map.of("test1", "test1", "test2", "test2"));
 
         //when
-        final String accessToken = tokenProvider.createAccessToken(subject, claims);
+        final String accessToken = tokenProvider.createAccessToken(subject, role, claims);
 
         //then
         final Claims result = getClaims(accessToken);
@@ -42,10 +43,11 @@ class JwtTokenProviderTest {
     void 정상적으로_subject와_claims를_포함한_REFRESH_TOKEN을_생성한다() {
         //given
         final String subject = "subject";
+        final String role = "role";
         final Map<String, Object> claims = new HashMap<>(Map.of("test1", "test1", "test2", "test2"));
 
         //when
-        final String accessToken = tokenProvider.createRefreshToken(subject, claims);
+        final String accessToken = tokenProvider.createRefreshToken(subject, role, claims);
 
         //then
         final Claims result = getClaims(accessToken);
@@ -63,8 +65,9 @@ class JwtTokenProviderTest {
     void 정상적인_토큰의_유효성을_검사한다() {
         //given
         final String subject = "subject";
+        final String role = "role";
         final Map<String, Object> claims = new HashMap<>(Map.of("test1", "test1", "test2", "test2"));
-        final String accessToken = tokenProvider.createAccessToken(subject, claims);
+        final String accessToken = tokenProvider.createAccessToken(subject, role, claims);
 
         //when
         final boolean result = tokenProvider.isValidToken(accessToken);
@@ -77,9 +80,10 @@ class JwtTokenProviderTest {
     void 만료된_토큰의_유효성을_검사한다() {
         //given
         final String subject = "subject";
+        final String role = "role";
         final Map<String, Object> claims = new HashMap<>(Map.of("test1", "test1", "test2", "test2"));
         final TokenProvider tokenProvider = new JwtTokenProvider(secretKey, 0L, 0L);
-        final String accessToken = tokenProvider.createAccessToken(subject, claims);
+        final String accessToken = tokenProvider.createAccessToken(subject, role, claims);
 
         //when
         //then
@@ -113,13 +117,29 @@ class JwtTokenProviderTest {
     void 토큰에서_Subject를_가져온다() {
         //given
         final String subject = "subject";
+        final String role = "role";
         final Map<String, Object> claims = new HashMap<>(Map.of("test1", "test1", "test2", "test2"));
-        final String accessToken = tokenProvider.createAccessToken(subject, claims);
+        final String accessToken = tokenProvider.createAccessToken(subject, role, claims);
 
         //when
         final String result = tokenProvider.findSubject(accessToken);
 
         //then
         assertThat(result).isEqualTo(subject);
+    }
+
+    @Test
+    void 토큰에서_Role을_가져온다() {
+        //given
+        final String subject = "subject";
+        final String role = "role";
+        final Map<String, Object> claims = new HashMap<>(Map.of("test1", "test1", "test2", "test2"));
+        final String accessToken = tokenProvider.createAccessToken(subject, role, claims);
+
+        //when
+        final String result = tokenProvider.findRole(accessToken);
+
+        //then
+        assertThat(result).isEqualTo(role);
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/MemberServiceTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/MemberServiceTest.java
@@ -75,8 +75,37 @@ class MemberServiceTest {
                 .willReturn(7);
 
         //when
+        final boolean isAdmin = false;
+
         //then
-        assertThat(memberService.join(request))
+        assertThat(memberService.join(request, isAdmin))
+                .isEqualTo(1L);
+    }
+
+    @Test
+    void 어드민_역할로_회원가입을_한다() {
+        //given
+        final MemberJoinRequest request = new MemberJoinRequest("identifier1", "password1!", "nickname",
+                "010-1234-5678", GenderType.MALE, LocalDate.now());
+
+        given(memberRepository.findByIdentifier(any()))
+                .willReturn(Optional.empty());
+        given(memberRepository.save(any()))
+                .willReturn(new Member(1L, null, null, null, null, null));
+        given(environment.getProperty(IMAGE_DEFAULT_ORIGINAL_FILE_NAME_PROPERTY))
+                .willReturn("default-member-image");
+        given(environment.getProperty(IMAGE_DEFAULT_SERVER_FILE_PATH_PROPERTY))
+                .willReturn("https://blog.kakaocdn.net/dn/GHYFr/btrsSwcSDQV/UQZxkayGyAXrPACyf0MaV1/img.jpg");
+        given(environment.getProperty(IMAGE_DEFAULT_IMAGE_CONTENT_TYPE_PROPERTY))
+                .willReturn("JPG");
+        given(numberGenerator.generate())
+                .willReturn(7);
+
+        //when
+        final boolean isAdmin = true;
+
+        //then
+        assertThat(memberService.join(request, isAdmin))
                 .isEqualTo(1L);
     }
 
@@ -97,7 +126,7 @@ class MemberServiceTest {
 
         //when
         //then
-        assertThatThrownBy(() -> memberService.join(request))
+        assertThatThrownBy(() -> memberService.join(request, false))
                 .isInstanceOf(ConflictException.class);
     }
 
@@ -108,11 +137,11 @@ class MemberServiceTest {
                 "010-1234-5678", GenderType.MALE, LocalDate.now());
 
         given(memberRepository.findByNickname(any()))
-                .willReturn(Optional.of(new Member(null, null, null, null, null, null)));
+                .willReturn(Optional.of(new Member(null, null, new Nickname("nickname"), null, null)));
 
         //when
         //then
-        assertThatThrownBy(() -> memberService.join(request))
+        assertThatThrownBy(() -> memberService.join(request, false))
                 .isInstanceOf(ConflictException.class);
     }
 


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-183](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-183)


## ✨ 작업 내용
- 사용자를 어드민과 일반 사용자로 나누기 위해 `Member` 엔티티에 `role` 필드를 추가했습니다.
- 사용자 역할을 구분하기 위해 JWT에 role 정보를 추가했습니다. 
- 어드민 권한이 필요한 API를 구분하기 위해 `@AdminPermission` 어노테이션을 만들었습니다. 어드민 권한이 필요한 API 메서드 위에 붙여서 사용하시면 됩니다.
- 로드맵 생성 api를 어드민 권한으로 변경했습니다. 
- 어드민 계정으로 회원가입하기 위한 API를 따로 만들었습니다. (`/member/join/admin`)
- 로그인 시 기존에는 토큰 정보만 반환하는데, 어드민 계정인지 확인할 수 있는 `isAdmin` 필드를 추가했습니다.


## 💬 리뷰어에게 남길 멘트
- 두둠이 만드신 카테고리 생성 API는 머지할 때 어드민 권한으로 변경하겠습니다!
- API에 어노테이션 판별할 때, `AuthInterceptor`에서 모두 처리하는데, `@AdminPermission`이 붙은 메서드는 따로 `@Authenticated`을 붙이지 않도록 하기 위해서 로직이 중복되는데 딱히 처리할 방법이 없더라구요.. 메서드로 분리해서 재사용하면 되긴 한데 오히려 가독성이 안좋은 것 같아서 그냥 놔뒀습니다. 확인 부탁드려요! 
- 테이블에 role 컬럼을 추가하면서 flyway에 sql을 작성했는데요. flyway가 이미 존재하는 데이터에 값을 추가해주지는 않기 때문에, 일단 not null 제약조건을 붙이지 않았어요! 그래서 `Member` 엔티티에도 `nullable`하도록 했습니다. 기존 데이터에 role을 넣어준 뒤에 not null로 바꾸면 될 것 같은데 어떠신가요?!

## 🚀 요구사항 분석
- [x]  어드민 계정으로 회원가입하는 API 구현
    - [x]  Member 엔티티에 role 필드 추가
- [x]  JWT 토큰에 역할 정보 추가
- [x]  어드민 API용 어노테이션 만들기
    - [x]  로드맵 생성
    - [ ]  카테고리 생성 (머지하면서 하기)
- [x]  로그인 시 어드민 계정인지 boolean값 반환하기
- [x]  flyway 적용하기

