### PR TITLE
[feat/CK-202] 태그 및 크리에이터로 로드맵을 검색할 때 규칙을 수정한다

### DIFF
--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapTags.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapTags.java
@@ -61,10 +61,4 @@ public class RoadmapTags {
     public Set<RoadmapTag> getValues() {
         return new HashSet<>(values);
     }
-
-    public List<RoadmapTag> findTagByName(final String tagName) {
-        return values.stream()
-                .filter(tag -> tag.getName().getValue().contains(tagName))
-                .toList();
-    }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapTags.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapTags.java
@@ -61,4 +61,10 @@ public class RoadmapTags {
     public Set<RoadmapTag> getValues() {
         return new HashSet<>(values);
     }
+
+    public List<RoadmapTag> findTagByName(final String tagName) {
+        return values.stream()
+                .filter(tag -> tag.getName().getValue().contains(tagName))
+                .toList();
+    }
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapTags.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/domain/roadmap/RoadmapTags.java
@@ -7,12 +7,13 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,6 +25,7 @@ public class RoadmapTags {
             cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
             orphanRemoval = true)
     @JoinColumn(name = "roadmap_id", updatable = false, nullable = false)
+    @BatchSize(size = 20)
     private final Set<RoadmapTag> values = new HashSet<>();
 
     public RoadmapTags(final List<RoadmapTag> roadmapTags) {

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapQueryRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapQueryRepository.java
@@ -19,9 +19,7 @@ public interface RoadmapQueryRepository {
                                          final int pageSize);
 
     List<Roadmap> findRoadmapsByCond(final RoadmapSearchDto searchRequest,
-                                     final RoadmapOrderType orderType,
-                                     final Long lastId,
-                                     final int pageSize);
+                                     final RoadmapOrderType orderType);
 
     List<Roadmap> findRoadmapsWithCategoryByMemberOrderByLatest(final Member member,
                                                                 final Long lastId,

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapQueryRepositoryImpl.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapQueryRepositoryImpl.java
@@ -72,23 +72,17 @@ public class RoadmapQueryRepositoryImpl extends QuerydslRepositorySupporter impl
     }
 
     @Override
-    public List<Roadmap> findRoadmapsByCond(final RoadmapSearchDto searchRequest, final RoadmapOrderType orderType,
-                                            final Long lastId, final int pageSize) {
+    public List<Roadmap> findRoadmapsByCond(final RoadmapSearchDto searchRequest, final RoadmapOrderType orderType) {
         return selectFrom(roadmap)
                 .innerJoin(roadmap.category, roadmapCategory)
                 .fetchJoin()
                 .innerJoin(roadmap.creator, member)
                 .fetchJoin()
-                .leftJoin(roadmap.tags.values, roadmapTag)
-                .fetchJoin()
-                .where(
-                        lessThanLastId(lastId, orderType),
-                        statusCond(RoadmapStatus.CREATED),
+                .where(statusCond(RoadmapStatus.CREATED),
                         titleCond(searchRequest.getTitle()),
-                        creatorNicknameCond(searchRequest.getCreatorName()),
-                        tagCond(searchRequest.getTagName()))
-                .limit(pageSize + LIMIT_OFFSET)
-                .orderBy(sortCond(orderType))
+                        tagCond(searchRequest.getTagName()),
+                        creatorNicknameCond(searchRequest.getCreatorName()))
+                .orderBy(sortCond(RoadmapOrderType.LATEST))
                 .fetch();
     }
 

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapQueryRepositoryImpl.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapQueryRepositoryImpl.java
@@ -46,6 +46,7 @@ public class RoadmapQueryRepositoryImpl extends QuerydslRepositorySupporter impl
                 .innerJoin(roadmap.category, roadmapCategory)
                 .fetchJoin()
                 .leftJoin(roadmap.tags.values, roadmapTag)
+                .fetchJoin()
                 .where(roadmapCond(roadmapId))
                 .fetchOne());
     }
@@ -60,6 +61,7 @@ public class RoadmapQueryRepositoryImpl extends QuerydslRepositorySupporter impl
                 .innerJoin(roadmap.creator, member)
                 .fetchJoin()
                 .leftJoin(roadmap.tags.values, roadmapTag)
+                .fetchJoin()
                 .where(
                         lessThanLastId(lastId, orderType),
                         statusCond(RoadmapStatus.CREATED),
@@ -78,6 +80,7 @@ public class RoadmapQueryRepositoryImpl extends QuerydslRepositorySupporter impl
                 .innerJoin(roadmap.creator, member)
                 .fetchJoin()
                 .leftJoin(roadmap.tags.values, roadmapTag)
+                .fetchJoin()
                 .where(
                         lessThanLastId(lastId, orderType),
                         statusCond(RoadmapStatus.CREATED),

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapQueryRepositoryImpl.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/roadmap/RoadmapQueryRepositoryImpl.java
@@ -159,7 +159,7 @@ public class RoadmapQueryRepositoryImpl extends QuerydslRepositorySupporter impl
         if (creatorName == null) {
             return null;
         }
-        return roadmap.creator.nickname.value.eq(creatorName.value());
+        return roadmap.creator.nickname.value.startsWith(creatorName.value());
     }
 
     private BooleanExpression tagCond(final RoadmapSearchTagName tagName) {
@@ -169,7 +169,7 @@ public class RoadmapQueryRepositoryImpl extends QuerydslRepositorySupporter impl
         return roadmap.tags.values
                 .any()
                 .name.value
-                .equalsIgnoreCase(tagName.value());
+                .startsWithIgnoreCase(tagName.value());
     }
 
     private OrderSpecifier<?> sortCond(final RoadmapOrderType orderType) {

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapCreateService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapCreateService.java
@@ -60,7 +60,6 @@ public class RoadmapCreateService {
         final RoadmapSaveDto roadmapSaveDto = RoadmapMapper.convertToRoadmapSaveDto(request);
         final Roadmap roadmap = createRoadmap(member, roadmapSaveDto, roadmapCategory);
         final Roadmap savedRoadmap = roadmapRepository.save(roadmap);
-
         applicationEventPublisher.publishEvent(new RoadmapCreateEvent(savedRoadmap, roadmapSaveDto));
 
         return savedRoadmap.getId();

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapReadService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapReadService.java
@@ -190,10 +190,9 @@ public class RoadmapReadService {
         final RoadmapOrderType orderType = RoadmapMapper.convertRoadmapOrderType(orderTypeRequest);
         final RoadmapSearchDto roadmapSearchDto = RoadmapSearchDto.create(
                 searchRequest.creatorName(), searchRequest.roadmapTitle(), searchRequest.tagName());
-        final List<Roadmap> roadmaps = roadmapRepository.findRoadmapsByCond(roadmapSearchDto, orderType,
-                scrollRequest.lastId(), scrollRequest.size());
+        final List<Roadmap> roadmaps = roadmapRepository.findRoadmapsByCond(roadmapSearchDto, orderType);
 
-        // 정렬
+        // todo: scrollRequest.lastId(), scrollRequest.size()만큼 정렬
 
         final RoadmapForListScrollDto roadmapForListScrollDto = makeRoadmapForListScrollDto(roadmaps,
                 scrollRequest.size());

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapReadService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/RoadmapReadService.java
@@ -192,6 +192,9 @@ public class RoadmapReadService {
                 searchRequest.creatorName(), searchRequest.roadmapTitle(), searchRequest.tagName());
         final List<Roadmap> roadmaps = roadmapRepository.findRoadmapsByCond(roadmapSearchDto, orderType,
                 scrollRequest.lastId(), scrollRequest.size());
+
+        // 정렬
+
         final RoadmapForListScrollDto roadmapForListScrollDto = makeRoadmapForListScrollDto(roadmaps,
                 scrollRequest.size());
         return RoadmapMapper.convertRoadmapResponses(roadmapForListScrollDto);

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadIntegrationTest.java
@@ -62,34 +62,6 @@ class RoadmapReadIntegrationTest extends InitIntegrationTest {
     }
 
     @Test
-    void 여러개의_태그를_가지는_로드맵_생성_요청을_성공한다() throws IOException {
-        //given
-        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
-        final RoadmapSaveRequest 다른_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "다른 로드맵 제목", "다른 로드맵 소개글",
-                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
-                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
-                List.of(new RoadmapTagSaveRequest("다른 태그1"),
-                        new RoadmapTagSaveRequest("다른 태그2"),
-                        new RoadmapTagSaveRequest("다른 태그3")));
-        로드맵_생성(다른_로드맵_생성_요청, 기본_로그인_토큰);
-
-        //when
-        final ExtractableResponse<Response> 단일_로드맵_조회_요청에_대한_응답 = 로드맵을_아이디로_조회한다(기본_로드맵_아이디);
-
-        //then
-        final RoadmapResponse 단일_로드맵_응답 = 단일_로드맵_조회_요청에_대한_응답.as(new TypeRef<>() {
-        });
-
-        assertAll(
-                () -> assertThat(단일_로드맵_조회_요청에_대한_응답.statusCode())
-                        .isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(단일_로드맵_응답.roadmapId())
-                        .isEqualTo(기본_로드맵_아이디),
-                () -> assertThat(단일_로드맵_응답.tags()).hasSize(3)
-        );
-    }
-
-    @Test
     void 존재하지_않는_로드맵_아이디로_요청했을_때_조회를_실패한다() {
         //given
         final Long 존재하지_않는_로드맵_아이디 = 1L;
@@ -156,9 +128,9 @@ class RoadmapReadIntegrationTest extends InitIntegrationTest {
 
         // then
         assertThat(로드맵_리스트_응답.hasNext()).isFalse();
-        assertThat(로드맵_리스트_응답.responses().size()).isEqualTo(10);
+        assertThat(로드맵_리스트_응답.responses()).hasSize(10);
         for (final RoadmapForListResponse response : 로드맵_리스트_응답.responses()) {
-            assertThat(response.tags().size()).isEqualTo(3);
+            assertThat(response.tags()).hasSize(3);
         }
     }
 

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadIntegrationTest.java
@@ -28,10 +28,10 @@ import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 import java.io.IOException;
 import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 class RoadmapReadIntegrationTest extends InitIntegrationTest {
 
@@ -57,6 +57,34 @@ class RoadmapReadIntegrationTest extends InitIntegrationTest {
                         .isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(단일_로드맵_응답.roadmapId())
                         .isEqualTo(기본_로드맵_아이디)
+        );
+    }
+
+    @Test
+    void 여러개의_태그를_가지는_로드맵_생성_요청을_성공한다() throws IOException {
+        //given
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final RoadmapSaveRequest 다른_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "다른 로드맵 제목", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest("다른 태그1"),
+                        new RoadmapTagSaveRequest("다른 태그2"),
+                        new RoadmapTagSaveRequest("다른 태그3")));
+        로드맵_생성(다른_로드맵_생성_요청, 기본_로그인_토큰);
+
+        //when
+        final ExtractableResponse<Response> 단일_로드맵_조회_요청에_대한_응답 = 로드맵을_아이디로_조회한다(기본_로드맵_아이디);
+
+        //then
+        final RoadmapResponse 단일_로드맵_응답 = 단일_로드맵_조회_요청에_대한_응답.as(new TypeRef<>() {
+        });
+
+        assertAll(
+                () -> assertThat(단일_로드맵_조회_요청에_대한_응답.statusCode())
+                        .isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(단일_로드맵_응답.roadmapId())
+                        .isEqualTo(기본_로드맵_아이디),
+                () -> assertThat(단일_로드맵_응답.tags()).hasSize(3)
         );
     }
 

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadOrderIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadOrderIntegrationTest.java
@@ -114,6 +114,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
 
         // when
+        System.out.println("여기서부터");
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_카테고리별_로드맵_리스트_조회(RoadmapOrderType.REVIEW_RATE, 기본_카테고리.getId(),
                 10)
                 .response()
@@ -153,6 +154,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
 
         // when
+        System.out.println("여기서부터");
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_카테고리별_로드맵_리스트_조회(RoadmapOrderType.GOAL_ROOM_COUNT,
                 기본_카테고리.getId(), 10)
                 .response()
@@ -195,6 +197,7 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
 
         // when
+        System.out.println("여기서부터");
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_카테고리별_로드맵_리스트_조회(RoadmapOrderType.PARTICIPANT_COUNT,
                 기본_카테고리.getId(), 10)
                 .response()

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadOrderIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapReadOrderIntegrationTest.java
@@ -114,7 +114,6 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
 
         // when
-        System.out.println("여기서부터");
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_카테고리별_로드맵_리스트_조회(RoadmapOrderType.REVIEW_RATE, 기본_카테고리.getId(),
                 10)
                 .response()
@@ -154,7 +153,6 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
 
         // when
-        System.out.println("여기서부터");
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_카테고리별_로드맵_리스트_조회(RoadmapOrderType.GOAL_ROOM_COUNT,
                 기본_카테고리.getId(), 10)
                 .response()
@@ -197,7 +195,6 @@ class RoadmapReadOrderIntegrationTest extends InitIntegrationTest {
         로드맵_생성(세번째_로드맵_생성_요청, 기본_로그인_토큰);
 
         // when
-        System.out.println("여기서부터");
         final RoadmapForListResponses 로드맵_리스트_응답 = 정렬된_카테고리별_로드맵_리스트_조회(RoadmapOrderType.PARTICIPANT_COUNT,
                 기본_카테고리.getId(), 10)
                 .response()

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapSearchIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapSearchIntegrationTest.java
@@ -7,10 +7,14 @@ import static co.kirikiri.integration.fixture.MemberAPIFixture.DEFAULT_NICKNAME;
 import static co.kirikiri.integration.fixture.MemberAPIFixture.요청을_받는_사용자_자신의_정보_조회_요청;
 import static co.kirikiri.integration.fixture.MemberAPIFixture.회원가입;
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.로드맵_생성;
+import static co.kirikiri.integration.fixture.RoadmapAPIFixture.이전_검색_결과를_전달받아_제목으로_최신순_정렬된_로드맵을_검색한다;
+import static co.kirikiri.integration.fixture.RoadmapAPIFixture.이전_검색_결과를_전달받아_크리에이터_닉네임으로_정렬된_로드맵을_검색한다;
+import static co.kirikiri.integration.fixture.RoadmapAPIFixture.이전_검색_결과를_전달받아_태그_이름으로_최신순_정렬된_로드맵을_검색한다;
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.제목으로_최신순_정렬된_로드맵을_검색한다;
-import static co.kirikiri.integration.fixture.RoadmapAPIFixture.크리에이터_닉네임으로_정렬된_로드맵을_생성한다;
+import static co.kirikiri.integration.fixture.RoadmapAPIFixture.크리에이터_닉네임으로_정렬된_로드맵을_검색한다;
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.태그_이름으로_최신순_정렬된_로드맵을_검색한다;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import co.kirikiri.integration.helper.InitIntegrationTest;
 import co.kirikiri.service.dto.auth.request.LoginRequest;
@@ -23,9 +27,9 @@ import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
 import co.kirikiri.service.dto.roadmap.request.RoadmapTagSaveRequest;
 import co.kirikiri.service.dto.roadmap.response.RoadmapForListResponses;
 import io.restassured.common.mapper.TypeRef;
-import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.List;
+import org.junit.jupiter.api.Test;
 
 class RoadmapSearchIntegrationTest extends InitIntegrationTest {
 
@@ -38,6 +42,7 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest("다른 태그1")));
         final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+
         final RoadmapSaveRequest 세번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
@@ -57,6 +62,44 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
     }
 
     @Test
+    void 이전_검색때_마지막으로_조회된_로드맵_아이디를_전달하여_로드맵을_제목을_기준으로_검색한다() throws IOException {
+        // given
+        로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest("다른 태그1")));
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+
+        final RoadmapSaveRequest 세번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest("다른 태그1")));
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+
+        // when
+        final RoadmapForListResponses 첫번째_로드맵_리스트_응답 = 제목으로_최신순_정렬된_로드맵을_검색한다(1, "roadmap")
+                .response()
+                .as(new TypeRef<>() {
+                });
+
+        final RoadmapForListResponses 두번째_로드맵_리스트_응답 = 이전_검색_결과를_전달받아_제목으로_최신순_정렬된_로드맵을_검색한다(
+                1, 첫번째_로드맵_리스트_응답.responses().get(0).roadmapId(), "roadmap")
+                .response()
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertAll(
+                () -> assertThat(첫번째_로드맵_리스트_응답.hasNext()).isTrue(),
+                () -> assertThat(첫번째_로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(세번째_로드맵_아이디),
+
+                () -> assertThat(두번째_로드맵_리스트_응답.hasNext()).isFalse(),
+                () -> assertThat(두번째_로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(두번째_로드맵_아이디)
+        );
+    }
+
+    @Test
     void 로드맵을_크리에이터_닉네임_기준으로_검색한다() throws IOException {
         // given
         final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
@@ -69,7 +112,7 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
         final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
 
         // when
-        final RoadmapForListResponses 로드맵_리스트_응답 = 크리에이터_닉네임으로_정렬된_로드맵을_생성한다(10, 사용자_정보.nickname())
+        final RoadmapForListResponses 로드맵_리스트_응답 = 크리에이터_닉네임으로_정렬된_로드맵을_검색한다(10, 사용자_정보.nickname())
                 .response()
                 .as(new TypeRef<>() {
                 });
@@ -84,16 +127,20 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
     void 크리에이터_닉네입_기준으로_로드맵_검색_시_크리에이터명이_검색어로_시작하는_모든_로드맵을_조회한다() throws IOException {
         // given
         final MemberJoinRequest 닉네임_시작이_다른_회원_가입_요청 = new MemberJoinRequest("identifier3", "paswword3#",
-                "a"+DEFAULT_NICKNAME, GenderType.MALE, DEFAULT_EMAIL);
-        final LoginRequest 닉네임_시작이_다른_사용자_로그인_요청 = new LoginRequest(닉네임_시작이_다른_회원_가입_요청.identifier(), 닉네임_시작이_다른_회원_가입_요청.password());
+                "a" + DEFAULT_NICKNAME, GenderType.MALE, DEFAULT_EMAIL);
+        final LoginRequest 닉네임_시작이_다른_사용자_로그인_요청 = new LoginRequest(닉네임_시작이_다른_회원_가입_요청.identifier(),
+                닉네임_시작이_다른_회원_가입_요청.password());
         회원가입(닉네임_시작이_다른_회원_가입_요청);
-        final String 닉네임_시작이_다른_사용자_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(닉네임_시작이_다른_사용자_로그인_요청).accessToken());
+        final String 닉네임_시작이_다른_사용자_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT,
+                로그인(닉네임_시작이_다른_사용자_로그인_요청).accessToken());
 
         final MemberJoinRequest 닉네임_시작이_같은_사용자_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
