### PR TITLE
[feat/CK-195] 노드 목록의 가시성 향상한다

### DIFF
--- a/client/src/components/roadmapDetailPage/roadmapNodeList/roadmapNodeList.styles.ts
+++ b/client/src/components/roadmapDetailPage/roadmapNodeList/roadmapNodeList.styles.ts
@@ -35,6 +35,7 @@ export const NodeIndicator = styled.div`
   ${({ theme }) => theme.fonts.nav_title}
   position: relative;
   left: 2rem;
+
   width: 4rem;
   height: 4rem;
 

--- a/client/src/components/roadmapDetailPage/roadmapNodeList/roadmapNodeList.styles.ts
+++ b/client/src/components/roadmapDetailPage/roadmapNodeList/roadmapNodeList.styles.ts
@@ -9,7 +9,7 @@ export const RoadmapNodeList = styled.div`
   width: 100%;
   min-height: 30rem;
   margin-top: 3rem;
-  padding-top: 2rem;
+  padding: 2rem 0;
 
   border-radius: 12px;
   box-shadow: ${({ theme }) => theme.shadows.box};
@@ -33,6 +33,8 @@ export const NodeItemContainer = styled.article`
 
 export const NodeIndicator = styled.div`
   ${({ theme }) => theme.fonts.nav_title}
+  position: relative;
+  left: 2rem;
   width: 4rem;
   height: 4rem;
 
@@ -53,11 +55,9 @@ export const NodeContent = styled.div`
   align-items: center;
 
   width: 50rem;
-  height: 15rem;
   padding: 2rem 0;
 
   border: 0.3rem solid ${({ theme }) => theme.colors.main_dark};
-  border-left: none;
   border-radius: 30px;
 `;
 


### PR DESCRIPTION
## 📌 작업 이슈 번호
CK-195


## ✨ 작업 내용
- 노드 목록의 컨텐츠를 한번에 보여주는 것으로 가시성을 향상한다
<img width="753" alt="image" src="https://github.com/woowacourse-teams/2023-co-kirikiri/assets/88191233/da9dd57f-25a6-4acc-b818-655ec13554fc">


## 💬 리뷰어에게 남길 멘트
잘 부탁드립니다!!


## 🚀 요구사항 분석
- 노드 목록의 가시성 향상

