### PR TITLE
[feat/CK-209] 새로고침 시 로그인 페이지로 이동하는 버그를 해결한다.

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
-import { lazy, PropsWithChildren, Suspense, useEffect } from 'react';
-import { BrowserRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { lazy, Suspense } from 'react';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import theme from '@styles/theme';
 import GlobalStyle from '@styles/GlobalStyle';
 import { ThemeProvider } from 'styled-components';
@@ -13,16 +13,13 @@ import RoadmapDetailPage from './pages/roadmapDetailPage/RoadmapDetailPage';
 import RoadmapCreatePage from './pages/roadmapCreatePage/RoadmapCreatePage';
 import ToastProvider from '@components/_common/toastProvider/ToastProvider';
 import MyPage from '@pages/myPage/MyPage';
-import UserInfoProvider, {
-  useUserInfoContext,
-} from './components/_providers/UserInfoProvider';
+import UserInfoProvider from './components/_providers/UserInfoProvider';
 import RoadmapSearchResult from './components/roadmapListPage/roadmapSearch/RoadmapSearchResult';
 import MainPage from '@pages/mainPage/MainPage';
-import useToast from '@hooks/_common/useToast';
 import OAuthRedirect from './components/loginPage/OAuthRedirect';
 import AsyncBoundary from './components/_common/errorBoundary/AsyncBoundary';
 import SessionHandler from '@components/_common/sessionHandler/SessionHandler';
-import { getCookie } from '@utils/_common/cookies';
+import PrivateRouter from '@components/_common/privateRouter/PrivateRouter';
 
 const GoalRoomDashboardPage = lazy(
   () => import('@pages/goalRoomDashboardPage/GoalRoomDashboardPage')
@@ -31,23 +28,6 @@ const GoalRoomListPage = lazy(() => import('@pages/goalRoomListPage/GoalRoomList
 const GoalRoomCreatePage = lazy(
   () => import('@pages/goalRoomCreatePage/GoalRoomCreatePage')
 );
-
-const PrivateRouter = (props: PropsWithChildren) => {
-  const { children } = props;
-  const { userInfo } = useUserInfoContext();
-  const { triggerToast } = useToast();
-  const navigate = useNavigate();
-  const accessToken = getCookie('access_token');
-
-  useEffect(() => {
-    if (userInfo.id === null && !accessToken) {
-      navigate('/login');
-      triggerToast({ message: '로그인이 필요한 서비스입니다.' });
-    }
-  }, [userInfo.id, navigate]);
-
-  return <>{children}</>;
-};
 
 const App = () => {
   return (

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,7 @@ import useToast from '@hooks/_common/useToast';
 import OAuthRedirect from './components/loginPage/OAuthRedirect';
 import AsyncBoundary from './components/_common/errorBoundary/AsyncBoundary';
 import SessionHandler from '@components/_common/sessionHandler/SessionHandler';
+import { getCookie } from '@utils/_common/cookies';
 
 const GoalRoomDashboardPage = lazy(
   () => import('@pages/goalRoomDashboardPage/GoalRoomDashboardPage')
@@ -36,9 +37,10 @@ const PrivateRouter = (props: PropsWithChildren) => {
   const { userInfo } = useUserInfoContext();
   const { triggerToast } = useToast();
   const navigate = useNavigate();
+  const accessToken = getCookie('access_token');
 
   useEffect(() => {
-    if (userInfo.id === null) {
+    if (userInfo.id === null && !accessToken) {
       navigate('/login');
       triggerToast({ message: '로그인이 필요한 서비스입니다.' });
     }

--- a/client/src/components/_common/privateRouter/PrivateRouter.tsx
+++ b/client/src/components/_common/privateRouter/PrivateRouter.tsx
@@ -1,0 +1,24 @@
+import { PropsWithChildren, useEffect } from 'react';
+import { useUserInfoContext } from '@components/_providers/UserInfoProvider';
+import useToast from '@hooks/_common/useToast';
+import { useNavigate } from 'react-router-dom';
+import { getCookie } from '@utils/_common/cookies';
+
+const PrivateRouter = (props: PropsWithChildren) => {
+  const { children } = props;
+  const { userInfo } = useUserInfoContext();
+  const { triggerToast } = useToast();
+  const navigate = useNavigate();
+  const accessToken = getCookie('access_token');
+
+  useEffect(() => {
+    if (userInfo.id === null && !accessToken) {
+      navigate('/login');
+      triggerToast({ message: '로그인이 필요한 서비스입니다.' });
+    }
+  }, [userInfo.id, navigate]);
+
+  return <>{children}</>;
+};
+
+export default PrivateRouter;


### PR DESCRIPTION
## 📌 작업 이슈 번호

CK-209


## ✨ 작업 내용

-  기존 로그인 시 `/me` 요청을 통해 나라는 유저의 정보를 가져오쥬? 그리고 받아온 정보를 전역 컨텍스트에 저장 후 지속적으로 사용합니다.
허나 문제는 새로고침 시 전역 컨텍스트에 저장되어 있는 나라는 유저의 정보가 초기화가 되기에, 미리 가지고 있던 accessToken 을 사용하여 다시 유저 정보를 가져온다 해도 가져오기 전 빈 시간동안은 유저 정보가 없게 됩니다. 그 시점에, 유저가 private router(유저가 로그인 되어있는지 체크) 로 감싸진 위치에 있다면 강제적으로 로그인 페이지로 이동하게 되었던 상황임다.

- 그래서 throttle 이나 debounce 를 걸어 시간을 벌어야 할지, 고민 중 성공은 했으나, 정확한 조건을 정의할 수 없었고 성공률이 100퍼센트는 아니라고 생각했기에, 단순 유저가 로그인 되어있는지 확인하는 로직에 accessToken 까지 체크하는 로직을 넣어 다시 유저 정보를 불러올 수 있는 시간을 벌 수 있게 했슴다.



## 💬 리뷰어에게 남길 멘트

잘 부탁드려요!


## 🚀 요구사항 분석

- 새로고침 시 로그인 페이지로 강제 이동하는 버그 픽스