-                DEFAULT_NICKNAME+"a", GenderType.FEMALE, DEFAULT_EMAIL);
-        final LoginRequest 닉네임_시작이_같은_사용자_로그인_요청 = new LoginRequest(닉네임_시작이_같은_사용자_회원_가입_요청.identifier(), 닉네임_시작이_같은_사용자_회원_가입_요청.password());
+                DEFAULT_NICKNAME + "a", GenderType.FEMALE, DEFAULT_EMAIL);
+        final LoginRequest 닉네임_시작이_같은_사용자_로그인_요청 = new LoginRequest(닉네임_시작이_같은_사용자_회원_가입_요청.identifier(),
+                닉네임_시작이_같은_사용자_회원_가입_요청.password());
         회원가입(닉네임_시작이_같은_사용자_회원_가입_요청);
-        final String 닉네임_시작이_같은_사용자_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(닉네임_시작이_같은_사용자_로그인_요청).accessToken());
+        final String 닉네임_시작이_같은_사용자_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT,
+                로그인(닉네임_시작이_같은_사용자_로그인_요청).accessToken());
 
         final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
 
@@ -110,16 +157,49 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
         final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 닉네임_시작이_같은_사용자_액세스_토큰);
 
         // when
-        final RoadmapForListResponses 로드맵_리스트_응답 = 크리에이터_닉네임으로_정렬된_로드맵을_생성한다(6, DEFAULT_NICKNAME)
+        final RoadmapForListResponses 로드맵_리스트_응답 = 크리에이터_닉네임으로_정렬된_로드맵을_검색한다(6, DEFAULT_NICKNAME)
                 .response()
                 .as(new TypeRef<>() {
                 });
 
         // then
         assertThat(로드맵_리스트_응답.hasNext()).isFalse();
