### PR TITLE
[feat/CK-237] 골룸 참여 시 발생하는 동시성 이슈를 해결한다

### DIFF
--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomQueryRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomQueryRepository.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 
 public interface GoalRoomQueryRepository {
 
+    Optional<GoalRoom> findGoalRoomByIdWithPessimisticLock(Long goalRoomId);
+
     Optional<GoalRoom> findByIdWithRoadmapContent(final Long goalRoomId);
 
     Optional<GoalRoom> findByIdWithContentAndTodos(final Long goalRoomId);

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomQueryRepositoryImpl.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomQueryRepositoryImpl.java
@@ -15,6 +15,7 @@ import co.kirikiri.persistence.QuerydslRepositorySupporter;
 import co.kirikiri.persistence.goalroom.dto.RoadmapGoalRoomsOrderType;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +26,16 @@ public class GoalRoomQueryRepositoryImpl extends QuerydslRepositorySupporter imp
 
     public GoalRoomQueryRepositoryImpl() {
         super(GoalRoom.class);
+    }
+
+    @Override
+    public Optional<GoalRoom> findGoalRoomByIdWithPessimisticLock(final Long goalRoomId) {
+        return Optional.ofNullable(selectFrom(goalRoom)
+                .innerJoin(goalRoom.goalRoomPendingMembers.values, goalRoomPendingMember)
+                .fetchJoin()
+                .where(goalRoom.id.eq(goalRoomId))
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .fetchOne());
     }
 
     @Override

--- a/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomRepository.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/persistence/goalroom/GoalRoomRepository.java
@@ -1,14 +1,13 @@
 package co.kirikiri.persistence.goalroom;
 
 import co.kirikiri.domain.goalroom.GoalRoom;
-import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GoalRoomRepository extends JpaRepository<GoalRoom, Long>, GoalRoomQueryRepository {
-
-    @Override
+    
     Optional<GoalRoom> findById(final Long goalRoomId);
 
     List<GoalRoom> findAllByEndDate(final LocalDate endDate);

--- a/backend/kirikiri/src/main/java/co/kirikiri/service/goalroom/GoalRoomCreateService.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/service/goalroom/GoalRoomCreateService.java
@@ -123,7 +123,7 @@ public class GoalRoomCreateService {
     }
 
     private GoalRoom findGoalRoomById(final Long goalRoomId) {
-        return goalRoomRepository.findById(goalRoomId)
+        return goalRoomRepository.findGoalRoomByIdWithPessimisticLock(goalRoomId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 골룸입니다. goalRoomId = " + goalRoomId));
     }
 


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-237](https://co-kirikiri.atlassian.net/jira/software/projects/CK/boards/1?selectedIssue=CK-237)


## ✨ 작업 내용
- 골룸 참여 시 골룸 조회 쿼리에 비관적 락을 적용했습니다.
- 기존에는 골룸을 먼저 조회 후 골룸에 대한 골룸 대기 멤버를 조회했는데, 이를 fetchJoin을 통해 한번에 가져오도록 수정했습니다.


## 💬 리뷰어에게 남길 멘트
- H2 환경에서는 조인된 쿼리에 락을 걸어도 문제가 해결되지 않았는데, MySQL 환경으로 테스트하니 정상적으로 동작하는 것을 확인했습니다.


## 🚀 요구사항 분석
- [x] 골룸 참여 시 발생하는 조회 쿼리에 비관적 락 적용

