### PR TITLE
[feat/CK-188] accessToken 재발행 로직을 고친다

### DIFF
--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -109,11 +109,10 @@ module.exports = {
     'react/jsx-props-no-spreading': 'off',
     'import/no-unresolved': 'off',
     'import/order': 'off',
-    'react/jsx-no-constructed-context-values': 'off',
-    'react/jsx-props-no-spreading': 'off',
     'no-nested-ternary': 'off',
     'react/jsx-no-useless-fragment': 'off',
     'react/no-unescaped-entities': 'off',
     'no-else-return': 'off',
+    'consistent-return': 'off',
   },
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, Suspense, useContext, useEffect } from 'react';
+import { PropsWithChildren, Suspense, useEffect } from 'react';
 import { BrowserRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import theme from '@styles/theme';
 import GlobalStyle from '@styles/GlobalStyle';
@@ -17,7 +17,7 @@ import GoalRoomListPage from './pages/goalRoomListPage/GoalRoomListPage';
 import GoalRoomCreatePage from './pages/goalRoomCreatePage/GoalRoomCreatePage';
 import MyPage from '@pages/myPage/MyPage';
 import UserInfoProvider, {
-  userInfoContext,
+  useUserInfoContext,
 } from './components/_providers/UserInfoProvider';
 import RoadmapSearchResult from './components/roadmapListPage/roadmapSearch/RoadmapSearchResult';
 import MainPage from '@pages/mainPage/MainPage';
@@ -26,7 +26,7 @@ import useToast from '@hooks/_common/useToast';
 
 const PrivateRouter = (props: PropsWithChildren) => {
   const { children } = props;
-  const { userInfo } = useContext(userInfoContext);
+  const { userInfo } = useUserInfoContext();
   const { triggerToast } = useToast();
   const navigate = useNavigate();
 

--- a/client/src/utils/user/isValidUserInfo.ts
+++ b/client/src/utils/user/isValidUserInfo.ts
@@ -1,7 +1,12 @@
 import { UserInfoResponse } from '@myTypes/user/remote';
 
 const isValidUserInfo = (userInfo: UserInfoResponse): boolean => {
-  return Object.values(userInfo).every((value) => Boolean(value));
+  return Object.entries(userInfo).every(([key, value]) => {
+    if (key === 'email') {
+      return true;
+    }
+    return Boolean(value);
+  });
 };
 
 export default isValidUserInfo;


### PR DESCRIPTION
## 📌 작업 이슈 번호

ck-188


## ✨ 작업 내용

### 1. [isValidUserInfo.ts](https://github.com/woowacourse-teams/2023-co-kirikiri/compare/develop-client...feature/CK-188#diff-3208601679f59b3ce783136e07dd0fbaea5bbf5df777e2ab78ba5efc2b025392) 로직 개편

- 유저 정보를 서버에 요청하면 `email` 필드를 `null` 로 주더군요..! 로그인 확인이 갑자기 안되서 깜짝 놀라 급하게 수정했습니다!

### 2. [client.ts](https://github.com/woowacourse-teams/2023-co-kirikiri/compare/develop-client...feature/CK-188#diff-697346bba1451f3ffe776c5c52790917db30a36f3df360da4e4b6c4d89c8b3db) accessToken 재발행 로직 수정

- accessToken이 만료된 시점에 2개 이상의 요청이 실패한다면 `reissue` 를 2번 이상 요청하기에 발생하는 에러를 수정했습니다! 
  - 강의장에서 말한 재요청 로직을 돌려 성공한 결과입니다 (2번째의 reissue 요청이 실패하더라도 굴하지 않고 재요청을 보냅니다) :)

<img width="736" alt="KakaoTalk_Image_2023-09-13-02-04-02" src="https://github.com/woowacourse-teams/2023-co-kirikiri/assets/81363031/e7d85925-92c6-46bf-a19b-677bd73afb2a">




## 💬 리뷰어에게 남길 멘트

잘 부탁드림다


## 🚀 요구사항 분석

accessToken 재발행 로직 오류 수정