-        assertThat(로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(세번째_로드맵_아이디);
-        assertThat(로드맵_리스트_응답.responses().get(1).roadmapId()).isEqualTo(기본_로드맵_아이디);
+        assertThat(로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(기본_로드맵_아이디);
+        assertThat(로드맵_리스트_응답.responses().get(1).roadmapId()).isEqualTo(세번째_로드맵_아이디);
+    }
 
+    @Test
+    void 이전_검색때_마지막으로_조회된_로드맵_아이디를_전달하여_로드맵을_크리에이터_닉네임_기준으로_검색한다() throws IOException {
+        // given
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+        final MemberInformationResponse 사용자_정보 = 요청을_받는_사용자_자신의_정보_조회_요청(기본_로그인_토큰).as(new TypeRef<>() {
+        });
+        final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest("다른 태그1")));
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+
+        // when
+        final RoadmapForListResponses 첫번째_로드맵_리스트_응답 = 크리에이터_닉네임으로_정렬된_로드맵을_검색한다(1, 사용자_정보.nickname())
+                .response()
+                .as(new TypeRef<>() {
+                });
+
+        final RoadmapForListResponses 두번째_로드맵_리스트_응답 = 이전_검색_결과를_전달받아_크리에이터_닉네임으로_정렬된_로드맵을_검색한다(
+                1, 첫번째_로드맵_리스트_응답.responses().get(0).roadmapId(), 사용자_정보.nickname())
+                .response()
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertAll(
+                () -> assertThat(첫번째_로드맵_리스트_응답.hasNext()).isTrue(),
+                () -> assertThat(첫번째_로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(두번째_로드맵_아이디),
+
+                () -> assertThat(두번째_로드맵_리스트_응답.hasNext()).isFalse(),
+                () -> assertThat(두번째_로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(기본_로드맵_아이디)
+        );
     }
 
     @Test
@@ -133,6 +213,7 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
                 List.of(new RoadmapTagSaveRequest(태그_이름)));
         final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+
         final RoadmapSaveRequest 세번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
