### PR TITLE
[feat/CK-212] 로드맵 생성페이지 오류를 해결한다.

### DIFF
--- a/client/src/components/roadmapCreatePage/difficulty/Difficulty.tsx
+++ b/client/src/components/roadmapCreatePage/difficulty/Difficulty.tsx
@@ -1,31 +1,32 @@
 /* eslint-disable react/no-unused-prop-types */
 import { useSelect } from '@/hooks/_common/useSelect';
+import { DifficultiesType, DifficultyKeyType } from '@/myTypes/roadmap/internal';
+import { getInvariantObjectKeys, invariantOf } from '@/utils/_common/invariantType';
 import { useEffect } from 'react';
 import { Select, SelectBox } from '../selector/SelectBox';
 import * as S from './difficulty.styles';
 
-// 임시 더미데이터
-export type DummyDifficultyType = {
-  [key: number]: string;
+const Difficulties: DifficultiesType = {
+  VERY_EASY: '매우쉬움',
+  EASY: '쉬움',
+  NORMAL: '보통',
+  DIFFICULT: '어려움',
+  VERY_DIFFICULT: '매우어려움',
 };
 
-const DummyDifficulty: DummyDifficultyType = {
-  1: '매우쉬움',
-  2: '쉬움',
-  3: '보통',
-  4: '어려움',
-  5: '매우어려움',
+type DifficultyProps = {
+  getSelectedDifficulty: (difficulty: DifficultyKeyType | null) => void;
 };
 
-type DifficultyType = {
-  getSelectedDifficulty: (difficulty: keyof DummyDifficultyType | null) => void;
-};
-
-const Difficulty = ({ getSelectedDifficulty }: DifficultyType) => {
+const Difficulty = ({ getSelectedDifficulty }: DifficultyProps) => {
   const { selectOption, selectedOption } = useSelect<number>();
 
   useEffect(() => {
-    getSelectedDifficulty(selectedOption);
+    if (selectedOption === null) return;
+
+    getSelectedDifficulty(
+      getInvariantObjectKeys(invariantOf(Difficulties))[selectedOption]
+    );
   }, [selectedOption]);
 
   return (
@@ -46,7 +47,11 @@ const Difficulty = ({ getSelectedDifficulty }: DifficultyType) => {
             {({ selectedId }: { selectedId: number | null }) => {
               return (
                 <S.DifficultyValue>
-                  {selectedId === null ? '선택안함' : DummyDifficulty[selectedId]}
+                  {selectedId === null
+                    ? '선택안함'
+                    : Difficulties[
+                        getInvariantObjectKeys(invariantOf(Difficulties))[selectedId]
+                      ]}
                 </S.DifficultyValue>
               );
             }}
@@ -55,14 +60,14 @@ const Difficulty = ({ getSelectedDifficulty }: DifficultyType) => {
       </Select.Trigger>
       <Select.OptionGroup asChild>
         <S.Wrapper>
-          {Object.keys(DummyDifficulty).map((difficultyId) => {
+          {getInvariantObjectKeys(invariantOf(Difficulties)).map((difficulty, idx) => {
             return (
-              <Select.Option id={Number(difficultyId)} asChild>
+              <Select.Option id={idx} asChild>
                 <S.DifficultyOption>
-                  <Select.Indicator id={Number(difficultyId)} asChild>
+                  <Select.Indicator id={idx} asChild>
                     <S.OptionIndicator />
                   </Select.Indicator>
-                  {DummyDifficulty[Number(difficultyId)]}
+                  {Difficulties[difficulty]}
                 </S.DifficultyOption>
               </Select.Option>
             );

--- a/client/src/components/roadmapCreatePage/roadmapCreateForm/RoadmapCreateForm.tsx
+++ b/client/src/components/roadmapCreatePage/roadmapCreateForm/RoadmapCreateForm.tsx
@@ -50,6 +50,14 @@ const RoadmapCreateForm = () => {
         <Period />
         <Roadmap>
           <>
+            {roadmapValue.roadmapNodes.length === 0 && (
+              <RoadmapItem
+                roadmapNumber={1}
+                itemId={0}
+                getRoadmapItemTitle={getRoadmapItemTitle}
+                getNodeImage={getNodeImage}
+              />
+            )}
             {roadmapValue.roadmapNodes.map((_, index) => {
               return (
                 <RoadmapItem

--- a/client/src/components/roadmapCreatePage/tag/Tag.tsx
+++ b/client/src/components/roadmapCreatePage/tag/Tag.tsx
@@ -9,8 +9,15 @@ type TagProps = {
   getTags: (tags: string[]) => void;
 };
 const Tag = ({ getTags }: TagProps) => {
-  const { tags, ref, addTagByButton, addTagByEnter, checkIsTagCountMax, deleteTag } =
-    useCreateTag();
+  const {
+    tags,
+    ref,
+    addTagByButton,
+    addTagByEnter,
+    checkIsTagCountMax,
+    checkIsAddCountMax,
+    deleteTag,
+  } = useCreateTag();
 
   useEffect(() => {
     getTags(tags);
@@ -29,8 +36,10 @@ const Tag = ({ getTags }: TagProps) => {
             </S.DeleteButton>
           </>
         ))}
-        <TagItem ref={ref} addTagByEnter={addTagByEnter} placeholder='# 태그명' />
-        {checkIsTagCountMax() && <S.AddButton onClick={addTagByButton}>+</S.AddButton>}
+        {checkIsTagCountMax() && (
+          <TagItem ref={ref} addTagByEnter={addTagByEnter} placeholder='# 태그명' />
+        )}
+        {checkIsAddCountMax() && <S.AddButton onClick={addTagByButton}>+</S.AddButton>}
       </S.TagWrapper>
     </S.Container>
   );

--- a/client/src/constants/roadmap/tag.ts
+++ b/client/src/constants/roadmap/tag.ts
@@ -1,3 +1,3 @@
-export const TAG_LIMIT = 4;
+export const TAG_LIMIT = 5;
 
 export const TAG_ITEM_MAX_LENGTH = 10;

--- a/client/src/hooks/roadmap/useCollectRoadmapData.ts
+++ b/client/src/hooks/roadmap/useCollectRoadmapData.ts
@@ -1,6 +1,9 @@
 import { DummyCategoryType } from '@/components/roadmapCreatePage/category/Category';
-import { DummyDifficultyType } from '@/components/roadmapCreatePage/difficulty/Difficulty';
-import { NodeImagesType, RoadmapValueType } from '@/myTypes/roadmap/internal';
+import {
+  DifficultyKeyType,
+  NodeImagesType,
+  RoadmapValueType,
+} from '@/myTypes/roadmap/internal';
 import { getInvariantObjectKeys, invariantOf } from '@/utils/_common/invariantType';
 import { useEffect, useState } from 'react';
 import { useCreateRoadmap } from '../queries/roadmap';
@@ -27,7 +30,7 @@ export const useCollectRoadmapData = () => {
     }));
   };
 
-  const getSelectedDifficulty = (difficulty: keyof DummyDifficultyType | null) => {
+  const getSelectedDifficulty = (difficulty: DifficultyKeyType | null) => {
     setRoadmapValue((prev) => ({
       ...prev,
       difficulty,

--- a/client/src/hooks/roadmap/useCollectRoadmapData.ts
+++ b/client/src/hooks/roadmap/useCollectRoadmapData.ts
@@ -106,6 +106,7 @@ export const useCollectRoadmapData = () => {
     if (isSumbited) {
       createRoadmap(formData);
     }
+    setIsSubmited(false);
   }, [isSumbited]);
 
   return {

--- a/client/src/hooks/roadmap/useCreateTag.ts
+++ b/client/src/hooks/roadmap/useCreateTag.ts
@@ -31,6 +31,10 @@ export const useCreateTag = () => {
     return tags.length < TAG_LIMIT;
   };
 
+  const checkIsAddCountMax = () => {
+    return tags.length < TAG_LIMIT - 1;
+  };
+
   const deleteTag = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
 
@@ -40,5 +44,13 @@ export const useCreateTag = () => {
       return prev.filter((tag) => tag !== target.value);
     });
   };
-  return { tags, ref, addTagByButton, addTagByEnter, checkIsTagCountMax, deleteTag };
+  return {
+    tags,
+    ref,
+    addTagByButton,
+    addTagByEnter,
+    checkIsTagCountMax,
+    checkIsAddCountMax,
+    deleteTag,
+  };
 };

--- a/client/src/hooks/roadmap/useCreateTag.ts
+++ b/client/src/hooks/roadmap/useCreateTag.ts
@@ -8,6 +8,7 @@ export const useCreateTag = () => {
   const getAddedTagText = () => {
     if (ref.current === null) return;
     if (ref.current.value === '') return;
+    if (tags.includes(ref.current.value)) return;
 
     setTags((prev) => {
       return [...prev, ref.current?.value as string];

--- a/client/src/hooks/roadmap/useCreateTag.ts
+++ b/client/src/hooks/roadmap/useCreateTag.ts
@@ -6,8 +6,8 @@ export const useCreateTag = () => {
   const ref = useRef<HTMLInputElement | null>(null);
 
   const getAddedTagText = () => {
-    if (ref.current === null) return;
-    if (ref.current.value === '') return;
+    if (!ref.current?.value) return;
+
     if (tags.includes(ref.current.value)) return;
 
     setTags((prev) => {

--- a/client/src/myTypes/roadmap/internal.ts
+++ b/client/src/myTypes/roadmap/internal.ts
@@ -1,6 +1,17 @@
 import { DIFFICULTY_ICON_NAME } from '@constants/roadmap/difficulty';
 import { CategoriesInfo } from '@constants/roadmap/category';
 
+export type DifficultyKeyType =
+  | 'VERY_EASY'
+  | 'EASY'
+  | 'NORMAL'
+  | 'DIFFICULT'
+  | 'VERY_DIFFICULT';
+
+export type DifficultyValueType = '매우쉬움' | '쉬움' | '보통' | '어려움' | '매우어려움';
+
+export type DifficultiesType = { [key in DifficultyKeyType]: DifficultyValueType };
+
 export type CategoryType = {
   id: keyof typeof CategoriesInfo;
   name: string;
@@ -64,7 +75,7 @@ export type RoadmapValueType = {
   title: null | string;
   introduction: null | string;
   content: null | string;
-  difficulty: null | number;
+  difficulty: null | DifficultyKeyType;
   requiredPeriod: null | string;
   roadmapTags: { name: string }[];
   roadmapNodes: RoadmapNodes[];


### PR DESCRIPTION
## 📌 작업 이슈 번호

CK-212

## ✨ 작업 내용
로드맵 생성페이지 오류 해결했습니다.
- 요청이 잘못되었을 때 다시 요청보낼 수 없는 오류 해결
- 난이도 요청 잘못가는 오류 해결
- 태그 무한생성오류 해결
- 중복되는 태그가 생성되는 오류 해결
- 로드맵의 첫번째 노드 기본으로 노출시킴


## 💬 리뷰어에게 남길 멘트
잘부탁드림당~


## 🚀 요구사항 분석


