### PR TITLE
[feat/CK-236] JdbcTemplate을 이용하여 bulk insert를 적용한다

### DIFF
--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomMemberDao.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomMemberDao.java
@@ -1,0 +1,29 @@
+package co.kirikiri.persistence.goalroom;
+
+import co.kirikiri.domain.goalroom.GoalRoomMember;
+import java.util.List;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class GoalRoomMemberDao {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public GoalRoomMemberDao(final JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void saveAll(final List<GoalRoomMember> goalRoomMembers) {
+        final String sql = "INSERT INTO goal_room_member "
+                + "(goal_room_id, member_id, role, joined_at, accomplishment_rate)"
+                + "VALUES (?, ?, ?, ?, ?)";
+        jdbcTemplate.batchUpdate(sql, goalRoomMembers, goalRoomMembers.size(), ((ps, goalRoomMember) -> {
+            ps.setLong(1, goalRoomMember.getGoalRoom().getId());
+            ps.setLong(2, goalRoomMember.getMember().getId());
+            ps.setString(3, goalRoomMember.getRole().name());
+            ps.setObject(4, goalRoomMember.getJoinedAt());
+            ps.setDouble(5, goalRoomMember.getAccomplishmentRate());
+        }));
+    }
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomMemberJdbcRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomMemberJdbcRepository.java
@@ -1,0 +1,9 @@
+package co.kirikiri.persistence.goalroom;
+
+import co.kirikiri.domain.goalroom.GoalRoomMember;
+import java.util.List;
+
+public interface GoalRoomMemberJdbcRepository {
+
+    void saveAllInBatch(final List<GoalRoomMember> goalRoomMembers);
+}

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomMemberJdbcRepositoryImpl.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomMemberJdbcRepositoryImpl.java
@@ -6,17 +6,18 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class GoalRoomMemberDao {
+public class GoalRoomMemberJdbcRepositoryImpl implements GoalRoomMemberJdbcRepository {
 
     private final JdbcTemplate jdbcTemplate;
 
-    public GoalRoomMemberDao(final JdbcTemplate jdbcTemplate) {
+    public GoalRoomMemberJdbcRepositoryImpl(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public void saveAll(final List<GoalRoomMember> goalRoomMembers) {
+    @Override
+    public void saveAllInBatch(final List<GoalRoomMember> goalRoomMembers) {
         final String sql = "INSERT INTO goal_room_member "
-                + "(goal_room_id, member_id, role, joined_at, accomplishment_rate)"
+                + "(goal_room_id, member_id, role, joined_at, accomplishment_rate) "
                 + "VALUES (?, ?, ?, ?, ?)";
         jdbcTemplate.batchUpdate(sql, goalRoomMembers, goalRoomMembers.size(), ((ps, goalRoomMember) -> {
             ps.setLong(1, goalRoomMember.getGoalRoom().getId());

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomMemberRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomMemberRepository.java
@@ -3,13 +3,14 @@ package co.kirikiri.persistence.goalroom;
 import co.kirikiri.domain.goalroom.GoalRoom;
 import co.kirikiri.domain.goalroom.GoalRoomMember;
 import co.kirikiri.domain.member.vo.Identifier;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import java.util.List;
-import java.util.Optional;
 
-public interface GoalRoomMemberRepository extends JpaRepository<GoalRoomMember, Long>, GoalRoomMemberQueryRepository {
+public interface GoalRoomMemberRepository extends JpaRepository<GoalRoomMember, Long>,
+        GoalRoomMemberQueryRepository, GoalRoomMemberJdbcRepository {
 
     @Query("select gm from GoalRoomMember gm "
             + "inner join fetch gm.goalRoom g "

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomPendingMemberRepository.java
@@ -3,11 +3,12 @@ package co.kirikiri.persistence.goalroom;
 import co.kirikiri.domain.goalroom.GoalRoom;
 import co.kirikiri.domain.goalroom.GoalRoomPendingMember;
 import co.kirikiri.domain.member.vo.Identifier;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GoalRoomPendingMemberRepository extends JpaRepository<GoalRoomPendingMember, Long>,
         GoalRoomPendingMemberQueryRepository {
@@ -28,4 +29,8 @@ public interface GoalRoomPendingMemberRepository extends JpaRepository<GoalRoomP
             + "where g=:goalRoom "
             + "and gp.member = m")
     List<GoalRoomPendingMember> findAllByGoalRoom(@Param("goalRoom") final GoalRoom goalRoom);
+
+    @Modifying
+    @Query("DELETE FROM GoalRoomPendingMember gp WHERE gp.id IN :ids")
+    void deleteAllByIdIn(@Param("ids") final List<Long> ids);
 }

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomQueryRepositoryImpl.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomQueryRepositoryImpl.java
@@ -116,6 +116,8 @@ public class GoalRoomQueryRepositoryImpl extends QuerydslRepositorySupporter imp
     @Override
     public List<GoalRoom> findAllRecruitingGoalRoomsByStartDateEarlierThan(final LocalDate date) {
         return selectFrom(goalRoom)
+                .innerJoin(goalRoom.goalRoomPendingMembers.values, goalRoomPendingMember)
+                .fetchJoin()
                 .where(statusCond(GoalRoomStatus.RECRUITING))
                 .where(equalOrEarlierStartDateThan(date))
                 .fetch();

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomRepository.java
@@ -1,10 +1,10 @@
 package co.kirikiri.persistence.goalroom;
 
 import co.kirikiri.domain.goalroom.GoalRoom;
-import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GoalRoomRepository extends JpaRepository<GoalRoom, Long>, GoalRoomQueryRepository {
 

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/scheduler/GoalRoomScheduler.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/scheduler/GoalRoomScheduler.java
@@ -4,7 +4,7 @@ import co.kirikiri.domain.BaseEntity;
 import co.kirikiri.domain.goalroom.GoalRoom;
 import co.kirikiri.domain.goalroom.GoalRoomMember;
 import co.kirikiri.domain.goalroom.GoalRoomPendingMember;
-import co.kirikiri.persistence.goalroom.GoalRoomMemberDao;
+import co.kirikiri.persistence.goalroom.GoalRoomMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomPendingMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomRepository;
 import co.kirikiri.service.aop.ExceptionConvert;
@@ -23,7 +23,7 @@ public class GoalRoomScheduler {
 
     private final GoalRoomRepository goalRoomRepository;
     private final GoalRoomPendingMemberRepository goalRoomPendingMemberRepository;
-    private final GoalRoomMemberDao goalRoomMemberDao;
+    private final GoalRoomMemberRepository goalRoomMemberRepository;
 
     @Scheduled(cron = "0 0 0 * * *")
     public void startGoalRooms() {
@@ -38,7 +38,7 @@ public class GoalRoomScheduler {
 
     private void saveGoalRoomMemberFromPendingMembers(final List<GoalRoomPendingMember> goalRoomPendingMembers) {
         final List<GoalRoomMember> goalRoomMembers = makeGoalRoomMembers(goalRoomPendingMembers);
-        goalRoomMemberDao.saveAll(goalRoomMembers);
+        goalRoomMemberRepository.saveAllInBatch(goalRoomMembers);
         final List<Long> ids = makeGoalRoomPendingMemberIds(goalRoomPendingMembers);
         goalRoomPendingMemberRepository.deleteAllByIdIn(ids);
     }

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomSchedulerIntegrationTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/GoalRoomSchedulerIntegrationTest.java
@@ -26,7 +26,6 @@ import co.kirikiri.domain.goalroom.GoalRoomStatus;
 import co.kirikiri.integration.helper.InitIntegrationTest;
 import co.kirikiri.persistence.goalroom.GoalRoomMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomPendingMemberRepository;
-import co.kirikiri.service.scheduler.GoalRoomScheduler;
 import co.kirikiri.service.dto.auth.request.LoginRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomCreateRequest;
 import co.kirikiri.service.dto.goalroom.request.GoalRoomRoadmapNodeRequest;
@@ -34,9 +33,10 @@ import co.kirikiri.service.dto.member.request.GenderType;
 import co.kirikiri.service.dto.member.request.MemberJoinRequest;
 import co.kirikiri.service.dto.member.response.MemberGoalRoomResponse;
 import co.kirikiri.service.dto.roadmap.response.RoadmapResponse;
-import org.junit.jupiter.api.Test;
+import co.kirikiri.service.scheduler.GoalRoomScheduler;
 import java.io.IOException;
 import java.util.List;
+import org.junit.jupiter.api.Test;
 
 class GoalRoomSchedulerIntegrationTest extends InitIntegrationTest {
 

--- a/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/TestTransactionService.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/integration/helper/TestTransactionService.java
@@ -88,7 +88,7 @@ public class TestTransactionService {
     }
 
     public void 골룸_멤버를_저장한다(final List<GoalRoomMember> 골룸_멤버_리스트) {
-        goalRoomMemberRepository.saveAll(골룸_멤버_리스트);
+        goalRoomMemberRepository.saveAllInBatch(골룸_멤버_리스트);
     }
 
     public void 골룸의_상태와_종료날짜를_변경한다(final Long 골룸_아이디, final GoalRoomStatus 골룸_상태, final LocalDate 변경할_종료날짜) {

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/CheckFeedRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/CheckFeedRepositoryTest.java
@@ -34,10 +34,10 @@ import co.kirikiri.persistence.helper.RepositoryTest;
 import co.kirikiri.persistence.member.MemberRepository;
 import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
 import co.kirikiri.persistence.roadmap.RoadmapRepository;
-import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.Test;
 
 @RepositoryTest
 class CheckFeedRepositoryTest {
@@ -86,7 +86,7 @@ class CheckFeedRepositoryTest {
         final GoalRoomMember leader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom, creator);
         final GoalRoomMember joinedMember = new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), goalRoom,
                 member);
-        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+        goalRoomMemberRepository.saveAllInBatch(List.of(leader, joinedMember));
 
         final GoalRoomRoadmapNode goalRoomRoadmapNode = goalRoom.getGoalRoomRoadmapNodes().getValues().get(0);
         인증_피드를_저장한다(goalRoomRoadmapNode, joinedMember);
@@ -120,7 +120,7 @@ class CheckFeedRepositoryTest {
         final GoalRoomMember leader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom, creator);
         final GoalRoomMember joinedMember = new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), goalRoom,
                 member);
-        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+        goalRoomMemberRepository.saveAllInBatch(List.of(leader, joinedMember));
 
         final GoalRoomRoadmapNode goalRoomRoadmapNode = goalRoom.getGoalRoomRoadmapNodes().getValues().get(0);
         인증_피드를_저장한다(goalRoomRoadmapNode, joinedMember);
@@ -151,7 +151,7 @@ class CheckFeedRepositoryTest {
         final GoalRoomMember leader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom, creator);
         final GoalRoomMember joinedMember = new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), goalRoom,
                 member);
-        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+        goalRoomMemberRepository.saveAllInBatch(List.of(leader, joinedMember));
 
         final GoalRoomRoadmapNode goalRoomRoadmapNode1 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(0);
         final GoalRoomRoadmapNode goalRoomRoadmapNode2 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(1);
@@ -188,7 +188,7 @@ class CheckFeedRepositoryTest {
                 member);
         final GoalRoomMember otherLeader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom2,
                 creator);
-        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+        goalRoomMemberRepository.saveAllInBatch(List.of(leader, joinedMember));
 
         final GoalRoomRoadmapNode goalRoomRoadmapNode1 = goalRoom1.getGoalRoomRoadmapNodes().getValues().get(0);
         final GoalRoomRoadmapNode goalRoomRoadmapNode2 = goalRoom1.getGoalRoomRoadmapNodes().getValues().get(1);
@@ -226,7 +226,7 @@ class CheckFeedRepositoryTest {
         final GoalRoomMember leader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom, creator);
         final GoalRoomMember joinedMember = new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), goalRoom,
                 member);
-        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+        goalRoomMemberRepository.saveAllInBatch(List.of(leader, joinedMember));
 
         final GoalRoomRoadmapNode goalRoomRoadmapNode1 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(0);
         final GoalRoomRoadmapNode goalRoomRoadmapNode2 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(1);
@@ -269,7 +269,7 @@ class CheckFeedRepositoryTest {
         final GoalRoomMember leader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom, creator);
         final GoalRoomMember joinedMember = new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), goalRoom,
                 member);
-        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+        goalRoomMemberRepository.saveAllInBatch(List.of(leader, joinedMember));
 
         final GoalRoomRoadmapNode goalRoomRoadmapNode1 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(0);
         final GoalRoomRoadmapNode goalRoomRoadmapNode2 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(1);
@@ -303,7 +303,7 @@ class CheckFeedRepositoryTest {
         final GoalRoomMember leader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom, creator);
         final GoalRoomMember joinedMember = new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), goalRoom,
                 member);
-        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+        goalRoomMemberRepository.saveAllInBatch(List.of(leader, joinedMember));
 
         final GoalRoomRoadmapNode goalRoomRoadmapNode1 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(0);
         final GoalRoomRoadmapNode goalRoomRoadmapNode2 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(1);
@@ -348,7 +348,7 @@ class CheckFeedRepositoryTest {
         final GoalRoomMember leader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom, creator);
         final GoalRoomMember joinedMember = new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), goalRoom,
                 member);
-        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+        goalRoomMemberRepository.saveAllInBatch(List.of(leader, joinedMember));
 
         final GoalRoomRoadmapNode goalRoomRoadmapNode1 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(0);
         final GoalRoomRoadmapNode goalRoomRoadmapNode2 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(1);
@@ -407,7 +407,7 @@ class CheckFeedRepositoryTest {
         final GoalRoomMember leader = new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), goalRoom, creator);
         final GoalRoomMember joinedMember = new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), goalRoom,
                 member);
-        goalRoomMemberRepository.saveAll(List.of(leader, joinedMember));
+        goalRoomMemberRepository.saveAllInBatch(List.of(leader, joinedMember));
 
         final GoalRoomRoadmapNode goalRoomRoadmapNode1 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(0);
         final GoalRoomRoadmapNode goalRoomRoadmapNode2 = goalRoom.getGoalRoomRoadmapNodes().getValues().get(1);

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/GoalRoomMemberRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/GoalRoomMemberRepositoryTest.java
@@ -33,12 +33,12 @@ import co.kirikiri.persistence.helper.RepositoryTest;
 import co.kirikiri.persistence.member.MemberRepository;
 import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
 import co.kirikiri.persistence.roadmap.RoadmapRepository;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 @RepositoryTest
 class GoalRoomMemberRepositoryTest {
@@ -296,11 +296,13 @@ class GoalRoomMemberRepositoryTest {
     private Member 크리에이터를_저장한다() {
         final MemberImage memberImage = new MemberImage("originalFileName", "serverFilePath", ImageContentType.JPG);
         final MemberProfile memberProfile = new MemberProfile(Gender.MALE, "kirikiri1@email.com");
-        final Member creator = new Member(1L, new Identifier("cokirikiri"), null, new EncryptedPassword(new Password("password1!")), new Nickname("코끼리"), memberImage, memberProfile);
+        final Member creator = new Member(1L, new Identifier("cokirikiri"), null,
+                new EncryptedPassword(new Password("password1!")), new Nickname("코끼리"), memberImage, memberProfile);
         return memberRepository.save(creator);
     }
 
-    private Member 사용자를_생성한다(final String identifier, final String password, final String nickname, final String email) {
+    private Member 사용자를_생성한다(final String identifier, final String password, final String nickname,
+                             final String email) {
         final MemberProfile memberProfile = new MemberProfile(Gender.MALE, email);
         final Member member = new Member(new Identifier(identifier),
                 new EncryptedPassword(new Password(password)), new Nickname(nickname),

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/GoalRoomToDoCheckRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/goalroom/GoalRoomToDoCheckRepositoryTest.java
@@ -30,10 +30,10 @@ import co.kirikiri.persistence.helper.RepositoryTest;
 import co.kirikiri.persistence.member.MemberRepository;
 import co.kirikiri.persistence.roadmap.RoadmapCategoryRepository;
 import co.kirikiri.persistence.roadmap.RoadmapRepository;
-import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.Test;
 
 @RepositoryTest
 class GoalRoomToDoCheckRepositoryTest {

--- a/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapRepositoryTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/persistence/roadmap/RoadmapRepositoryTest.java
@@ -37,11 +37,11 @@ import co.kirikiri.persistence.goalroom.GoalRoomMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomRepository;
 import co.kirikiri.persistence.helper.RepositoryTest;
 import co.kirikiri.persistence.member.MemberRepository;
-import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.Test;
 
 @RepositoryTest
 class RoadmapRepositoryTest {
@@ -249,13 +249,13 @@ class RoadmapRepositoryTest {
         // gameRoadmap2 : 참가인원 1명
         final List<GoalRoomMember> gameRoadmap2GoalRoomMembers = List.of(
                 new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), gameRoadmap2GoalRoom, creator));
-        goalRoomMemberRepository.saveAll(gameRoadmap2GoalRoomMembers);
+        goalRoomMemberRepository.saveAllInBatch(gameRoadmap2GoalRoomMembers);
 
         // travelRoadmap : 참가인원 2명
         final List<GoalRoomMember> travelRoadmapGoalRoomMembers = List.of(
                 new GoalRoomMember(GoalRoomRole.LEADER, LocalDateTime.now(), travelRoadmapGoalRoom, creator),
                 new GoalRoomMember(GoalRoomRole.FOLLOWER, LocalDateTime.now(), travelRoadmapGoalRoom, follower));
-        goalRoomMemberRepository.saveAll(travelRoadmapGoalRoomMembers);
+        goalRoomMemberRepository.saveAllInBatch(travelRoadmapGoalRoomMembers);
 
         final RoadmapCategory category = null;
         final RoadmapOrderType orderType = RoadmapOrderType.PARTICIPANT_COUNT;

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomSchedulerTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomSchedulerTest.java
@@ -34,7 +34,7 @@ import co.kirikiri.domain.roadmap.RoadmapNode;
 import co.kirikiri.domain.roadmap.RoadmapNodeImage;
 import co.kirikiri.domain.roadmap.RoadmapNodeImages;
 import co.kirikiri.domain.roadmap.RoadmapNodes;
-import co.kirikiri.persistence.goalroom.GoalRoomMemberDao;
+import co.kirikiri.persistence.goalroom.GoalRoomMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomPendingMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomRepository;
 import co.kirikiri.service.scheduler.GoalRoomScheduler;
@@ -60,9 +60,9 @@ class GoalRoomSchedulerTest {
 
     @Mock
     private GoalRoomPendingMemberRepository goalRoomPendingMemberRepository;
-
+    
     @Mock
-    private GoalRoomMemberDao goalRoomMemberDao;
+    private GoalRoomMemberRepository goalRoomMemberRepository;
 
     @InjectMocks
     private GoalRoomScheduler goalRoomScheduler;

--- a/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomSchedulerTest.java
+++ b/backend/kirikiri/src/test/java/co/kirikiri/service/GoalRoomSchedulerTest.java
@@ -4,9 +4,8 @@ import static co.kirikiri.domain.goalroom.GoalRoomStatus.RECRUITING;
 import static co.kirikiri.domain.goalroom.GoalRoomStatus.RUNNING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -35,19 +34,19 @@ import co.kirikiri.domain.roadmap.RoadmapNode;
 import co.kirikiri.domain.roadmap.RoadmapNodeImage;
 import co.kirikiri.domain.roadmap.RoadmapNodeImages;
 import co.kirikiri.domain.roadmap.RoadmapNodes;
-import co.kirikiri.persistence.goalroom.GoalRoomMemberRepository;
+import co.kirikiri.persistence.goalroom.GoalRoomMemberDao;
 import co.kirikiri.persistence.goalroom.GoalRoomPendingMemberRepository;
 import co.kirikiri.persistence.goalroom.GoalRoomRepository;
 import co.kirikiri.service.scheduler.GoalRoomScheduler;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class GoalRoomSchedulerTest {
@@ -60,10 +59,10 @@ class GoalRoomSchedulerTest {
     private GoalRoomRepository goalRoomRepository;
 
     @Mock
-    private GoalRoomMemberRepository goalRoomMemberRepository;
+    private GoalRoomPendingMemberRepository goalRoomPendingMemberRepository;
 
     @Mock
-    private GoalRoomPendingMemberRepository goalRoomPendingMemberRepository;
+    private GoalRoomMemberDao goalRoomMemberDao;
 
     @InjectMocks
     private GoalRoomScheduler goalRoomScheduler;
@@ -83,9 +82,9 @@ class GoalRoomSchedulerTest {
         final Member follower2 = 사용자를_생성한다(3L, "identifier2", "password3!", "name2", "kirikiri@email.com");
         final Member follower3 = 사용자를_생성한다(4L, "identifier3", "password4!", "name3", "kirikiri@email.com");
 
-        final GoalRoomPendingMember goalRoomPendingMember = 골룸_대기자를_생성한다(goalRoom2, creator, GoalRoomRole.FOLLOWER);
-        final GoalRoomPendingMember goalRoomPendingMember1 = 골룸_대기자를_생성한다(goalRoom1, follower1, GoalRoomRole.FOLLOWER);
-        final GoalRoomPendingMember goalRoomPendingMember2 = 골룸_대기자를_생성한다(goalRoom1, follower2, GoalRoomRole.FOLLOWER);
+        골룸_대기자를_생성한다(goalRoom2, creator, GoalRoomRole.FOLLOWER);
+        골룸_대기자를_생성한다(goalRoom1, follower1, GoalRoomRole.FOLLOWER);
+        골룸_대기자를_생성한다(goalRoom1, follower2, GoalRoomRole.FOLLOWER);
 
         goalRoom1.join(follower1);
         goalRoom1.join(follower2);
@@ -130,9 +129,7 @@ class GoalRoomSchedulerTest {
         goalRoomScheduler.startGoalRooms();
 
         // then
-        verify(goalRoomPendingMemberRepository, times(0)).findAllByGoalRoom(any());
-        verify(goalRoomMemberRepository, times(0)).saveAll(anyList());
-        verify(goalRoomPendingMemberRepository, times(0)).deleteAll(anyList());
+        verify(goalRoomPendingMemberRepository, never()).deleteAllByIdIn(anyList());
 
         assertAll(
                 () -> assertThat(goalRoom1.getStatus()).isEqualTo(RECRUITING),


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-236](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-236)


## ✨ 작업 내용
- 기존 골룸 시작 시 골룸 대기자에서 참여자로 변경되는 시점에 데이터 삽입, 삭제를 jdbcTemplate을 이용하여 bulk insert를 적용했습니다.


## 💬 리뷰어에게 남길 멘트
- JPA에서 saveAll, deleteAll은 내부적으로 데이터 하나씩 쿼리가 나가기 때문에, 이를 개선하고자 JdbcTemplate을 사용해서 bulk insert를 적용했습니다.
- JPA에서는 id 전략이 Identity이면 bulk insert가 지원이 안되고, Sequence나 Table 전략을 사용해야 가능합니다. 하지만 MySql은 Sequence를 지원하지 않고, Table 전략을 채택하기에는 테이블을 추가해야하는 점에서 부담이 되어 Identity 전략을 그대로 가되, JdbcTemplate을 사용하여 bulk insert를 적용하도록 했습니다.
- 추가적으로, 로드맵 삭제 시 관련 데이터들이 모두 삭제되는데 이 부분도 단 건씩 삭제되어 개선이 필요합니다! 로드맵 삭제 부분은 비교적 중요한 부분이 아니고, 쿼리만 추가해주면 되기 때문에 바쁜 일정이 끝나는대로 수정해보겠습니다 🥲  


## 🚀 요구사항 분석
- [x] 골룸 시작 부분 bulk insert 적용 