@@ -158,10 +239,17 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
 
         로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
 
+        final RoadmapSaveRequest 첫번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest(태그_이름 + "eq")));
+        final Long 첫번째_로드맵_아이디 = 로드맵_생성(첫번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+
         final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
                 "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
                 List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
-                List.of(new RoadmapTagSaveRequest(태그_이름)));
+                List.of(new RoadmapTagSaveRequest(태그_이름),
+                        new RoadmapTagSaveRequest("testTag")));
         final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
 
         final RoadmapSaveRequest 세번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
@@ -183,15 +271,79 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
         로드맵_생성(다섯번쨰_로드맵_생성_요청, 기본_로그인_토큰);
 
         // when
-        final RoadmapForListResponses 로드맵_리스트_응답 = 태그_이름으로_최신순_정렬된_로드맵을_검색한다(6, 태그_이름)
+        final RoadmapForListResponses 첫번째_로드맵_리스트_응답 = 태그_이름으로_최신순_정렬된_로드맵을_검색한다(4, 태그_이름)
                 .response()
                 .as(new TypeRef<>() {
                 });
 
         // then
-        assertThat(로드맵_리스트_응답.hasNext()).isFalse();
-        assertThat(로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(네번째_로드맵_아이디);
-        assertThat(로드맵_리스트_응답.responses().get(1).roadmapId()).isEqualTo(세번째_로드맵_아이디);
-        assertThat(로드맵_리스트_응답.responses().get(2).roadmapId()).isEqualTo(두번째_로드맵_아이디);
+        assertThat(첫번째_로드맵_리스트_응답.hasNext()).isFalse();
+        assertThat(첫번째_로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(세번째_로드맵_아이디);
+        assertThat(첫번째_로드맵_리스트_응답.responses().get(1).roadmapId()).isEqualTo(두번째_로드맵_아이디);
+        assertThat(첫번째_로드맵_리스트_응답.responses().get(2).roadmapId()).isEqualTo(네번째_로드맵_아이디);
+        assertThat(첫번째_로드맵_리스트_응답.responses().get(3).roadmapId()).isEqualTo(첫번째_로드맵_아이디);
+    }
+
+    @Test
+    void 이전_검색때_마지막으로_조회된_로드맵_아이디를_전달하여_로드맵을_태그_기준으로_검색한다() throws IOException {
+        // given
+        final String 태그_이름 = "java";
+
+        로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+
+        final RoadmapSaveRequest 첫번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest(태그_이름 + "eq")));
+        final Long 첫번째_로드맵_아이디 = 로드맵_생성(첫번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+
+        final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest(태그_이름),
+                        new RoadmapTagSaveRequest("testTag")));
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+
+        final RoadmapSaveRequest 세번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest(태그_이름)));
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+
+        final RoadmapSaveRequest 네번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest(태그_이름 + "왕")));
+        final Long 네번째_로드맵_아이디 = 로드맵_생성(네번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+
+        final RoadmapSaveRequest 다섯번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest("왕" + 태그_이름)));
+        로드맵_생성(다섯번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+
+        // when
+        final RoadmapForListResponses 첫번째_로드맵_리스트_응답 = 태그_이름으로_최신순_정렬된_로드맵을_검색한다(3, 태그_이름)
+                .response()
+                .as(new TypeRef<>() {
+                });
+
+        final RoadmapForListResponses 두번째_로드맵_리스트_응답 = 이전_검색_결과를_전달받아_태그_이름으로_최신순_정렬된_로드맵을_검색한다(
+                3, 첫번째_로드맵_리스트_응답.responses().get(2).roadmapId(), 태그_이름)
+                .response()
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertAll(
+                () -> assertThat(첫번째_로드맵_리스트_응답.hasNext()).isTrue(),
+                () -> assertThat(첫번째_로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(세번째_로드맵_아이디),
+                () -> assertThat(첫번째_로드맵_리스트_응답.responses().get(1).roadmapId()).isEqualTo(두번째_로드맵_아이디),
+                () -> assertThat(첫번째_로드맵_리스트_응답.responses().get(2).roadmapId()).isEqualTo(네번째_로드맵_아이디),
+
+                () -> assertThat(두번째_로드맵_리스트_응답.hasNext()).isFalse(),
+                () -> assertThat(두번째_로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(첫번째_로드맵_아이디)
+        );
+
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapSearchIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/RoadmapSearchIntegrationTest.java
@@ -1,6 +1,11 @@
 package co.kirikiri.integration;
 
+import static co.kirikiri.integration.fixture.AuthenticationAPIFixture.로그인;
+import static co.kirikiri.integration.fixture.CommonFixture.BEARER_TOKEN_FORMAT;
+import static co.kirikiri.integration.fixture.MemberAPIFixture.DEFAULT_EMAIL;
+import static co.kirikiri.integration.fixture.MemberAPIFixture.DEFAULT_NICKNAME;
 import static co.kirikiri.integration.fixture.MemberAPIFixture.요청을_받는_사용자_자신의_정보_조회_요청;
+import static co.kirikiri.integration.fixture.MemberAPIFixture.회원가입;
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.로드맵_생성;
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.제목으로_최신순_정렬된_로드맵을_검색한다;
 import static co.kirikiri.integration.fixture.RoadmapAPIFixture.크리에이터_닉네임으로_정렬된_로드맵을_생성한다;
@@ -8,6 +13,9 @@ import static co.kirikiri.integration.fixture.RoadmapAPIFixture.태그_이름으
 import static org.assertj.core.api.Assertions.assertThat;
 
 import co.kirikiri.integration.helper.InitIntegrationTest;
+import co.kirikiri.service.dto.auth.request.LoginRequest;
+import co.kirikiri.service.dto.member.request.GenderType;
+import co.kirikiri.service.dto.member.request.MemberJoinRequest;
 import co.kirikiri.service.dto.member.response.MemberInformationResponse;
 import co.kirikiri.service.dto.roadmap.request.RoadmapDifficultyType;
 import co.kirikiri.service.dto.roadmap.request.RoadmapNodeSaveRequest;
@@ -73,6 +81,48 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
     }
 
     @Test
+    void 크리에이터_닉네입_기준으로_로드맵_검색_시_크리에이터명이_검색어로_시작하는_모든_로드맵을_조회한다() throws IOException {
+        // given
+        final MemberJoinRequest 닉네임_시작이_다른_회원_가입_요청 = new MemberJoinRequest("identifier3", "paswword3#",
+                "a"+DEFAULT_NICKNAME, GenderType.MALE, DEFAULT_EMAIL);
+        final LoginRequest 닉네임_시작이_다른_사용자_로그인_요청 = new LoginRequest(닉네임_시작이_다른_회원_가입_요청.identifier(), 닉네임_시작이_다른_회원_가입_요청.password());
+        회원가입(닉네임_시작이_다른_회원_가입_요청);
+        final String 닉네임_시작이_다른_사용자_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(닉네임_시작이_다른_사용자_로그인_요청).accessToken());
+
+        final MemberJoinRequest 닉네임_시작이_같은_사용자_회원_가입_요청 = new MemberJoinRequest("identifier2", "paswword2@",
+                DEFAULT_NICKNAME+"a", GenderType.FEMALE, DEFAULT_EMAIL);
+        final LoginRequest 닉네임_시작이_같은_사용자_로그인_요청 = new LoginRequest(닉네임_시작이_같은_사용자_회원_가입_요청.identifier(), 닉네임_시작이_같은_사용자_회원_가입_요청.password());
+        회원가입(닉네임_시작이_같은_사용자_회원_가입_요청);
+        final String 닉네임_시작이_같은_사용자_액세스_토큰 = String.format(BEARER_TOKEN_FORMAT, 로그인(닉네임_시작이_같은_사용자_로그인_요청).accessToken());
+
+        final Long 기본_로드맵_아이디 = 로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+
+        final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "third roadmap", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.NORMAL, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest("다른 태그2")));
+        로드맵_생성(두번째_로드맵_생성_요청, 닉네임_시작이_다른_사용자_액세스_토큰);
+
+        final RoadmapSaveRequest 세번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest("다른 태그1")));
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번째_로드맵_생성_요청, 닉네임_시작이_같은_사용자_액세스_토큰);
+
+        // when
+        final RoadmapForListResponses 로드맵_리스트_응답 = 크리에이터_닉네임으로_정렬된_로드맵을_생성한다(6, DEFAULT_NICKNAME)
+                .response()
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertThat(로드맵_리스트_응답.hasNext()).isFalse();
+        assertThat(로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(세번째_로드맵_아이디);
+        assertThat(로드맵_리스트_응답.responses().get(1).roadmapId()).isEqualTo(기본_로드맵_아이디);
+
+    }
+
+    @Test
     void 로드맵을_태그_이름을_기준으로_검색한다() throws IOException {
         // given
         final String 태그_이름 = "tag name";
@@ -99,5 +149,49 @@ class RoadmapSearchIntegrationTest extends InitIntegrationTest {
         assertThat(로드맵_리스트_응답.hasNext()).isFalse();
         assertThat(로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(세번째_로드맵_아이디);
         assertThat(로드맵_리스트_응답.responses().get(1).roadmapId()).isEqualTo(두번째_로드맵_아이디);
+    }
+
+    @Test
+    void 태그_기준으로_로드맵_검색_시_태그_이름이_검색어로_시작하는_모든_로드맵을_조회한다() throws IOException {
+        // given
+        final String 태그_이름 = "java";
+
+        로드맵_생성(기본_로드맵_생성_요청, 기본_로그인_토큰);
+
+        final RoadmapSaveRequest 두번째_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "second roadmap", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest(태그_이름)));
+        final Long 두번째_로드맵_아이디 = 로드맵_생성(두번째_로드맵_생성_요청, 기본_로그인_토큰);
+
+        final RoadmapSaveRequest 세번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest(태그_이름)));
+        final Long 세번째_로드맵_아이디 = 로드맵_생성(세번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+
+        final RoadmapSaveRequest 네번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest(태그_이름 + "왕")));
+        final Long 네번째_로드맵_아이디 = 로드맵_생성(네번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+
+        final RoadmapSaveRequest 다섯번쨰_로드맵_생성_요청 = new RoadmapSaveRequest(기본_카테고리.getId(), "세번쨰 로드맵", "다른 로드맵 소개글",
+                "다른 로드맵 본문", RoadmapDifficultyType.DIFFICULT, 30,
+                List.of(new RoadmapNodeSaveRequest("다른 로드맵 1주차", "다른 로드맵 1주차 내용", null)),
+                List.of(new RoadmapTagSaveRequest("왕" + 태그_이름)));
+        로드맵_생성(다섯번쨰_로드맵_생성_요청, 기본_로그인_토큰);
+
+        // when
+        final RoadmapForListResponses 로드맵_리스트_응답 = 태그_이름으로_최신순_정렬된_로드맵을_검색한다(6, 태그_이름)
+                .response()
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertThat(로드맵_리스트_응답.hasNext()).isFalse();
+        assertThat(로드맵_리스트_응답.responses().get(0).roadmapId()).isEqualTo(네번째_로드맵_아이디);
+        assertThat(로드맵_리스트_응답.responses().get(1).roadmapId()).isEqualTo(세번째_로드맵_아이디);
+        assertThat(로드맵_리스트_응답.responses().get(2).roadmapId()).isEqualTo(두번째_로드맵_아이디);
     }
 }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/RoadmapAPIFixture.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/RoadmapAPIFixture.java
