### PR TITLE
[feat/CK-192] 툴팁 적용 및 골룸 개선

### DIFF
--- a/client/src/apis/axios/client.ts
+++ b/client/src/apis/axios/client.ts
@@ -51,8 +51,6 @@ client.interceptors.response.use(
           setCookie('access_token', data.accessToken);
           setCookie('refresh_token', data.refreshToken);
 
-          console.log(originalRequest, 'ORRRRRRRR');
-
           return client(originalRequest);
         } catch (reissueError) {
           const axiosError = reissueError as AxiosError<ErrorData>;

--- a/client/src/apis/axios/client.ts
+++ b/client/src/apis/axios/client.ts
@@ -11,9 +11,6 @@ export const BASE_URL = `${
 
 const client = axios.create({
   baseURL: BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
 });
 
 client.interceptors.request.use((config) => {
@@ -53,6 +50,8 @@ client.interceptors.response.use(
 
           setCookie('access_token', data.accessToken);
           setCookie('refresh_token', data.refreshToken);
+
+          console.log(originalRequest, 'ORRRRRRRR');
 
           return client(originalRequest);
         } catch (reissueError) {

--- a/client/src/components/_common/toolTip/ToolTip.styles.ts
+++ b/client/src/components/_common/toolTip/ToolTip.styles.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const ToolTip = styled.div`
   position: relative;
   display: inline-block;
+  box-sizing: border-box;
   width: 18px;
 `;
 
@@ -26,12 +27,14 @@ export const ToolTipButton = styled.button<{ isActive: boolean }>`
 export const ToolTipContent = styled.p<{ isShow: boolean }>`
   ${({ theme }) => theme.fonts.description4}
   position: absolute;
-  top: 150%;
+  top: 30px;
   left: 50%;
 
   width: 16rem;
   margin-left: -8rem;
   padding: 0.5rem;
+
+  z-index: ${({ theme }) => theme.zIndex.toolTip};
 
   color: ${({ theme }) => theme.colors.black};
   text-align: center;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/GoalRoomCertificationFeed.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/GoalRoomCertificationFeed.tsx
@@ -9,6 +9,7 @@ import {
   DialogTrigger,
 } from '@components/_common/dialog/dialog';
 import CertificationFeedModal from '@components/goalRoomDahsboardPage/goalRoomCertificationFeed/certificationFeedModal/CertificationFeedModal';
+import ToolTip from '@components/_common/toolTip/ToolTip';
 
 type GoalRoomCertificationFeedProps = {
   goalRoomData: GoalRoomBrowseResponse;
@@ -23,6 +24,11 @@ const GoalRoomCertificationFeed = ({ goalRoomData }: GoalRoomCertificationFeedPr
         <div>
           <S.CertificationTitleWrapper>
             <h2>인증 피드</h2>
+            <ToolTip>
+              <p>
+                인증피드는 하루에 한 번만 <br /> 등록할 수 있습니다.
+              </p>
+            </ToolTip>
           </S.CertificationTitleWrapper>
 
           <DialogTrigger asChild>

--- a/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/GoalRoomCertificationFeed.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/GoalRoomCertificationFeed.tsx
@@ -13,7 +13,6 @@ import CertificationFeedModal from '@components/goalRoomDahsboardPage/goalRoomCe
 type GoalRoomCertificationFeedProps = {
   goalRoomData: GoalRoomBrowseResponse;
 };
-// TODO: 사진 누르면 모달로 사진 크게 보여주기
 
 const GoalRoomCertificationFeed = ({ goalRoomData }: GoalRoomCertificationFeedProps) => {
   const { checkFeeds } = goalRoomData;
@@ -24,7 +23,6 @@ const GoalRoomCertificationFeed = ({ goalRoomData }: GoalRoomCertificationFeedPr
         <div>
           <S.CertificationTitleWrapper>
             <h2>인증 피드</h2>
-            <S.CertificationCountBox>{checkFeeds.length}</S.CertificationCountBox>
           </S.CertificationTitleWrapper>
 
           <DialogTrigger asChild>

--- a/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/certificationFeedModal/CertificationModal.styles.ts
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/certificationFeedModal/CertificationModal.styles.ts
@@ -6,8 +6,8 @@ import {
 import styled from 'styled-components';
 
 export const CertificationModalWrapper = styled(ModalWrapper)`
-  max-height: 80vh;
   overflow-y: scroll;
+  max-height: 80vh;
 `;
 
 export const CertificationHeader = styled(ModalHeader)``;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/certificationFeedModal/CertificationModal.styles.ts
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomCertificationFeed/certificationFeedModal/CertificationModal.styles.ts
@@ -5,7 +5,10 @@ import {
 } from '@components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal.styles';
 import styled from 'styled-components';
 
-export const CertificationModalWrapper = styled(ModalWrapper)``;
+export const CertificationModalWrapper = styled(ModalWrapper)`
+  max-height: 80vh;
+  overflow-y: scroll;
+`;
 
 export const CertificationHeader = styled(ModalHeader)``;
 
@@ -99,7 +102,6 @@ export const CertificationFeedsWrapper = styled.div`
 `;
 
 export const CertificationFeedCard = styled.div`
-  overflow: hidden;
   flex: 0 0 calc(33.33% - 1.5rem);
 
   width: 20rem;

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
@@ -9,6 +9,7 @@ import {
   DialogTrigger,
 } from '@components/_common/dialog/dialog';
 import TodoModal from '@components/goalRoomDahsboardPage/goalRoomDahsboardTodo/todoModal/TodoModal';
+import ToolTip from '@components/_common/toolTip/ToolTip';
 
 type GoalRoomDashboardTodoProps = {
   goalRoomData: GoalRoomBrowseResponse;
@@ -27,6 +28,9 @@ const GoalRoomDashboardTodo = ({
         <div>
           <S.TitleWrapper>
             <h2>투두 리스트</h2>
+            <ToolTip>
+              <p>모임 생성자만 투두리스트를 등록할 수 있습니다.</p>
+            </ToolTip>
           </S.TitleWrapper>
 
           <DialogTrigger asChild>

--- a/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomDahsboardTodo/GoalRoomDashboardTodo.tsx
@@ -27,7 +27,6 @@ const GoalRoomDashboardTodo = ({
         <div>
           <S.TitleWrapper>
             <h2>투두 리스트</h2>
-            <S.CountBox>{goalRoomTodos.length}</S.CountBox>
           </S.TitleWrapper>
 
           <DialogTrigger asChild>

--- a/client/src/components/goalRoomDahsboardPage/goalRoomUserRanking/GoalRoomUserRanking.tsx
+++ b/client/src/components/goalRoomDahsboardPage/goalRoomUserRanking/GoalRoomUserRanking.tsx
@@ -12,6 +12,7 @@ import {
 } from '@components/_common/dialog/dialog';
 import SVGIcon from '@components/icons/SVGIcon';
 import GoalRoomRankingModal from '@components/goalRoomDahsboardPage/goalRoomUserRanking/goalRoomRankingModal/GoalRoomRankingModal';
+import ToolTip from '@components/_common/toolTip/ToolTip';
 
 const GoalRoomUserRanking = () => {
   const { goalroomId } = useValidParams<GoalRoomDashboardContentParams>();
@@ -35,6 +36,11 @@ const GoalRoomUserRanking = () => {
       <S.CalenderWrapper>
         <div>
           <h2>골룸 유저 랭킹</h2>
+          <ToolTip>
+            <p>
+              인증 피드 개수를 기반으로 <br /> 랭킹이 측정됩니다.
+            </p>
+          </ToolTip>
 
           <DialogTrigger asChild>
             <button aria-labelledby='유저 랭킹 전체보기'>

--- a/client/src/hooks/queries/goalRoom.ts
+++ b/client/src/hooks/queries/goalRoom.ts
@@ -100,15 +100,16 @@ export const useCreateGoalRoom = (roadmapContentId: number) => {
 
 export const useCreateTodo = (goalRoomId: string) => {
   const queryClient = useQueryClient();
+  const { triggerToast } = useToast();
 
   const { mutate } = useMutation(
     (body: newTodoPayload) => postCreateNewTodo(goalRoomId, body),
     {
       onSuccess() {
-        queryClient.invalidateQueries([
-          [QUERY_KEYS.goalRoom.dashboard, goalRoomId],
-          [QUERY_KEYS.goalRoom.todos, goalRoomId],
-        ]);
+        queryClient.invalidateQueries([QUERY_KEYS.goalRoom.dashboard, goalRoomId]);
+        queryClient.invalidateQueries([QUERY_KEYS.goalRoom.todos, goalRoomId]);
+
+        triggerToast({ message: '새로운 투두리스트가 등록되었습니다.' });
       },
     }
   );

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -42,6 +42,7 @@ const theme: DefaultTheme = {
     navBarOverlay: 3,
     toast: 4,
     modal: 5,
+    toolTip: 6,
   },
 
   shadows: {


### PR DESCRIPTION
## 📌 작업 이슈 번호

CK-192

## ✨ 작업 내용

- 인증피드 모달 내부 스크롤 구현 
- 투두리스트 등록 시 invalidation 처리 정상화
- 골룸 항목들 (투두리스트, 인증피드) 전체 개수 표기 제거
- 툴팁 적용


## 💬 리뷰어에게 남길 멘트

잘 부탁드립니다!

## 🚀 요구사항 분석

- 인증피드 모달 내부 스크롤 구현 
- 투두리스트 등록 시 invalidation 처리 정상화
- 골룸 항목들 (투두리스트, 인증피드) 전체 개수 표기 제거
- 툴팁 적용

