### PR TITLE
[feat/CK-231] 인증/ 인가 시 @MemberIdentifier를 @Authenticated와 함께 사용하도록 수정한다

### DIFF
--- a/backend/kirikiri/src/main/java/co/kirikiri/common/resolver/MemberIdentifierArgumentResolver.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/common/resolver/MemberIdentifierArgumentResolver.java
@@ -1,6 +1,8 @@
 package co.kirikiri.common.resolver;
 
+import co.kirikiri.common.interceptor.Authenticated;
 import co.kirikiri.exception.AuthenticationException;
+import co.kirikiri.exception.ServerException;
 import co.kirikiri.service.auth.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -21,6 +23,9 @@ public class MemberIdentifierArgumentResolver implements HandlerMethodArgumentRe
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
+        if (!parameter.hasMethodAnnotation(Authenticated.class)) {
+            throw new ServerException("MemberIdentifier는 인증된 사용자만 사용 가능합니다. (@Authenticated)");
+        }
         return parameter.getParameterType().equals(String.class)
                 && parameter.hasParameterAnnotation(MemberIdentifier.class);
     }

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/GoalRoomController.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/GoalRoomController.java
@@ -2,8 +2,6 @@ package co.kirikiri.controller;
 
 import co.kirikiri.common.interceptor.Authenticated;
 import co.kirikiri.common.resolver.MemberIdentifier;
-import co.kirikiri.service.goalroom.GoalRoomCreateService;
-import co.kirikiri.service.goalroom.GoalRoomReadService;
 import co.kirikiri.service.dto.goalroom.GoalRoomMemberSortTypeDto;
 import co.kirikiri.service.dto.goalroom.request.CheckFeedRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomCreateRequest;
@@ -18,6 +16,8 @@ import co.kirikiri.service.dto.goalroom.response.GoalRoomToDoCheckResponse;
 import co.kirikiri.service.dto.goalroom.response.GoalRoomTodoResponse;
 import co.kirikiri.service.dto.member.response.MemberGoalRoomForListResponse;
 import co.kirikiri.service.dto.member.response.MemberGoalRoomResponse;
+import co.kirikiri.service.goalroom.GoalRoomCreateService;
+import co.kirikiri.service.goalroom.GoalRoomReadService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
@@ -50,16 +50,16 @@ public class GoalRoomController {
         return ResponseEntity.created(URI.create("/api/goal-rooms/" + id)).build();
     }
 
-    @Authenticated
     @PostMapping("/{goalRoomId}/join")