@@ -14,15 +14,12 @@ import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.restassured.config.HttpClientConfig;
-import io.restassured.config.RestAssuredConfig;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.http.entity.mime.HttpMultipartMode;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -200,11 +197,31 @@ public class RoadmapAPIFixture {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 크리에이터_닉네임으로_정렬된_로드맵을_생성한다(final int 페이지_사이즈, final String 크리에이터_닉네임) {
+    public static ExtractableResponse<Response> 이전_검색_결과를_전달받아_태그_이름으로_최신순_정렬된_로드맵을_검색한다
+            (final int 페이지_사이즈, final Long 마지막_로드맵_아이디, final String 태그) {
+        return given()
+                .log().all()
+                .when()
+                .get("/api/roadmaps/search?size=" + 페이지_사이즈 + "&lastId=" + 마지막_로드맵_아이디 + "&tagName=" + 태그)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 크리에이터_닉네임으로_정렬된_로드맵을_검색한다(final int 페이지_사이즈, final String 크리에이터_닉네임) {
         return given()
                 .log().all()
                 .when()
                 .get("/api/roadmaps/search?size=" + 페이지_사이즈 + "&creatorName=" + 크리에이터_닉네임)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 이전_검색_결과를_전달받아_크리에이터_닉네임으로_정렬된_로드맵을_검색한다(
+            final int 페이지_사이즈, final Long 마지막_로드맵_아이디, final String 크리에이터_닉네임) {
+        return given()
+                .log().all()
+                .when()
+                .get("/api/roadmaps/search?size=" + 페이지_사이즈 + "&lastId=" + 마지막_로드맵_아이디 + "&creatorName=" + 크리에이터_닉네임)
                 .then().log().all()
                 .extract();
     }
@@ -214,6 +231,16 @@ public class RoadmapAPIFixture {
                 .log().all()
                 .when()
                 .get("/api/roadmaps/search?size=" + 페이지_사이즈 + "&roadmapTitle=" + 로드맵_제목)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 이전_검색_결과를_전달받아_제목으로_최신순_정렬된_로드맵을_검색한다(
+            final int 페이지_사이즈, final Long 마지막_로드맵_아이디, final String 로드맵_제목) {
+        return given()
+                .log().all()
+                .when()
+                .get("/api/roadmaps/search?size=" + 페이지_사이즈 + "&lastId=" + 마지막_로드맵_아이디 + "&roadmapTitle=" + 로드맵_제목)
                 .then().log().all()
                 .extract();
     }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/RoadmapAPIFixture.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/fixture/RoadmapAPIFixture.java
@@ -14,15 +14,18 @@ import co.kirikiri.service.dto.roadmap.request.RoadmapSaveRequest;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.restassured.config.HttpClientConfig;
+import io.restassured.config.RestAssuredConfig;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.http.entity.mime.HttpMultipartMode;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 
 public class RoadmapAPIFixture {
 
@@ -215,7 +218,8 @@ public class RoadmapAPIFixture {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 로드맵_카테고리를_생성한다(final String 로그인_토큰_정보, final RoadmapCategorySaveRequest 카테고리_생성_요청) {
+    public static ExtractableResponse<Response> 로드맵_카테고리를_생성한다(final String 로그인_토큰_정보,
+                                                               final RoadmapCategorySaveRequest 카테고리_생성_요청) {
         return given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapRepositoryTest.java
@@ -371,33 +371,36 @@ class RoadmapRepositoryTest {
     void 로드맵을_크리에이터_닉네임으로_검색한다() {
         // given
         final Member creator1 = 사용자를_생성한다("cokirikiri", "코끼리");
-        final Member creator2 = 사용자를_생성한다("cokirikiri2", "끼리코");
+        final Member creator2 = 사용자를_생성한다("cokirikiri2", "코코끼");
+        final Member creator3 = 사용자를_생성한다("cokirikiri3", "코끼코");
         final RoadmapCategory category = 카테고리를_생성한다("여가");
 
         final Roadmap roadmap1 = 로드맵을_저장한다("로드맵", creator1, category);
         final Roadmap roadmap2 = 로드맵을_저장한다("로드맵", creator1, category);
+        final Roadmap roadmap3 = 로드맵을_저장한다("로드맵", creator1, category);
         로드맵을_저장한다("로드맵", creator2, category);
-        final Roadmap roadmap4 = 로드맵을_저장한다("로드맵", creator1, category);
         로드맵을_저장한다("로드맵", creator2, category);
+        final Roadmap roadmap4 = 로드맵을_저장한다("로드맵", creator3, category);
+        final Roadmap roadmap5 = 로드맵을_저장한다("로드맵", creator3, category);
         삭제된_로드맵을_저장한다("로드맵", creator1, category);
 
         final RoadmapOrderType orderType = RoadmapOrderType.LATEST;
-        final RoadmapSearchDto searchRequest = RoadmapSearchDto.create(creator1.getNickname().getValue(), null, null);
+        final RoadmapSearchDto searchRequest = RoadmapSearchDto.create("코끼", null, null);
 
         // when
         final List<Roadmap> firstRoadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType,
-                null, 2);
+                null, 4);
         final List<Roadmap> secondRoadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType,
                 roadmap2.getId(), 3);
 
         // then
         assertAll(
-                () -> assertThat(firstRoadmapRequest.size()).isEqualTo(3),
+                () -> assertThat(firstRoadmapRequest).hasSize(5),
                 () -> assertThat(firstRoadmapRequest).usingRecursiveComparison()
                         .ignoringFields("id", "createdAt", "updatedAt")
-                        .isEqualTo(List.of(roadmap4, roadmap2, roadmap1)),
+                        .isEqualTo(List.of(roadmap5, roadmap4, roadmap3, roadmap2, roadmap1)),
 
-                () -> assertThat(secondRoadmapRequest.size()).isEqualTo(1),
+                () -> assertThat(secondRoadmapRequest).hasSize(1),
                 () -> assertThat(secondRoadmapRequest).usingRecursiveComparison()
                         .ignoringFields("id", "createdAt", "updatedAt")
                         .isEqualTo(List.of(roadmap1))
@@ -415,11 +418,23 @@ class RoadmapRepositoryTest {
                         new RoadmapTag(new RoadmapTagName("자바")),
                         new RoadmapTag(new RoadmapTagName("스프링")))));
 
-        로드맵을_저장한다("로드맵", creator, category);
+        final Roadmap roadmap2 = 로드맵을_태그와_저장한다("로드맵", creator, category,
+                new RoadmapTags(List.of(
+                        new RoadmapTag(new RoadmapTagName("자바")))));
 
         final Roadmap roadmap3 = 로드맵을_태그와_저장한다("로드맵", creator, category,
                 new RoadmapTags(List.of(
-                        new RoadmapTag(new RoadmapTagName("자바")))));
+                        new RoadmapTag(new RoadmapTagName("자바스크립트")))));
+
+        로드맵을_저장한다("로드맵", creator, category);
+
+        로드맵을_태그와_저장한다("로드맵", creator, category,
+                new RoadmapTags(List.of(
+                        new RoadmapTag(new RoadmapTagName("왕자바")))));
+
+        로드맵을_태그와_저장한다("로드맵", creator, category,
+                new RoadmapTags(List.of(
+                        new RoadmapTag(new RoadmapTagName("야자바위")))));
 
         로드맵을_태그와_저장한다("로드맵", creator, category, new RoadmapTags(List.of(
                 new RoadmapTag(new RoadmapTagName("스프링")))));
@@ -429,18 +444,18 @@ class RoadmapRepositoryTest {
 
         // when
         final List<Roadmap> firstRoadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType,
-                null, 1);
+                null, 2);
         final List<Roadmap> secondRoadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType,
-                roadmap3.getId(), 1);
+                roadmap2.getId(), 2);
 
         // then
         assertAll(
-                () -> assertThat(firstRoadmapRequest.size()).isEqualTo(2),
+                () -> assertThat(firstRoadmapRequest).hasSize(3),
                 () -> assertThat(firstRoadmapRequest).usingRecursiveComparison()
                         .ignoringFields("id", "createdAt", "updatedAt")
-                        .isEqualTo(List.of(roadmap3, roadmap1)),
+                        .isEqualTo(List.of(roadmap3, roadmap2, roadmap1)),
 
-                () -> assertThat(secondRoadmapRequest.size()).isEqualTo(1),
+                () -> assertThat(secondRoadmapRequest).hasSize(1),
                 () -> assertThat(secondRoadmapRequest).usingRecursiveComparison()
                         .ignoringFields("id", "createdAt", "updatedAt")
                         .isEqualTo(List.of(roadmap1))

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapRepositoryTest.java
@@ -348,22 +348,14 @@ class RoadmapRepositoryTest {
         final RoadmapSearchDto searchRequest = RoadmapSearchDto.create(null, " 로 드 맵 ", null);
 
         // when
-        final List<Roadmap> firstRoadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType,
-                null, 2);
-        final List<Roadmap> secondRoadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType,
-                roadmap3.getId(), 3);
+        final List<Roadmap> roadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType);
 
         // then
         assertAll(
-                () -> assertThat(firstRoadmapRequest.size()).isEqualTo(3),
-                () -> assertThat(firstRoadmapRequest).usingRecursiveComparison()
+                () -> assertThat(roadmapRequest).hasSize(4),
+                () -> assertThat(roadmapRequest).usingRecursiveComparison()
                         .ignoringFields("id", "createdAt", "updatedAt")
-                        .isEqualTo(List.of(roadmap4, roadmap3, roadmap2)),
-
-                () -> assertThat(secondRoadmapRequest.size()).isEqualTo(2),
-                () -> assertThat(secondRoadmapRequest).usingRecursiveComparison()
-                        .ignoringFields("id", "createdAt", "updatedAt")
-                        .isEqualTo(List.of(roadmap2, roadmap1))
+                        .isEqualTo(List.of(roadmap4, roadmap3, roadmap2, roadmap1))
         );
     }
 
