### PR TITLE
[hotfix/CK-208] 마이 페이지에 이메일을 도출한다

### DIFF
--- a/client/src/components/_providers/UserInfoProvider.tsx
+++ b/client/src/components/_providers/UserInfoProvider.tsx
@@ -9,6 +9,7 @@ export const defaultUserInfo: UserInfoResponse = {
   profileImageUrl: '',
   gender: null,
   identifier: '',
+  email: '',
 };
 
 export const userInfoContext = createContext<UserInfoContextType>({

--- a/client/src/components/myPage/myPageUserInfo/MyPageUserInfo.tsx
+++ b/client/src/components/myPage/myPageUserInfo/MyPageUserInfo.tsx
@@ -16,6 +16,7 @@ const MyPageUserInfo = () => {
           <h2>{userInfo.nickname}</h2>
         </S.UserNickname>
         <S.UserIdentifier>@ {userInfo.identifier}</S.UserIdentifier>
+        <S.UserIdentifier>{userInfo.email}</S.UserIdentifier>
       </S.UserDetails>
     </S.UserInfoWrapper>
   );

--- a/client/src/hooks/_common/useIdentifyUser.ts
+++ b/client/src/hooks/_common/useIdentifyUser.ts
@@ -9,6 +9,7 @@ export const defaultUserInfo: UserInfoResponse = {
   profileImageUrl: '',
   gender: null,
   identifier: '',
+  email: '',
 };
 
 export const useIdentifyUser = () => {

--- a/client/src/myTypes/user/remote.ts
+++ b/client/src/myTypes/user/remote.ts
@@ -31,4 +31,5 @@ export type UserInfoResponse = {
   profileImageUrl: string;
   gender: UserGender | null;
   identifier: string;
+  email: string;
 };

--- a/client/src/tests/utilTests/isValidUserInfo.test.ts
+++ b/client/src/tests/utilTests/isValidUserInfo.test.ts
@@ -9,6 +9,7 @@ describe('사용자 정보 검증', () => {
       profileImageUrl: 'http://example.com/profile.jpg',
       gender: 'MALE',
       identifier: 'test',
+      email: 'NONE',
     };
 
     expect(isValidUserInfo(userInfo)).toBe(true);
@@ -21,6 +22,7 @@ describe('사용자 정보 검증', () => {
       profileImageUrl: 'http://example.com/profile.jpg',
       gender: null,
       identifier: '',
+      email: '',
     };
 
     expect(isValidUserInfo(userInfo)).toBe(false);


### PR DESCRIPTION
## 📌 작업 이슈 번호

ck-208

## ✨ 작업 내용

- `/me` response type 에 이메일 필드를 추가했습니다!
- 마이 페이지에 이메일을 도출 할 수 있도록 했습니다!

## 💬 리뷰어에게 남길 멘트


잘 부탁드려요~



## 🚀 요구사항 분석

- `/me` response type 에 이메일 필드 추가
- 마이 페이지에 이메일을 도출 