+    @Authenticated
     public ResponseEntity<Void> joinGoalRoom(@MemberIdentifier final String identifier,
                                              @PathVariable final Long goalRoomId) {
         goalRoomCreateService.join(identifier, goalRoomId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @Authenticated
     @PostMapping("/{goalRoomId}/todos")
+    @Authenticated
     public ResponseEntity<Void> addTodo(@RequestBody @Valid final GoalRoomTodoRequest goalRoomTodoRequest,
                                         @PathVariable final Long goalRoomId,
                                         @MemberIdentifier final String identifier) {
@@ -67,8 +67,8 @@ public class GoalRoomController {
         return ResponseEntity.created(URI.create("/api/goal-rooms/" + goalRoomId + "/todos/" + id)).build();
     }
 
-    @Authenticated
     @PostMapping("/{goalRoomId}/todos/{todoId}")
+    @Authenticated
     public ResponseEntity<GoalRoomToDoCheckResponse> checkTodo(@PathVariable final Long goalRoomId,
                                                                @PathVariable final Long todoId,
                                                                @MemberIdentifier final String identifier) {
@@ -77,8 +77,8 @@ public class GoalRoomController {
         return ResponseEntity.ok(checkResponse);
     }
 
-    @Authenticated
     @PostMapping(value = "/{goalRoomId}/checkFeeds", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Authenticated
     public ResponseEntity<Void> createCheckFeed(@MemberIdentifier final String identifier,
                                                 @PathVariable("goalRoomId") final Long goalRoomId,
                                                 @ModelAttribute final CheckFeedRequest checkFeedRequest) {
@@ -116,8 +116,8 @@ public class GoalRoomController {
         return ResponseEntity.ok(goalRoomResponse);
     }
 
-    @Authenticated
     @GetMapping("/{goalRoomId}/members")
+    @Authenticated
     public ResponseEntity<List<GoalRoomMemberResponse>> findGoalRoomMembers(
             @PathVariable final Long goalRoomId,
             @RequestParam(value = "sortCond", required = false) final GoalRoomMemberSortTypeDto sortType) {
@@ -126,8 +126,8 @@ public class GoalRoomController {
         return ResponseEntity.ok(goalRoomMembers);
     }
 
-    @Authenticated
     @GetMapping("/{goalRoomId}/me")
+    @Authenticated
     public ResponseEntity<MemberGoalRoomResponse> findMemberGoalRoom(
             @MemberIdentifier final String identifier, @PathVariable final Long goalRoomId) {
         final MemberGoalRoomResponse memberGoalRoomResponse = goalRoomReadService.findMemberGoalRoom(identifier,
@@ -135,8 +135,8 @@ public class GoalRoomController {
         return ResponseEntity.ok(memberGoalRoomResponse);
     }
 
-    @Authenticated
     @GetMapping("/me")
+    @Authenticated
     public ResponseEntity<List<MemberGoalRoomForListResponse>> findMemberGoalRoomsByStatus(
             @MemberIdentifier final String identifier,
             @RequestParam(value = "statusCond", required = false) final GoalRoomStatusTypeRequest goalRoomStatusTypeRequest) {
@@ -150,8 +150,8 @@ public class GoalRoomController {
         return ResponseEntity.ok(memberGoalRoomForListResponses);
     }
 
-    @Authenticated
     @GetMapping("/{goalRoomId}/todos")
+    @Authenticated
     public ResponseEntity<List<GoalRoomTodoResponse>> findAllTodos(
             @PathVariable final Long goalRoomId,
             @MemberIdentifier final String identifier) {
@@ -160,8 +160,8 @@ public class GoalRoomController {
         return ResponseEntity.ok(todoResponses);
     }
 
-    @Authenticated
     @GetMapping("/{goalRoomId}/nodes")
+    @Authenticated
     public ResponseEntity<List<GoalRoomRoadmapNodeDetailResponse>> findAllNodes(
             @PathVariable final Long goalRoomId,
             @MemberIdentifier final String identifier
@@ -171,8 +171,8 @@ public class GoalRoomController {
         return ResponseEntity.ok(nodeResponses);
     }
 
-    @Authenticated
     @GetMapping("/{goalRoomId}/checkFeeds")
+    @Authenticated
     public ResponseEntity<List<GoalRoomCheckFeedResponse>> findGoalRoomCheckFeeds(
             @MemberIdentifier final String identifier,
             @PathVariable("goalRoomId") final Long goalRoomId) {

--- a/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/controller/RoadmapController.java
@@ -2,8 +2,6 @@ package co.kirikiri.controller;
 
 import co.kirikiri.common.interceptor.Authenticated;
 import co.kirikiri.common.resolver.MemberIdentifier;
-import co.kirikiri.service.roadmap.RoadmapCreateService;
-import co.kirikiri.service.roadmap.RoadmapReadService;
 import co.kirikiri.service.dto.CustomScrollRequest;
 import co.kirikiri.service.dto.roadmap.RoadmapGoalRoomsOrderTypeDto;
 import co.kirikiri.service.dto.roadmap.request.RoadmapCategorySaveRequest;
@@ -17,7 +15,11 @@ import co.kirikiri.service.dto.roadmap.response.RoadmapForListResponses;
 import co.kirikiri.service.dto.roadmap.response.RoadmapGoalRoomResponses;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapReviewResponse;
+import co.kirikiri.service.roadmap.RoadmapCreateService;
+import co.kirikiri.service.roadmap.RoadmapReadService;
 import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -31,8 +33,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import java.net.URI;
-import java.util.List;
 
 @RestController
 @RequestMapping("/roadmaps")
@@ -42,14 +42,15 @@ public class RoadmapController {
     private final RoadmapCreateService roadmapCreateService;
     private final RoadmapReadService roadmapReadService;
 
-    @Authenticated
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Authenticated
     public ResponseEntity<Void> create(final RoadmapSaveRequest request, @MemberIdentifier final String identifier) {
         final Long roadmapId = roadmapCreateService.create(request, identifier);
         return ResponseEntity.created(URI.create("/api/roadmaps/" + roadmapId)).build();
     }
 
     @PostMapping("/{roadmapId}/reviews")
+    @Authenticated
     public ResponseEntity<Void> createReview(
             @PathVariable("roadmapId") final Long roadmapId,
             @MemberIdentifier final String identifier,
@@ -93,7 +94,8 @@ public class RoadmapController {
     }
 
     @PostMapping("/categories")
-    public ResponseEntity<Void> createRoadmapCategory(@RequestBody @Valid final RoadmapCategorySaveRequest roadmapCategorySaveRequest) {
+    public ResponseEntity<Void> createRoadmapCategory(
+            @RequestBody @Valid final RoadmapCategorySaveRequest roadmapCategorySaveRequest) {
         roadmapCreateService.createRoadmapCategory(roadmapCategorySaveRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/backend/kirikiri/src/test/java/co/kirikiri/common/resolver/MemberIdentifierArgumentResolverTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/common/resolver/MemberIdentifierArgumentResolverTest.java
@@ -5,8 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import co.kirikiri.common.interceptor.Authenticated;
 import co.kirikiri.exception.AuthenticationException;
+import co.kirikiri.exception.ServerException;
 import co.kirikiri.service.auth.AuthService;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,7 +21,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
-import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class MemberIdentifierArgumentResolverTest {
@@ -50,6 +52,8 @@ class MemberIdentifierArgumentResolverTest {
                 .thenReturn(String.class);
         when(parameter.hasParameterAnnotation(MemberIdentifier.class))
                 .thenReturn(true);
+        when(parameter.hasMethodAnnotation(Authenticated.class))
+                .thenReturn(true);
 
         //when
         final boolean result = memberIdentifierArgumentResolver.supportsParameter(parameter);
@@ -63,6 +67,8 @@ class MemberIdentifierArgumentResolverTest {
         //given
         Mockito.<Class<?>>when(parameter.getParameterType())
                 .thenReturn(List.class);
+        when(parameter.hasMethodAnnotation(Authenticated.class))
+                .thenReturn(true);
 
         //when
         final boolean result = memberIdentifierArgumentResolver.supportsParameter(parameter);
@@ -78,12 +84,27 @@ class MemberIdentifierArgumentResolverTest {
                 .thenReturn(String.class);
         when(parameter.hasParameterAnnotation(MemberIdentifier.class))
                 .thenReturn(false);
+        when(parameter.hasMethodAnnotation(Authenticated.class))
+                .thenReturn(true);
 
         //when
         final boolean result = memberIdentifierArgumentResolver.supportsParameter(parameter);
 
         //then
         assertThat(result).isFalse();
+    }
+
+    @Test
+    void String_타입이고_Authenticated가_붙지_않은_인자인_경우_예외가_발생한다() {
+        //given
+        when(parameter.hasMethodAnnotation(Authenticated.class))
+                .thenReturn(false);
+
+        //when
+        //then
+        assertThatThrownBy(() -> memberIdentifierArgumentResolver.supportsParameter(parameter))
+                .isInstanceOf(ServerException.class)
+                .hasMessageContaining("MemberIdentifier는 인증된 사용자만 사용 가능합니다. (@Authenticated)");
     }
 
     @Test


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-231](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-231)


## ✨ 작업 내용
- `@MemberIdentifier`를 사용하려면 `@Authenticated`를 사용하도록 강제했습니다.


## 💬 리뷰어에게 남길 멘트
- 몹프로그래밍👨‍👩‍👦


## 🚀 요구사항 분석