@@ -372,7 +364,7 @@ class RoadmapRepositoryTest {
         // given
         final Member creator1 = 사용자를_생성한다("cokirikiri", "코끼리");
         final Member creator2 = 사용자를_생성한다("cokirikiri2", "코코끼");
-        final Member creator3 = 사용자를_생성한다("cokirikiri3", "코끼코");
+        final Member creator3 = 사용자를_생성한다("cokirikiri3", "코끼코끼");
         final RoadmapCategory category = 카테고리를_생성한다("여가");
 
         final Roadmap roadmap1 = 로드맵을_저장한다("로드맵", creator1, category);
@@ -388,22 +380,14 @@ class RoadmapRepositoryTest {
         final RoadmapSearchDto searchRequest = RoadmapSearchDto.create("코끼", null, null);
 
         // when
-        final List<Roadmap> firstRoadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType,
-                null, 4);
-        final List<Roadmap> secondRoadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType,
-                roadmap2.getId(), 3);
+        final List<Roadmap> roadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType);
 
         // then
         assertAll(
-                () -> assertThat(firstRoadmapRequest).hasSize(5),
-                () -> assertThat(firstRoadmapRequest).usingRecursiveComparison()
+                () -> assertThat(roadmapRequest).hasSize(5),
+                () -> assertThat(roadmapRequest).usingRecursiveComparison()
                         .ignoringFields("id", "createdAt", "updatedAt")
-                        .isEqualTo(List.of(roadmap5, roadmap4, roadmap3, roadmap2, roadmap1)),
-
-                () -> assertThat(secondRoadmapRequest).hasSize(1),
-                () -> assertThat(secondRoadmapRequest).usingRecursiveComparison()
-                        .ignoringFields("id", "createdAt", "updatedAt")
-                        .isEqualTo(List.of(roadmap1))
+                        .isEqualTo(List.of(roadmap5, roadmap4, roadmap3, roadmap2, roadmap1))
         );
     }
 
