### PR TITLE
feat: amazon s3 접근 시 credentials 사용하도록 수정

### DIFF
--- a/backend/kirikiri/src/main/java/co/kirikiri/common/config/AWSConfig.java
+++ b/backend/kirikiri/src/main/java/co/kirikiri/common/config/AWSConfig.java
@@ -1,5 +1,7 @@
 package co.kirikiri.common.config;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -11,15 +13,23 @@ import org.springframework.context.annotation.Configuration;
 public class AWSConfig {
 
     private final Regions region;
+    private final String accessKey;
+    private final String secretKey;
 
-    public AWSConfig(@Value("${cloud.aws.region.static}") final String region) {
+    public AWSConfig(@Value("${cloud.aws.region.static}") final String region,
+                     @Value("${cloud.aws.credentials.access-key}") final String accessKey,
+                     @Value("${cloud.aws.credentials.secret-key}") final String secretKey) {
         this.region = Regions.fromName(region);
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
     }
 
     @Bean
     public AmazonS3 amazonS3() {
+        final BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
         return AmazonS3ClientBuilder.standard()
                 .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
                 .build();
     }
 }


### PR DESCRIPTION
## 📌 작업 이슈 번호
[CK-239](https://co-kirikiri.atlassian.net/browse/CK-239?atlOrigin=eyJpIjoiZjNjNzMxMjk4MmFlNGQwMDhiNTFiYTg1NWU2Mjk2MWEiLCJwIjoiaiJ9)


## ✨ 작업 내용
서버 이관으로 인해 기존 key 없이 s3에 접근하던 방식을 key를 사용하여 접근하는 방식으로 수정 했습니다!


## 💬 리뷰어에게 남길 멘트
간단한 수정이라 없습니다!


## 🚀 요구사항 분석
- [X] Amazon S3 접근 시 credential 정보를 이용하도록 수정

