### PR TITLE
[feat/CK-229] 표시할 골룸 목록이 없다면 대체 UI를 표시한다

### DIFF
--- a/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
+++ b/client/src/components/goalRoomListPage/goalRoomList/GoalRoomList.tsx
@@ -29,6 +29,10 @@ const GoalRoomList = () => {
     fetchNextPage,
   });
 
+  const RecruitingGoalRoomList = goalRoomList.filter(
+    (goalRoomInfo) => goalRoomInfo.status === 'RECRUITING'
+  );
+
   return (
     <S.ListContainer role='main' aria-label='골룸 리스트'>
       <S.FilterBar>
@@ -58,13 +62,18 @@ const GoalRoomList = () => {
           }}
         </GoalRoomFilter>
       </S.FilterBar>
-      <S.ListWrapper aria-label='골룸 리스트'>
-        {goalRoomList
-          .filter((goalRoomInfo) => goalRoomInfo.status === 'RECRUITING')
-          .map((goalRoomInfo) => (
+      {RecruitingGoalRoomList.length ? (
+        <S.ListWrapper aria-label='골룸 리스트'>
+          {RecruitingGoalRoomList.map((goalRoomInfo) => (
             <GoalRoomItem key={goalRoomInfo.goalRoomId} {...goalRoomInfo} />
           ))}
-      </S.ListWrapper>
+        </S.ListWrapper>
+      ) : (
+        <S.NoContent>
+          <div>현재 모집중인 모임이 존재하지 않아요</div>
+          <div>모임을 생성해서 목표 달성을 함께 할 동료들을 모집 해 보세요!</div>
+        </S.NoContent>
+      )}
       {hasNext && <WavyLoading loadMoreRef={loadMoreRef} />}
       <Link to={`/roadmap/${Number(id)}/goalroom-create`}>
         <S.CreateGoalRoomButton>

--- a/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
+++ b/client/src/components/goalRoomListPage/goalRoomList/goalRoomList.styles.ts
@@ -144,3 +144,20 @@ export const FilterOption = styled.li`
 
   background-color: ${({ theme }) => theme.colors.main_dark};
 `;
+
+export const NoContent = styled.div`
+  ${({ theme }) => theme.fonts.h1}
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  margin-top: 8rem;
+
+  line-height: 3rem;
+
+  opacity: 0.6;
+
+  & > div:first-child {
+    margin-bottom: 2rem;
+  }
+`;

--- a/client/src/components/roadmapCreatePage/selector/SelectBox.tsx
+++ b/client/src/components/roadmapCreatePage/selector/SelectBox.tsx
@@ -87,7 +87,6 @@ export const Trigger = (props: PropsWithChildren<TriggerProps>) => {
 
 export const Value = (props: ValueProps) => {
   const { asChild = false, children, ...restProps } = props;
-  console.log(restProps);
   const { selectedId } = useContextScope(SelectContext);
   return cloneElement(children({ selectedId }));
 };

--- a/client/src/components/roadmapListPage/categories/Categories.tsx
+++ b/client/src/components/roadmapListPage/categories/Categories.tsx
@@ -16,7 +16,6 @@ const Categories = ({ selectedCategoryId, selectCategory }: CategoriesProps) => 
   const downCategories = categories.slice(5);
 
   const navigate = useNavigate();
-  console.log(selectCategory);
 
   const handleClickCategory = (categoryId: CategoryType['id']) => {
     const queryParams = new URLSearchParams();

--- a/client/src/components/roadmapListPage/roadmapList/RoadmapList.tsx
+++ b/client/src/components/roadmapListPage/roadmapList/RoadmapList.tsx
@@ -30,7 +30,7 @@ const RoadmapList = ({ selectedCategoryId }: RoadmapListProps) => {
   const moveRoadmapCreatePage = () => {
     navigate('/roadmap-create');
   };
-  console.log(selectedCategoryId);
+
   return (
     <S.RoadmapList aria-label='로드맵 목록'>
       {!roadmapListResponse.responses.length && <NoResult />}


### PR DESCRIPTION
## 📌 작업 이슈 번호
CK-229


## ✨ 작업 내용
- 골룸 목록 대체 UI 생성
- 프로젝트 내 console.log 일괄 제거


## 💬 리뷰어에게 남길 멘트
<img width="1141" alt="image" src="https://github.com/woowacourse-teams/2023-co-kirikiri/assets/88191233/716fe8b8-f9a7-43c6-91ee-9fcfe7a34614">

잘 부탁드립니다~!!