@@ -415,8 +399,8 @@ class RoadmapRepositoryTest {
 
         final Roadmap roadmap1 = 로드맵을_태그와_저장한다("로드맵", creator, category,
                 new RoadmapTags(List.of(
-                        new RoadmapTag(new RoadmapTagName("자바")),
-                        new RoadmapTag(new RoadmapTagName("스프링")))));
+                        new RoadmapTag(new RoadmapTagName("스프링")),
+                        new RoadmapTag(new RoadmapTagName("자바")))));
 
         final Roadmap roadmap2 = 로드맵을_태그와_저장한다("로드맵", creator, category,
                 new RoadmapTags(List.of(
@@ -443,22 +427,14 @@ class RoadmapRepositoryTest {
         final RoadmapSearchDto searchRequest = RoadmapSearchDto.create(null, null, " 자 바 ");
 
         // when
-        final List<Roadmap> firstRoadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType,
-                null, 2);
-        final List<Roadmap> secondRoadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType,
-                roadmap2.getId(), 2);
+        final List<Roadmap> roadmapRequest = roadmapRepository.findRoadmapsByCond(searchRequest, orderType);
 
         // then
         assertAll(
-                () -> assertThat(firstRoadmapRequest).hasSize(3),
-                () -> assertThat(firstRoadmapRequest).usingRecursiveComparison()
+                () -> assertThat(roadmapRequest).hasSize(3),
+                () -> assertThat(roadmapRequest).usingRecursiveComparison()
                         .ignoringFields("id", "createdAt", "updatedAt")
-                        .isEqualTo(List.of(roadmap3, roadmap2, roadmap1)),
-
-                () -> assertThat(secondRoadmapRequest).hasSize(1),
-                () -> assertThat(secondRoadmapRequest).usingRecursiveComparison()
-                        .ignoringFields("id", "createdAt", "updatedAt")
-                        .isEqualTo(List.of(roadmap1))
+                        .isEqualTo(List.of(roadmap3, roadmap2, roadmap1))
         );
     }
 

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/RoadmapReadServiceTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/RoadmapReadServiceTest.java
@@ -372,7 +372,7 @@ class RoadmapReadServiceTest {
                 로드맵을_생성한다("첫 번째 로드맵", category),
                 로드맵을_생성한다("두 번째 로드맵", category));
 
-        when(roadmapRepository.findRoadmapsByCond(any(), any(), any(), anyInt()))
+        when(roadmapRepository.findRoadmapsByCond(any(), any()))
                 .thenReturn(roadmaps);
         given(fileService.generateUrl(anyString(), any()))
                 .willReturn(new URL("http://example.com/serverFilePath"));


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-202](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-202)


## ✨ 작업 내용
- 크리에이터명으로 로드맵 검색 시 기존에는 검색어가 완전히 일치하는 로드맵만 반환했지만, 크리에이터명이 검색어로 시작하는 모든 로드맵을 반환하도록 수정했습니다.
- 태그로 로드맵 검색 시 기존에는 검색어와 완전히 일치하는 태그를 가지는 로드맵만 반환했지만, 검색어로 시작하는 태그를 가진 모든 로드맵을 반환하도록 수정했습니다.
- 검색어와 완전히 일치하는 로드맵을 먼저 반환하도록 했습니다. 일치도가 같다면 최근에 만들어진 것을 먼저 반환합니다. 일치도는 임시로 로드맵의 크리에이터명/제목/태그의 길이로 판단하지만 너무 단순한 방법이라 나중에 개선이 필요할 것을 생각합니다.
- 데이터베이스 수준에서 무한 스크롤을 구현하는 것이 아니라 자바 수준에서 구현했습니다. 그에 따라 데이터베이스에서는 항상 전체 테이블에 대해서 조회하기에 성능이 좋지 않을 수 있습니다. 특히 로드맵 제목에 대한 검색이 검색어를 포함하는 것까지 반환하는데 이 부분은 인덱스를 걸 수 없어서 엄청 성능이 안 좋습니다. 근데 딱히 좋은 개선 방안이 생각나지 않는데 방법을 추천해주시면 감사하겠습니다.


## 💬 리뷰어에게 남길 멘트
- 기존에 있던 테스트 외에 규칙변경으로 인해 추가된 케이스들에 대한 테스트를 작성해주었습니다.
- 통합 테스트에서 h2 database에 한글이 제대로 저장되지 않는 것 같아서 해결해보려고 했는데 (`?`로만 담기기 때문에 한글깨짐 현상과는 다른 것으로 예상) 실패해서 영어 케이스만 검증했습니다. 기존에도 발생했던 문제라서 실제 개발 서버에 merge됐을 때는 큰 오류가 없을 것으로 생각합니다.


## 🚀 요구사항 분석
- [x] 크리에이터명으로 로드맵 검색 시 검색어로 시작하는 크리에이터가 만든 모든 로드맵을 반환한다.
- [x] 태그로 로드맵 검색 시 검색어로 시작하는 태그를 가진 모든 로드맵을 반환한다.
- [x] 로드맵 제목으로 로드맵 검색 시 검색어를 포함하는 제목을 가진 모든 로드맵을 반환한다. 

